### PR TITLE
fixed bug when playing against lichess ai

### DIFF
--- a/model.py
+++ b/model.py
@@ -168,7 +168,7 @@ class Game:
 
 class Player:
     def __init__(self, json: Dict[str, Any]) -> None:
-        self.name: str = json["name"]
+        self.name: str = json.get("name")
         self.title = json.get("title")
         self.rating = json.get("rating")
         self.provisional = json.get("provisional")

--- a/model.py
+++ b/model.py
@@ -168,7 +168,7 @@ class Game:
 
 class Player:
     def __init__(self, json: Dict[str, Any]) -> None:
-        self.name: str = json.get("name")
+        self.name = json.get("name")
         self.title = json.get("title")
         self.rating = json.get("rating")
         self.provisional = json.get("provisional")


### PR DESCRIPTION
lichess ai which does not have name but just has `{"aiLevel":6}`, and in model.py line 172 it expects there to be name field which is not present for lichess's ai sample respone from https://lichess.org/api/bot/game/stream/QzH18wWL when playing against stockfish level 6 on lichess 
```json
{"id":"QzH18wWL","variant":{"key":"standard","name":"Standard","short":"Std"},"clock":{"initial":240000,"increment":0},"speed":"blitz","perf":{"name":"Blitz"},"rated":false,"createdAt":1675023820190,"white":{"aiLevel":6},"black":{"id":"flawed_formula","name":"Flawed_Formula","title":"BOT","rating":1097},"initialFen":"startpos","type":"gameFull","state":{"type":"gameState","moves":"e2e4 b8c6 d2d4 e7e6 d4d5 e6d5 e4d5 f8b4 c2c3 b4c3 b1c3 d8e7 f1e2 c6b4 c1f4 c7c5 a2a3 e7f6 g1h3 b4a6 d1c2 c5c4 c3e4 f6d8 h3g5 d8a5 e1f1 g8f6 e4f6 g7f6 c2e4 e8f8 g5h7 h8h7 e4h7 a5d5 a1e1 f6f5 e2g4 d5d3 f1g1 d3e3 f4d6 f8e8 e1e3 e8d8 h7f5 a6c7 f5e5 c7e6 e3c3 a7a5 e5h8 e6f8 c3c4 f7f5 c4c8 d8c8 h8c3 c8d8 c3h8 d8c8 h8c3 c8d8 g4h5 f8g6 h5g6 a8b8 c3h8","wtime":173120,"btime":195440,"winc":0,"binc":0,"status":"mate","winner":"white"}}```