### PR TITLE
Move `is_final` outside class

### DIFF
--- a/lichess.py
+++ b/lichess.py
@@ -265,7 +265,7 @@ class Lichess:
                               max_time=60,
                               max_tries=self.max_retries,
                               interval=0.1,
-                              giveup=self.is_final,
+                              giveup=is_final,
                               backoff_log_level=logging.DEBUG,
                               giveup_log_level=logging.DEBUG)
         def online_book_get() -> JSON_REPLY_TYPE:

--- a/lichess.py
+++ b/lichess.py
@@ -259,19 +259,17 @@ class Lichess:
     def cancel(self, challenge_id: str) -> JSON_REPLY_TYPE:
         return self.api_post("cancel", challenge_id, raise_for_status=False)
 
+    @backoff.on_exception(backoff.constant,
+                          (RemoteDisconnected, ConnectionError, HTTPError, ReadTimeout),
+                          max_time=60,
+                          max_tries=self.max_retries,
+                          interval=0.1,
+                          giveup=is_final,
+                          backoff_log_level=logging.DEBUG,
+                          giveup_log_level=logging.DEBUG)
     def online_book_get(self, path: str, params: Optional[Dict[str, Any]] = None) -> JSON_REPLY_TYPE:
-        @backoff.on_exception(backoff.constant,
-                              (RemoteDisconnected, ConnectionError, HTTPError, ReadTimeout),
-                              max_time=60,
-                              max_tries=self.max_retries,
-                              interval=0.1,
-                              giveup=is_final,
-                              backoff_log_level=logging.DEBUG,
-                              giveup_log_level=logging.DEBUG)
-        def online_book_get() -> JSON_REPLY_TYPE:
-            json_response: JSON_REPLY_TYPE = self.other_session.get(path, timeout=2, params=params).json()
-            return json_response
-        return online_book_get()
+        json_response: JSON_REPLY_TYPE = self.other_session.get(path, timeout=2, params=params).json()
+        return json_response
 
     def is_online(self, user_id: str) -> bool:
         user = self.api_get_list("status", params={"ids": user_id})

--- a/lichess.py
+++ b/lichess.py
@@ -47,6 +47,10 @@ def is_new_rate_limit(response: requests.models.Response) -> bool:
     return response.status_code == 429
 
 
+def is_final(exception: Exception) -> bool:
+    return isinstance(exception, HTTPError) and exception.response.status_code < 500
+
+
 # docs: https://lichess.org/api
 class Lichess:
     def __init__(self, token: str, url: str, version: str, logging_level: int, max_retries: int) -> None:
@@ -62,10 +66,6 @@ class Lichess:
         self.logging_level = logging_level
         self.max_retries = max_retries
         self.rate_limit_timers: DefaultDict[str, Timer] = defaultdict(Timer)
-
-    @staticmethod
-    def is_final(exception: Exception) -> bool:
-        return isinstance(exception, HTTPError) and exception.response.status_code < 500
 
     @backoff.on_exception(backoff.constant,
                           (RemoteDisconnected, ConnectionError, HTTPError, ReadTimeout),


### PR DESCRIPTION
I couldn't reproduce it in python 3.11 but I could in python 3.8. I don't know the last python version that causes this error. This fixes the error in python 3.8.

closes #653
