### PR TITLE
Handle errors from Lichess class outside of games

### DIFF
--- a/lichess.py
+++ b/lichess.py
@@ -223,7 +223,7 @@ class Lichess:
                                           "application/x-www-form-urlencoded"},
                                  raise_for_status=False)
         except Exception:
-            pass
+            return {}
 
     def get_profile(self) -> JSON_REPLY_TYPE:
         profile = self.api_get("profile")

--- a/lichess.py
+++ b/lichess.py
@@ -246,7 +246,10 @@ class Lichess:
         self.session.headers.update(self.header)
 
     def get_game_pgn(self, game_id: str) -> str:
-        return self.api_get_raw("export", game_id)
+        try:
+            return self.api_get_raw("export", game_id)
+        except Exception:
+            return ""
 
     def get_online_bots(self) -> List[Dict[str, Any]]:
         try:

--- a/lichess.py
+++ b/lichess.py
@@ -216,11 +216,14 @@ class Lichess:
         return self.api_post("accept", challenge_id)
 
     def decline_challenge(self, challenge_id: str, reason: str = "generic") -> JSON_REPLY_TYPE:
-        return self.api_post("decline", challenge_id,
-                             data=f"reason={reason}",
-                             headers={"Content-Type":
-                                      "application/x-www-form-urlencoded"},
-                             raise_for_status=False)
+        try:
+            return self.api_post("decline", challenge_id,
+                                 data=f"reason={reason}",
+                                 headers={"Content-Type":
+                                          "application/x-www-form-urlencoded"},
+                                 raise_for_status=False)
+        except Exception:
+            pass
 
     def get_profile(self) -> JSON_REPLY_TYPE:
         profile = self.api_get("profile")

--- a/matchmaking.py
+++ b/matchmaking.py
@@ -79,7 +79,10 @@ class Matchmaking:
     def update_user_profile(self) -> None:
         if self.last_user_profile_update_time.is_expired():
             self.last_user_profile_update_time.reset()
-            self.user_profile = self.li.get_profile()
+            try:
+                self.user_profile = self.li.get_profile()
+            except Exception:
+                pass
 
     def choose_opponent(self) -> Tuple[Optional[str], int, int, int, str, str]:
         variant = self.get_random_config_value("challenge_variant", self.variants)


### PR DESCRIPTION
These changes ignore errors from contacting lichess.org outside of games. In each case, ignoring the error and continuing to run is either acceptable (when declining a challenge) or much less inconvenient than stopping the whole program (updating bot ratings or failing to download the completed game PGN).

Other methods that are called outside of games are already handled.