### PR TITLE
Change default Timer duration

### DIFF
--- a/timer.py
+++ b/timer.py
@@ -2,7 +2,7 @@ import time
 
 
 class Timer:
-    def __init__(self, duration: int = -1) -> None:
+    def __init__(self, duration: int = 0) -> None:
         self.duration = duration
         self.reset()
 


### PR DESCRIPTION
This fixes a small annoyance in displaying the time before challenging another user that declines a challenge (`Matchmaking.declined_challenge()`). The message displayed is off by one hour since the duration after adding 3600 seconds is 3599, which causes `int(delay_timer.duration/3600)` to round down to 0.

It is still the case that Timer() results in a timer that is already expired, which is required for respecting rate limits for lichess requests.