### PR TITLE
Fix auto version updater

### DIFF
--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -10,6 +10,8 @@ jobs:
       runs-on: ubuntu-latest
       steps:
       - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.VERSION_BOT_TOKEN }}
       - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
To be able to use `actions/checkout@v3` instead of `v1` we have to start the workflow with a Personal Access Token instead of `GITHUB_TOKEN`. `VERSION_BOT_TOKEN` is the same token that is used in `VERSION_BOT_SSH`.