### PR TITLE
Slow down challenge creation as daily limit is approached

### DIFF
--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -210,6 +210,7 @@ def lichess_bot_main(li: lichess.Lichess,
 
     last_check_online_time = Timer(60 * 60)  # one hour interval
     matchmaker = matchmaking.Matchmaking(li, config, user_profile)
+    matchmaker.show_earliest_challenge_time()
 
     play_game_args = {"li": li,
                       "control_queue": control_queue,
@@ -233,9 +234,11 @@ def lichess_bot_main(li: lichess.Lichess,
                 control_queue.task_done()  # type: ignore[attr-defined]
                 break
             elif event["type"] in ["local_game_done", "gameFinish"]:
-                active_games.discard(event["game"]["id"])
-                matchmaker.game_done()
-                log_proc_count("Freed", active_games)
+                id = event["game"]["id"]
+                if id in active_games:
+                    active_games.discard(id)
+                    matchmaker.game_done()
+                    log_proc_count("Freed", active_games)
                 one_game_completed = True
             elif event["type"] == "challenge":
                 handle_challenge(event, li, challenge_queue, config.challenge, user_profile, matchmaker, recent_bot_challenges)

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -234,7 +234,7 @@ def lichess_bot_main(li: lichess.Lichess,
                 break
             elif event["type"] in ["local_game_done", "gameFinish"]:
                 active_games.discard(event["game"]["id"])
-                matchmaker.last_game_ended_delay.reset()
+                matchmaker.game_done()
                 log_proc_count("Freed", active_games)
                 one_game_completed = True
             elif event["type"] == "challenge":

--- a/matchmaking.py
+++ b/matchmaking.py
@@ -178,6 +178,9 @@ class Matchmaking:
 
     def game_done(self) -> None:
         self.last_game_ended_delay.reset()
+        self.show_earliest_challenge_time()
+
+    def show_earliest_challenge_time(self) -> None:
         postgame_timeout = self.last_game_ended_delay.time_until_expiration()
         time_to_next_challenge = self.min_wait_time - self.last_challenge_created_delay.time_since_reset()
         time_left = max(postgame_timeout, time_to_next_challenge)
@@ -216,6 +219,8 @@ class Matchmaking:
                         f"{challenge.variant} game for {int(delay_timer.duration/3600)} {hours}.")
         else:
             logger.info(f"Will not challenge {opponent} for {int(delay_timer.duration/3600)} {hours}.")
+
+        self.show_earliest_challenge_time()
 
     def get_delay_timer(self, opponent_name: str, variant: str, time_control: str, rated_mode: str) -> Timer:
         if self.delay_type == DelayType.FINE:

--- a/matchmaking.py
+++ b/matchmaking.py
@@ -68,7 +68,7 @@ class Matchmaking:
         min_wait_time_passed = self.last_challenge_created_delay.time_since_reset() > self.min_wait_time
         if challenge_expired:
             self.li.cancel(self.challenge_id)
-            logger.debug(f"Challenge id {self.challenge_id} cancelled.")
+            logger.info(f"Challenge id {self.challenge_id} cancelled.")
             self.challenge_id = ""
         return bool(matchmaking_enabled and (time_has_passed or challenge_expired) and min_wait_time_passed)
 

--- a/matchmaking.py
+++ b/matchmaking.py
@@ -84,6 +84,7 @@ class Matchmaking:
 
         try:
             self.update_daily_challenge_record()
+            self.last_challenge_created_delay.reset()
             response = self.li.challenge(username, params)
             challenge_id: str = response.get("challenge", {}).get("id", "")
             if not challenge_id:
@@ -196,7 +197,6 @@ class Matchmaking:
         logger.info(f"Will challenge {bot_username} for a {variant} game.")
         challenge_id = self.create_challenge(bot_username, base_time, increment, days, variant, mode) if bot_username else ""
         logger.info(f"Challenge id is {challenge_id if challenge_id else 'None'}.")
-        self.last_challenge_created_delay.reset()
         self.challenge_id = challenge_id
 
     def game_done(self) -> None:

--- a/matchmaking.py
+++ b/matchmaking.py
@@ -61,8 +61,8 @@ class Matchmaking:
             return ""
 
         try:
-            response = self.li.challenge(username, params)
             self.update_daily_challenge_record()
+            response = self.li.challenge(username, params)
             challenge_id: str = response.get("challenge", {}).get("id", "")
             if not challenge_id:
                 logger.error(response)

--- a/matchmaking.py
+++ b/matchmaking.py
@@ -14,20 +14,16 @@ MULTIPROCESSING_LIST_TYPE = List[model.Challenge]
 logger = logging.getLogger(__name__)
 
 daily_challenges_file_name = "daily_challenge_times.txt"
-timestamp_format = "%Y-%m-%d %H:%M:%S"
-one_day = datetime.timedelta(days=1)
+timestamp_format = "%Y-%m-%d %H:%M:%S\n"
+one_day_seconds = datetime.timedelta(days=1).total_seconds()
 
 
 def read_daily_challenges() -> List[Timer]:
-    timers = []
-    now = datetime.datetime.now()
-
     try:
+        timers: List[Timer] = []
         with open(daily_challenges_file_name) as file:
             for line in file:
-                timestamp = datetime.datetime.strptime(line.strip(), timestamp_format)
-                time_left = one_day - (now - timestamp)
-                timers.append(Timer(int(time_left.total_seconds())))
+                timers.append(Timer(one_day_seconds, datetime.datetime.strptime(line, timestamp_format)))
     except FileNotFoundError:
         pass
 
@@ -35,9 +31,9 @@ def read_daily_challenges() -> List[Timer]:
 
 
 def write_daily_challenges(daily_challenges: List[Timer]) -> None:
-    with open(daily_challenges_file_name, 'w') as file:
+    with open(daily_challenges_file_name, "w") as file:
         for timer in daily_challenges:
-            file.write(timer.starting_timestamp().strftime(timestamp_format) + "\n")
+            file.write(timer.starting_timestamp().strftime(timestamp_format))
 
 
 class Matchmaking:
@@ -105,7 +101,7 @@ class Matchmaking:
         # 100 - 149 challenges --> 3 minutes
         # etc.
         self.daily_challenges = [timer for timer in self.daily_challenges if not timer.is_expired()]
-        self.daily_challenges.append(Timer(int(one_day.total_seconds())))
+        self.daily_challenges.append(Timer(one_day_seconds))
         self.min_wait_time = 60 * ((len(self.daily_challenges) // 50) + 1)
         write_daily_challenges(self.daily_challenges)
 

--- a/matchmaking.py
+++ b/matchmaking.py
@@ -176,6 +176,14 @@ class Matchmaking:
         self.last_challenge_created_delay.reset()
         self.challenge_id = challenge_id
 
+    def game_done(self) -> None:
+        self.last_game_ended_delay.reset()
+        postgame_timeout = self.last_game_ended_delay.time_until_expiration()
+        time_to_next_challenge = self.min_wait_time - self.last_challenge_created_delay.time_since_reset()
+        time_left = max(postgame_timeout, time_to_next_challenge)
+        earliest_challenge_time = datetime.datetime.now() + datetime.timedelta(seconds=time_left)
+        logger.info(f"Next challenge will be created after {earliest_challenge_time.strftime('%X')}")
+
     def add_to_block_list(self, username: str) -> None:
         logger.info(f"Will not challenge {username} again during this session.")
         self.block_list.append(username)

--- a/matchmaking.py
+++ b/matchmaking.py
@@ -185,7 +185,9 @@ class Matchmaking:
         time_to_next_challenge = self.min_wait_time - self.last_challenge_created_delay.time_since_reset()
         time_left = max(postgame_timeout, time_to_next_challenge)
         earliest_challenge_time = datetime.datetime.now() + datetime.timedelta(seconds=time_left)
-        logger.info(f"Next challenge will be created after {earliest_challenge_time.strftime('%X')}")
+        challenges = "challenge" + ("" if len(self.daily_challenges) == 1 else "s")
+        logger.info(f"Next challenge will be created after {earliest_challenge_time.strftime('%X')} "
+                    f"({len(self.daily_challenges)} {challenges} in last 24 hours)")
 
     def add_to_block_list(self, username: str) -> None:
         logger.info(f"Will not challenge {username} again during this session.")

--- a/matchmaking.py
+++ b/matchmaking.py
@@ -91,8 +91,10 @@ class Matchmaking:
                 logger.error(response)
                 self.add_to_block_list(username)
             return challenge_id
-        except Exception:
-            logger.exception("Could not create challenge")
+        except Exception as e:
+            logger.warning("Could not create challenge")
+            logger.debug(e, exc_info=e)
+            self.show_earliest_challenge_time()
             return ""
 
     def update_daily_challenge_record(self) -> None:

--- a/timer.py
+++ b/timer.py
@@ -1,4 +1,5 @@
 import time
+import datetime
 
 
 class Timer:
@@ -17,3 +18,6 @@ class Timer:
 
     def time_until_expiration(self) -> float:
         return max(0., self.duration - self.time_since_reset())
+
+    def starting_timestamp(self) -> datetime.datetime:
+        return datetime.datetime.now() - datetime.timedelta(seconds=self.time_since_reset())

--- a/timer.py
+++ b/timer.py
@@ -1,11 +1,15 @@
 import time
 import datetime
+from typing import Optional
 
 
 class Timer:
-    def __init__(self, duration: int = 0) -> None:
+    def __init__(self, duration: float = 0, backdated_start: Optional[datetime.datetime] = None) -> None:
         self.duration = duration
         self.reset()
+        if backdated_start:
+            time_already_used = datetime.datetime.now() - backdated_start
+            self.starting_time -= time_already_used.total_seconds()
 
     def is_expired(self) -> bool:
         return self.time_since_reset() >= self.duration


### PR DESCRIPTION
Since lichess has a daily limit on the number of challenges a bot can issue, this change slows down the rate of challenge creation as the number created in the past 24 hours increases. This should prevent hours-long denials of challenges due to 429 responses.

Closes #678