### PR TITLE
Fix messages for timeout without material

### DIFF
--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -74,7 +74,7 @@ def translate_termination(game: model.Game, board: chess.Board) -> str:
     if termination == model.Termination.MATE:
         return f"{winner_color.title()} mates"
     elif termination == model.Termination.TIMEOUT:
-        return "Time forfeiture"
+        return "Time forfeiture" if winner_color else "Timeout with insufficient material"
     elif termination == model.Termination.RESIGN:
         resigner = "black" if winner_color == "white" else "white"
         return f"{resigner.title()} resigns"

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -638,13 +638,12 @@ def tell_user_game_result(game: model.Game, board: chess.Board) -> None:
 
     if winner is not None:
         logger.info(f"{winning_name} won!")
-    elif termination == model.Termination.DRAW:
+    elif termination in [model.Termination.DRAW, model.Termination.TIMEOUT]:
         logger.info("Game ended in draw.")
     else:
         logger.info("Game adjourned.")
 
     simple_endings = {model.Termination.MATE: "Game won by checkmate.",
-                      model.Termination.TIMEOUT: f"{losing_name} forfeited on time.",
                       model.Termination.RESIGN: f"{losing_name} resigned.",
                       model.Termination.ABORT: "Game aborted."}
 
@@ -657,6 +656,13 @@ def tell_user_game_result(game: model.Game, board: chess.Board) -> None:
             logger.info("Game drawn by threefold repetition.")
         else:
             logger.info("Game drawn by agreement.")
+    elif termination == model.Termination.TIMEOUT:
+        if winner:
+            logger.info(f"{losing_name} forfeited on time.")
+        else:
+            timeout_name = game.white.name if game.state.get("wtime") == 0 else game.black.name
+            other_name = game.white.name if timeout_name == game.black.name else game.black.name
+            logger.info(f"{timeout_name} ran out of time, but {other_name} did not have enough material to mate.")
     elif termination:
         logger.info(f"Game ended by {termination}")
 

--- a/model.py
+++ b/model.py
@@ -192,7 +192,7 @@ class Game:
             result = GameEnding.WHITE_WINS
         elif winner == "black":
             result = GameEnding.BLACK_WINS
-        elif termination == Termination.DRAW:
+        elif termination in [Termination.DRAW, Termination.TIMEOUT]:
             result = GameEnding.DRAW
         else:
             result = GameEnding.INCOMPLETE


### PR DESCRIPTION
If a player runs out of time, but their opponent does not have enough material to mate, the game ends in a draw. These changes ensure that the correct endgame messages are printed and logged.