### PR TITLE
Delay rechallenging based on specific challenge decline reason

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,17 +274,17 @@ will precede the `go` command to start thinking with `sd 5`. The other `go_comma
   - `opponent_rating_difference`: The maximum difference between the bot's rating and the opponent bot's rating.
   - `opponent_allow_tos_violation`: Whether to challenge bots that violated Lichess Terms of Service. Note that even rated games against them will not affect ratings.
   - `challenge_mode`: Possible options are `casual`, `rated` and `random`.
-  - `delay_after_decline`: Whether and how to delay challenging a bot after that bot declines a challenge. Options are `none`, `coarse`, and `fine`.
-    - `none` does not delay challenging a bot that declined a challenge.
-    - `coarse` will delay challenging a bot to any type of game for a set time.
-    - `fine` will delay challenging a bot to the same kind of game that was declined for a set time.
+  - `challenge_filter`: Whether and how to prevent challenging a bot after that bot declines a challenge. Options are `none`, `coarse`, and `fine`.
+    - `none` does not prevent challenging a bot that declined a challenge.
+    - `coarse` will prevent challenging a bot to any type of game after it declines one challenge.
+    - `fine` will prevent challenging a bot to the same kind of game that was declined.
   - `block_list`: An indented list of usernames of bots that will not be challenged. If this option is not present, then the list is considered empty.
 
 If there are entries for both real-time (`challenge_initial_time` and/or `challenge_increment`) and correspondence games (`challenge_days`), the challenge will be a random choice between the two.
 
 If there are entries for both absolute ratings (`opponent_min_rating` and `opponent_max_rating`) and rating difference (`opponent_rating_difference`), the rating difference takes precedence.
 
-The `delay_after_decline` option can be useful if your matchmaking settings result in a lot of declined challenges. The bots that accept challenges will be challenged more often than those that have declined. The delay is only temporary, so bots that decline a challenge will eventually be challenged again.
+The `challenge_filter` option can be useful if your matchmaking settings result in a lot of declined challenges. The bots that accept challenges will be challenged more often than those that have declined. The filter will remain until lichess-bot quits or the connection with lichess.org is reset.
 
 ```yml
 matchmaking:
@@ -305,7 +305,7 @@ matchmaking:
   opponent_rating_difference: 100
   opponent_allow_tos_violation: true
   challenge_mode: "random"
-  delay_after_decline: none
+  challenge_filter: none
 ```
 
 ## Lichess Upgrade to Bot Account

--- a/config.py
+++ b/config.py
@@ -173,6 +173,44 @@ def log_config(CONFIG: CONFIG_DICT_TYPE) -> None:
     logger.debug("====================")
 
 
+def validate_config(CONFIG: CONFIG_DICT_TYPE) -> None:
+    check_config_section(CONFIG, "token", str)
+    check_config_section(CONFIG, "url", str)
+    check_config_section(CONFIG, "engine", dict)
+    check_config_section(CONFIG, "challenge", dict)
+    check_config_section(CONFIG, "dir", str, "engine")
+    check_config_section(CONFIG, "name", str, "engine")
+
+    config_assert(CONFIG["token"] != "xxxxxxxxxxxxxxxx",
+                  "Your config.yml has the default Lichess API token. This is probably wrong.")
+    config_assert(os.path.isdir(CONFIG["engine"]["dir"]),
+                  f'Your engine directory `{CONFIG["engine"]["dir"]}` is not a directory.')
+
+    working_dir = CONFIG["engine"].get("working_dir")
+    config_assert(not working_dir or os.path.isdir(working_dir),
+                  f"Your engine's working directory `{working_dir}` is not a directory.")
+
+    engine = os.path.join(CONFIG["engine"]["dir"], CONFIG["engine"]["name"])
+    config_assert(os.path.isfile(engine) or CONFIG["engine"]["protocol"] == "homemade",
+                  f"The engine {engine} file does not exist.")
+    config_assert(os.access(engine, os.X_OK) or CONFIG["engine"]["protocol"] == "homemade",
+                  f"The engine {engine} doesn't have execute (x) permission. Try: chmod +x {engine}")
+
+    if CONFIG["engine"]["protocol"] == "xboard":
+        for section, subsection in (("online_moves", "online_egtb"),
+                                    ("lichess_bot_tbs", "syzygy"),
+                                    ("lichess_bot_tbs", "gaviota")):
+            online_section = (CONFIG["engine"].get(section) or {}).get(subsection) or {}
+            config_assert(online_section.get("move_quality") != "suggest" or not online_section.get("enabled"),
+                          f"XBoard engines can't be used with `move_quality` set to `suggest` in {subsection}.")
+
+    filter_option = "challenge_filter"
+    filter_type = (CONFIG.get("matchmaking") or {}).get(filter_option)
+    config_assert(filter_type is None or filter_type in FilterType.__members__.values(),
+                  f"{filter_type} is not a valid value for {filter_option} (formerly delay_after_decline) parameter. "
+                  f"Choices are: {', '.join(FilterType)}.")
+
+
 def load_config(config_file: str) -> Configuration:
     with open(config_file) as stream:
         try:
@@ -181,47 +219,14 @@ def load_config(config_file: str) -> Configuration:
             logger.exception("There appears to be a syntax problem with your config.yml")
             raise
 
-        log_config(CONFIG)
+    log_config(CONFIG)
 
-        if "LICHESS_BOT_TOKEN" in os.environ:
-            CONFIG["token"] = os.environ["LICHESS_BOT_TOKEN"]
+    if "LICHESS_BOT_TOKEN" in os.environ:
+        CONFIG["token"] = os.environ["LICHESS_BOT_TOKEN"]
 
-        check_config_section(CONFIG, "token", str)
-        check_config_section(CONFIG, "url", str)
-        check_config_section(CONFIG, "engine", dict)
-        check_config_section(CONFIG, "challenge", dict)
-        check_config_section(CONFIG, "dir", str, "engine")
-        check_config_section(CONFIG, "name", str, "engine")
-
-        config_assert(CONFIG["token"] != "xxxxxxxxxxxxxxxx",
-                      "Your config.yml has the default Lichess API token. This is probably wrong.")
-        config_assert(os.path.isdir(CONFIG["engine"]["dir"]),
-                      f'Your engine directory `{CONFIG["engine"]["dir"]}` is not a directory.')
-
-        working_dir = CONFIG["engine"].get("working_dir")
-        config_assert(not working_dir or os.path.isdir(working_dir),
-                      f"Your engine's working directory `{working_dir}` is not a directory.")
-
-        engine = os.path.join(CONFIG["engine"]["dir"], CONFIG["engine"]["name"])
-        config_assert(os.path.isfile(engine) or CONFIG["engine"]["protocol"] == "homemade",
-                      f"The engine {engine} file does not exist.")
-        config_assert(os.access(engine, os.X_OK) or CONFIG["engine"]["protocol"] == "homemade",
-                      f"The engine {engine} doesn't have execute (x) permission. Try: chmod +x {engine}")
-
-        if CONFIG["engine"]["protocol"] == "xboard":
-            for section, subsection in (("online_moves", "online_egtb"),
-                                        ("lichess_bot_tbs", "syzygy"),
-                                        ("lichess_bot_tbs", "gaviota")):
-                online_section = (CONFIG["engine"].get(section) or {}).get(subsection) or {}
-                config_assert(online_section.get("move_quality") != "suggest" or not online_section.get("enabled"),
-                              f"XBoard engines can't be used with `move_quality` set to `suggest` in {subsection}.")
-
-        filter_option = "challenge_filter"
-        filter_type = (CONFIG.get("matchmaking") or {}).get(filter_option)
-        config_assert(filter_type is None or filter_type in FilterType.__members__.values(),
-                      f"{filter_type} is not a valid value for {filter_option} parameter. "
-                      f"Choices are: {', '.join(FilterType)}.")
-
+    validate_config(CONFIG)
     insert_default_values(CONFIG)
     log_config(CONFIG)
+    validate_config(CONFIG)
+
     return Configuration(CONFIG)

--- a/config.py
+++ b/config.py
@@ -142,7 +142,7 @@ def insert_default_values(CONFIG: CONFIG_DICT_TYPE) -> None:
     set_config_default(CONFIG, "matchmaking", key="challenge_timeout", default=30, force_empty_values=True)
     CONFIG["matchmaking"]["challenge_timeout"] = max(CONFIG["matchmaking"]["challenge_timeout"], 1)
     set_config_default(CONFIG, "matchmaking", key="block_list", default=[], force_empty_values=True)
-    set_config_default(CONFIG, "matchmaking", key="delay_after_decline", default=DelayType.NONE, force_empty_values=True)
+    set_config_default(CONFIG, "matchmaking", key="delay_after_decline", default=DelayType.NONE.value, force_empty_values=True)
     set_config_default(CONFIG, "matchmaking", key="allow_matchmaking", default=False)
     set_config_default(CONFIG, "matchmaking", key="challenge_initial_time", default=[60], force_empty_values=True)
     change_value_to_list(CONFIG, "matchmaking", key="challenge_initial_time")

--- a/config.py
+++ b/config.py
@@ -11,7 +11,7 @@ CONFIG_DICT_TYPE = Dict[str, Any]
 logger = logging.getLogger(__name__)
 
 
-class DelayType(str, Enum):
+class FilterType(str, Enum):
     NONE = "none"
     COARSE = "coarse"
     FINE = "fine"
@@ -142,7 +142,7 @@ def insert_default_values(CONFIG: CONFIG_DICT_TYPE) -> None:
     set_config_default(CONFIG, "matchmaking", key="challenge_timeout", default=30, force_empty_values=True)
     CONFIG["matchmaking"]["challenge_timeout"] = max(CONFIG["matchmaking"]["challenge_timeout"], 1)
     set_config_default(CONFIG, "matchmaking", key="block_list", default=[], force_empty_values=True)
-    default_filter = (CONFIG.get("matchmaking") or {}).get("delay_after_decline") or DelayType.NONE.value
+    default_filter = (CONFIG.get("matchmaking") or {}).get("delay_after_decline") or FilterType.NONE.value
     set_config_default(CONFIG, "matchmaking", key="challenge_filter", default=default_filter, force_empty_values=True)
     set_config_default(CONFIG, "matchmaking", key="allow_matchmaking", default=False)
     set_config_default(CONFIG, "matchmaking", key="challenge_initial_time", default=[60], force_empty_values=True)
@@ -216,10 +216,11 @@ def load_config(config_file: str) -> Configuration:
                 config_assert(online_section.get("move_quality") != "suggest" or not online_section.get("enabled"),
                               f"XBoard engines can't be used with `move_quality` set to `suggest` in {subsection}.")
 
-        delay_option = "delay_after_decline"
-        delay_type = (CONFIG.get("matchmaking") or {}).get(delay_option)
-        config_assert(delay_type is None or delay_type in DelayType.__members__.values(),
-                      f"{delay_type} is not a valid value for {delay_option} parameter. Choices are: {', '.join(DelayType)}.")
+        filter_option = "challenge_filter"
+        filter_type = (CONFIG.get("matchmaking") or {}).get(filter_option)
+        config_assert(filter_type is None or filter_type in FilterType.__members__.values(),
+                      f"{filter_type} is not a valid value for {filter_option} parameter. "
+                      f"Choices are: {', '.join(FilterType)}.")
 
     insert_default_values(CONFIG)
     log_config(CONFIG)

--- a/config.py
+++ b/config.py
@@ -215,6 +215,11 @@ def load_config(config_file: str) -> Configuration:
                 config_assert(online_section.get("move_quality") != "suggest" or not online_section.get("enabled"),
                               f"XBoard engines can't be used with `move_quality` set to `suggest` in {subsection}.")
 
+        delay_option = "delay_after_decline"
+        delay_type = (CONFIG.get("matchmaking") or {}).get(delay_option)
+        config_assert(delay_type is None or delay_type in DelayType.__members__.values(),
+                      f"{delay_type} is not a valid value for {delay_option} parameter. Choices are: {', '.join(DelayType)}.")
+
     insert_default_values(CONFIG)
     log_config(CONFIG)
     return Configuration(CONFIG)

--- a/config.py
+++ b/config.py
@@ -142,7 +142,8 @@ def insert_default_values(CONFIG: CONFIG_DICT_TYPE) -> None:
     set_config_default(CONFIG, "matchmaking", key="challenge_timeout", default=30, force_empty_values=True)
     CONFIG["matchmaking"]["challenge_timeout"] = max(CONFIG["matchmaking"]["challenge_timeout"], 1)
     set_config_default(CONFIG, "matchmaking", key="block_list", default=[], force_empty_values=True)
-    set_config_default(CONFIG, "matchmaking", key="delay_after_decline", default=DelayType.NONE.value, force_empty_values=True)
+    default_filter = (CONFIG.get("matchmaking") or {}).get("delay_after_decline") or DelayType.NONE.value
+    set_config_default(CONFIG, "matchmaking", key="challenge_filter", default=default_filter, force_empty_values=True)
     set_config_default(CONFIG, "matchmaking", key="allow_matchmaking", default=False)
     set_config_default(CONFIG, "matchmaking", key="challenge_initial_time", default=[60], force_empty_values=True)
     change_value_to_list(CONFIG, "matchmaking", key="challenge_initial_time")

--- a/config.yml.default
+++ b/config.yml.default
@@ -181,7 +181,7 @@ matchmaking:
   opponent_rating_difference: 100 # The maximum difference in rating between the bot's rating and opponent's rating.
   opponent_allow_tos_violation: true # Set to 'false' to prevent challenging bots that violated Lichess Terms of Service.
   challenge_mode: "random"    # Set it to the mode in which challenges are sent. Possible options are 'casual', 'rated' and 'random'.
-  delay_after_decline: none  # If a bot declines a challenge, delay issuing another challenge to that bot. Possible options are 'none', 'coarse', and 'fine'.
+  challenge_filter: none  # If a bot declines a challenge, do not issue a similar challenge to that bot. Possible options are 'none', 'coarse', and 'fine'.
 # block_list:                 # The list of bots that will not be challenged
 #   - user1
 #   - user2

--- a/matchmaking.py
+++ b/matchmaking.py
@@ -261,7 +261,7 @@ class Matchmaking:
             hours = "hours" if delay_timer.duration > 3600 else "hour"
             logger.info(f"Will not challenge {opponent} to a {game_problem}".strip()
                         + f" game for {int(delay_timer.duration/3600)} {hours}.")
-        
+
         self.show_earliest_challenge_time()
 
     def get_delay_timers(self, opponent_name: str, variant: str, time_control: str, rated_mode: str) -> List[Timer]:

--- a/matchmaking.py
+++ b/matchmaking.py
@@ -261,7 +261,8 @@ class Matchmaking:
             hours = "hours" if delay_timer.duration > 3600 else "hour"
             logger.info(f"Will not challenge {opponent} to a {game_problem}".strip()
                         + f" game for {int(delay_timer.duration/3600)} {hours}.")
-            self.show_earliest_challenge_time()
+        
+        self.show_earliest_challenge_time()
 
     def get_delay_timers(self, opponent_name: str, variant: str, time_control: str, rated_mode: str) -> List[Timer]:
         aspects = ["", variant, time_control, rated_mode] if self.delay_type == DelayType.FINE else [""]

--- a/matchmaking.py
+++ b/matchmaking.py
@@ -57,11 +57,7 @@ class Matchmaking:
         #   - casual/rated
         #   - empty string (if no other reason is given or self.delay_type is COARSE)
         self.delay_timers: DefaultDict[Tuple[str, str], Timer] = defaultdict(Timer)
-        delay_option = "delay_after_decline"
-        self.delay_type = self.matchmaking_cfg.lookup(delay_option)
-        if self.delay_type not in DelayType.__members__.values():
-            raise ValueError(f"{self.delay_type} is not a valid value for {delay_option} parameter."
-                             f" Choices are: {', '.join(DelayType)}.")
+        self.delay_type = self.matchmaking_cfg.delay_after_decline
 
     def should_create_challenge(self) -> bool:
         matchmaking_enabled = self.matchmaking_cfg.allow_matchmaking

--- a/matchmaking.py
+++ b/matchmaking.py
@@ -5,7 +5,7 @@ from timer import Timer
 from collections import defaultdict
 import lichess
 import datetime
-from config import Configuration, DelayType
+from config import Configuration, FilterType
 from typing import Dict, Any, Set, Optional, Tuple, List, DefaultDict
 USER_PROFILE_TYPE = Dict[str, Any]
 EVENT_TYPE = Dict[str, Any]
@@ -166,7 +166,7 @@ class Matchmaking:
         online_bots = list(filter(is_suitable_opponent, online_bots))
 
         def ready_for_challenge(bot: USER_PROFILE_TYPE) -> bool:
-            aspects = ["", variant, game_type, mode] if self.challenge_filter == DelayType.FINE else [""]
+            aspects = ["", variant, game_type, mode] if self.challenge_filter == FilterType.FINE else [""]
             return all(self.challenge_type_acceptable[(bot["username"], aspect)] for aspect in aspects)
 
         ready_bots = list(filter(ready_for_challenge, online_bots))
@@ -232,7 +232,7 @@ class Matchmaking:
         logger.info(f"{opponent} declined {challenge}: {reason}")
         if self.challenge_id == challenge.id:
             self.challenge_id = ""
-        if not challenge.from_self or self.challenge_filter == DelayType.NONE:
+        if not challenge.from_self or self.challenge_filter == FilterType.NONE:
             return
 
         # Add one hour to delay each time a challenge is declined.
@@ -251,7 +251,7 @@ class Matchmaking:
         reason_key = event["challenge"]["declineReasonKey"].lower()
         if reason_key not in decline_details:
             logger.warning(f"Unknown decline reason received: {reason_key}")
-        game_problem = decline_details.get(reason_key, "") if self.challenge_filter == DelayType.FINE else ""
+        game_problem = decline_details.get(reason_key, "") if self.challenge_filter == FilterType.FINE else ""
         self.challenge_type_acceptable[(opponent.name, game_problem)] = False
         logger.info(f"Will not challenge {opponent} to another {game_problem}".strip() + " game.")
 

--- a/matchmaking.py
+++ b/matchmaking.py
@@ -248,7 +248,9 @@ class Matchmaking:
                                            "variant": challenge.variant}
 
         reason_key = event["challenge"]["declineReasonKey"].lower()
-        game_problem = decline_details[reason_key] if self.delay_type == DelayType.FINE else ""
+        if reason_key not in decline_details:
+            logger.warning(f"Unknown decline reason received: {reason_key}")
+        game_problem = decline_details.get(reason_key, "") if self.delay_type == DelayType.FINE else ""
         delay_timer = self.delay_timers[(opponent.name, game_problem)]
         delay_timer.duration += 3600
         delay_timer.reset()

--- a/matchmaking.py
+++ b/matchmaking.py
@@ -55,7 +55,7 @@ class Matchmaking:
         #   - game speed (bullet, blitz, etc.)
         #   - variant (standard, horde, etc.)
         #   - casual/rated
-        #   - opponent name (if no other reason is given)
+        #   - empty string (if no other reason is given or self.delay_type is COARSE)
         self.delay_timers: DefaultDict[Tuple[str, str], Timer] = defaultdict(Timer)
         delay_option = "delay_after_decline"
         self.delay_type = self.matchmaking_cfg.lookup(delay_option)
@@ -240,9 +240,9 @@ class Matchmaking:
 
         # Add one hour to delay each time a challenge is declined.
         mode = "rated" if challenge.rated else "casual"
-        decline_details: Dict[str, str] = {"generic": opponent.name,
-                                           "later": opponent.name,
-                                           "nobot": opponent.name,
+        decline_details: Dict[str, str] = {"generic": "",
+                                           "later": "",
+                                           "nobot": "",
                                            "toofast": challenge.speed,
                                            "tooslow": challenge.speed,
                                            "timecontrol": challenge.speed,
@@ -263,7 +263,7 @@ class Matchmaking:
         self.show_earliest_challenge_time()
 
     def get_delay_timers(self, opponent_name: str, variant: str, time_control: str, rated_mode: str) -> List[Timer]:
-        aspects = [opponent_name, variant, time_control, rated_mode] if self.delay_type == DelayType.FINE else [opponent_name]
+        aspects = ["", variant, time_control, rated_mode] if self.delay_type == DelayType.FINE else [""]
         return [self.delay_timers[(opponent_name, aspect)] for aspect in aspects]
 
 


### PR DESCRIPTION
Lichess now includes a machine-readable key for the reason a challenge was declined. This key can be used to not rechallenge a potential opponent with game configurations that would lead to rejection. For example, if the user's bot challenges another bot with a rated blitz standard game and the challenged bot declines with a `declineReasonKey` of `timecontrol`, then lichess-bot will delay creating another blitz challenge for that opponent.