### PR TITLE
Drop support for Python 3.8

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        python: [3.8, "3.11"]
+        python: [3.9, "3.11"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -27,7 +27,6 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install mypy types-requests types-PyYAML
         pip install -r requirements.txt
     - name: Run mypy
       run: |

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -28,7 +28,6 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 flake8-markdown
         pip install -r requirements.txt
     - name: Lint with flake8
       run: |

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python: [3.8, 3.9, "3.10", "3.11"]
+        python: [3.9, "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python: [3.8, "3.11"]
+        python: [3.9, "3.11"]
 
 
     steps:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A bridge between [Lichess Bot API](https://lichess.org/api#tag/Bot) and bots.
 
 ## How to Install
 ### Mac/Linux:
-- **NOTE: Only Python 3.8 or later is supported!**
+- **NOTE: Only Python 3.9 or later is supported!**
 - Download the repo into lichess-bot directory.
 - Navigate to the directory in cmd/Terminal: `cd lichess-bot`.
 - Install pip: `apt install python3-pip`.
@@ -24,12 +24,12 @@ python3 -m pip install -r requirements.txt
 - Edit the variants: `supported_variants` and time controls: `supported_tc` from the `config.yml` file as necessary.
 
 ### Windows:
-- **NOTE: Only Python 3.8 or later is supported!**
+- **NOTE: Only Python 3.9 or later is supported!**
 - If needed, install Python:
   - [Download Python here](https://www.python.org/downloads/).
   - When installing, enable "add Python to PATH".
   - If the Python version is at least 3.10, a default local install works.
-  - If the Python version is 3.8 or 3.9, choose "Custom installation", keep the defaults on the Optional Features page, and choose "Install for all users" in the Advanced Options page.
+  - If the Python version is 3.9, choose "Custom installation", keep the defaults on the Optional Features page, and choose "Install for all users" in the Advanced Options page.
 - Start Terminal, PowerShell, cmd, or your preferred command prompt.
 - Upgrade pip: `python -m pip install --upgrade pip`.
 - Download the repo into lichess-bot directory.

--- a/config.py
+++ b/config.py
@@ -5,8 +5,8 @@ import logging
 import math
 from abc import ABCMeta
 from enum import Enum
-from typing import Dict, Any
-CONFIG_DICT_TYPE = Dict[str, Any]
+from typing import Any
+CONFIG_DICT_TYPE = dict[str, Any]
 
 logger = logging.getLogger(__name__)
 

--- a/conversation.py
+++ b/conversation.py
@@ -3,7 +3,7 @@ import logging
 import model
 from engine_wrapper import EngineWrapper
 from lichess import Lichess
-from typing import Dict, Sequence
+from collections.abc import Sequence
 MULTIPROCESSING_LIST_TYPE = Sequence[model.Challenge]
 
 logger = logging.getLogger(__name__)
@@ -59,7 +59,7 @@ class Conversation:
 
 
 class ChatLine:
-    def __init__(self, json: Dict[str, str]) -> None:
+    def __init__(self, json: dict[str, str]) -> None:
         self.room = json["room"]
         self.username = json["username"]
         self.text = json["text"]

--- a/conversation.py
+++ b/conversation.py
@@ -3,8 +3,8 @@ import logging
 import model
 from engine_wrapper import EngineWrapper
 from lichess import Lichess
-from typing import Dict, List
-MULTIPROCESSING_LIST_TYPE = List[model.Challenge]
+from typing import Dict, Sequence
+MULTIPROCESSING_LIST_TYPE = Sequence[model.Challenge]
 
 logger = logging.getLogger(__name__)
 

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -9,18 +9,19 @@ import logging
 import time
 import random
 from collections import Counter
+from collections.abc import Generator, Callable
 from contextlib import contextmanager
 import config
 import model
 import lichess
 from config import Configuration
-from typing import Dict, Any, List, Optional, Union, Tuple, Generator, Callable, Type
-OPTIONS_TYPE = Dict[str, Any]
-MOVE_INFO_TYPE = Dict[str, Any]
-COMMANDS_TYPE = List[str]
-LICHESS_EGTB_MOVE = Dict[str, Any]
-CHESSDB_EGTB_MOVE = Dict[str, Any]
-MOVE = Union[chess.engine.PlayResult, List[chess.Move]]
+from typing import Any, Optional, Union
+OPTIONS_TYPE = dict[str, Any]
+MOVE_INFO_TYPE = dict[str, Any]
+COMMANDS_TYPE = list[str]
+LICHESS_EGTB_MOVE = dict[str, Any]
+CHESSDB_EGTB_MOVE = dict[str, Any]
+MOVE = Union[chess.engine.PlayResult, list[chess.Move]]
 
 logger = logging.getLogger(__name__)
 
@@ -39,7 +40,7 @@ def create_engine(engine_config: config.Configuration) -> Generator[EngineWrappe
 
     stderr = None if cfg.silence_stderr else subprocess.DEVNULL
 
-    Engine: Union[Type[UCIEngine], Type[XBoardEngine], Type[MinimalEngine]]
+    Engine: Union[type[UCIEngine], type[XBoardEngine], type[MinimalEngine]]
     if engine_type == "xboard":
         Engine = XBoardEngine
     elif engine_type == "uci":
@@ -99,10 +100,10 @@ PONDERPV_CHARACTERS = 6  # The length of ", PV: ".
 class EngineWrapper:
     def __init__(self, options: OPTIONS_TYPE, draw_or_resign: config.Configuration) -> None:
         self.engine: Union[chess.engine.SimpleEngine, FillerEngine]
-        self.scores: List[chess.engine.PovScore] = []
+        self.scores: list[chess.engine.PovScore] = []
         self.draw_or_resign = draw_or_resign
         self.go_commands = config.Configuration(options.pop("go_commands", {}) or {})
-        self.move_commentary: List[MOVE_INFO_TYPE] = []
+        self.move_commentary: list[MOVE_INFO_TYPE] = []
         self.comment_start_index = -1
 
     def play_move(self,
@@ -302,12 +303,12 @@ class EngineWrapper:
             return f"{round(number / 1e3, 1)}K"
         return str(number)
 
-    def get_stats(self, for_chat: bool = False) -> List[str]:
+    def get_stats(self, for_chat: bool = False) -> list[str]:
         can_index = self.move_commentary and self.move_commentary[-1]
         info: MOVE_INFO_TYPE = self.move_commentary[-1].copy() if can_index else {}
 
         def to_readable_value(stat: str, info: MOVE_INFO_TYPE) -> str:
-            readable: Dict[str, Callable[[Any], str]] = {"score": self.readable_score, "wdl": self.readable_wdl,
+            readable: dict[str, Callable[[Any], str]] = {"score": self.readable_score, "wdl": self.readable_wdl,
                                                          "hashfull": lambda x: f"{round(x / 10, 1)}%",
                                                          "nodes": self.readable_number,
                                                          "nps": lambda x: f"{self.readable_number(x)}nps",
@@ -346,7 +347,7 @@ class EngineWrapper:
         pass
 
     def name(self) -> str:
-        engine_info: Dict[str, str] = dict(self.engine.id)
+        engine_info: dict[str, str] = dict(self.engine.id)
         name: str = engine_info["name"]
         return name
 
@@ -493,7 +494,7 @@ class FillerEngine:
     in "MinimalEngine" which extends "EngineWrapper"
     """
     def __init__(self, main_engine: MinimalEngine, name: str = "") -> None:
-        self.id: Dict[str, str] = {
+        self.id: dict[str, str] = {
             "name": name
         }
         self.name = name
@@ -510,9 +511,9 @@ class FillerEngine:
         return method
 
 
-def getHomemadeEngine(name: str) -> Type[MinimalEngine]:
+def getHomemadeEngine(name: str) -> type[MinimalEngine]:
     import strategies
-    engine: Type[MinimalEngine] = getattr(strategies, name)
+    engine: type[MinimalEngine] = getattr(strategies, name)
     return engine
 
 
@@ -591,7 +592,7 @@ def get_book_move(board: chess.Board, game: model.Game,
 
 
 def get_online_move(li: lichess.Lichess, board: chess.Board, game: model.Game, online_moves_cfg: config.Configuration,
-                    draw_or_resign_cfg: config.Configuration) -> Union[chess.engine.PlayResult, List[chess.Move]]:
+                    draw_or_resign_cfg: config.Configuration) -> Union[chess.engine.PlayResult, list[chess.Move]]:
     online_egtb_cfg = online_moves_cfg.online_egtb
     chessdb_cfg = online_moves_cfg.chessdb_book
     lichess_cloud_cfg = online_moves_cfg.lichess_cloud_analysis
@@ -635,7 +636,7 @@ def get_online_move(li: lichess.Lichess, board: chess.Board, game: model.Game, o
 
 
 def get_chessdb_move(li: lichess.Lichess, board: chess.Board, game: model.Game,
-                     chessdb_cfg: config.Configuration) -> Tuple[Optional[str], Optional[chess.engine.InfoDict]]:
+                     chessdb_cfg: config.Configuration) -> tuple[Optional[str], Optional[chess.engine.InfoDict]]:
     wb = "w" if board.turn == chess.WHITE else "b"
     use_chessdb = chessdb_cfg.enabled
     time_left = game.state[f"{wb}time"]
@@ -679,7 +680,7 @@ def get_chessdb_move(li: lichess.Lichess, board: chess.Board, game: model.Game,
 
 
 def get_lichess_cloud_move(li: lichess.Lichess, board: chess.Board, game: model.Game,
-                           lichess_cloud_cfg: config.Configuration) -> Tuple[Optional[str], Optional[chess.engine.InfoDict]]:
+                           lichess_cloud_cfg: config.Configuration) -> tuple[Optional[str], Optional[chess.engine.InfoDict]]:
     wb = "w" if board.turn == chess.WHITE else "b"
     time_left = game.state[f"{wb}time"]
     min_time = lichess_cloud_cfg.min_time * 1000
@@ -731,7 +732,7 @@ def get_lichess_cloud_move(li: lichess.Lichess, board: chess.Board, game: model.
 
 
 def get_online_egtb_move(li: lichess.Lichess, board: chess.Board, game: model.Game,
-                         online_egtb_cfg: config.Configuration) -> Tuple[Union[str, List[str], None], int]:
+                         online_egtb_cfg: config.Configuration) -> tuple[Union[str, list[str], None], int]:
     use_online_egtb = online_egtb_cfg.enabled
     wb = "w" if board.turn == chess.WHITE else "b"
     pieces = chess.popcount(board.occupied)
@@ -763,7 +764,7 @@ def get_online_egtb_move(li: lichess.Lichess, board: chess.Board, game: model.Ga
 
 
 def get_egtb_move(board: chess.Board, game: model.Game, lichess_bot_tbs: config.Configuration,
-                  draw_or_resign_cfg: config.Configuration) -> Union[chess.engine.PlayResult, List[chess.Move]]:
+                  draw_or_resign_cfg: config.Configuration) -> Union[chess.engine.PlayResult, list[chess.Move]]:
     best_move, wdl = get_syzygy(board, game, lichess_bot_tbs.syzygy)
     if best_move is None:
         best_move, wdl = get_gaviota(board, game, lichess_bot_tbs.gaviota)
@@ -784,7 +785,7 @@ def get_egtb_move(board: chess.Board, game: model.Game, lichess_bot_tbs: config.
 
 
 def get_lichess_egtb_move(li: lichess.Lichess, game: model.Game, board: chess.Board, quality: str,
-                          variant: str) -> Tuple[Union[str, List[str], None], int]:
+                          variant: str) -> tuple[Union[str, list[str], None], int]:
     name_to_wld = {"loss": -2,
                    "maybe-loss": -1,
                    "blessed-loss": -1,
@@ -846,7 +847,7 @@ def get_lichess_egtb_move(li: lichess.Lichess, game: model.Game, board: chess.Bo
 
 
 def get_chessdb_egtb_move(li: lichess.Lichess, game: model.Game, board: chess.Board,
-                          quality: str) -> Tuple[Union[str, List[str], None], int]:
+                          quality: str) -> tuple[Union[str, list[str], None], int]:
     def score_to_wdl(score: int) -> int:
         return piecewise_function([(-20001, 2),
                                    (-1, -1),
@@ -905,12 +906,12 @@ def get_chessdb_egtb_move(li: lichess.Lichess, game: model.Game, board: chess.Bo
 
 
 def get_syzygy(board: chess.Board, game: model.Game,
-               syzygy_cfg: config.Configuration) -> Tuple[Union[chess.Move, List[chess.Move], None], int]:
+               syzygy_cfg: config.Configuration) -> tuple[Union[chess.Move, list[chess.Move], None], int]:
     if (not syzygy_cfg.enabled
             or chess.popcount(board.occupied) > syzygy_cfg.max_pieces
             or board.uci_variant not in ["chess", "antichess", "atomic"]):
         return None, -3
-    move: Union[chess.Move, List[chess.Move]]
+    move: Union[chess.Move, list[chess.Move]]
     move_quality = syzygy_cfg.move_quality
     with chess.syzygy.open_tablebase(syzygy_cfg.paths[0]) as tablebase:
         for path in syzygy_cfg.paths[1:]:
@@ -964,12 +965,12 @@ def dtz_to_wdl(dtz: int) -> int:
 
 
 def get_gaviota(board: chess.Board, game: model.Game,
-                gaviota_cfg: config.Configuration) -> Tuple[Union[chess.Move, List[chess.Move], None], int]:
+                gaviota_cfg: config.Configuration) -> tuple[Union[chess.Move, list[chess.Move], None], int]:
     if (not gaviota_cfg.enabled
             or chess.popcount(board.occupied) > gaviota_cfg.max_pieces
             or board.uci_variant != "chess"):
         return None, -3
-    move: Union[chess.Move, List[chess.Move]]
+    move: Union[chess.Move, list[chess.Move]]
     move_quality = gaviota_cfg.move_quality
     # Since gaviota TBs use dtm and not dtz, we have to put a limit where after it the position are considered to have
     # a syzygy wdl=1/-1, so the positions are draws under the 50 move rule. We use min_dtm_to_consider_as_wdl_1 as a
@@ -1028,8 +1029,8 @@ def dtm_to_wdl(dtm: int, min_dtm_to_consider_as_wdl_1: int) -> int:
     return piecewise_function([(-100, -1), (-1, -2), (0, 0), (min_dtm_to_consider_as_wdl_1 - 1, 2)], 1, dtm)
 
 
-def good_enough_gaviota_moves(good_moves: List[Tuple[chess.Move, int]], best_dtm: int,
-                              min_dtm_to_consider_as_wdl_1: int) -> List[Tuple[chess.Move, int]]:
+def good_enough_gaviota_moves(good_moves: list[tuple[chess.Move, int]], best_dtm: int,
+                              min_dtm_to_consider_as_wdl_1: int) -> list[tuple[chess.Move, int]]:
     if best_dtm < 100:
         # If a move had wdl=2 and dtz=98, but halfmove_clock is 4 then the real wdl=1 and dtz=102, so we
         # want to avoid these positions, if there is a move where even when we add the halfmove_clock the
@@ -1052,7 +1053,7 @@ def good_enough_gaviota_moves(good_moves: List[Tuple[chess.Move, int]], best_dtm
         return good_moves
 
 
-def piecewise_function(range_definitions: List[Tuple[int, int]], last_value: int, position: int) -> int:
+def piecewise_function(range_definitions: list[tuple[int, int]], last_value: int, position: int) -> int:
     """ Returns a value according to a position argument
     This function is meant to replace if-elif-else blocks that turn ranges into discrete values. For
     example,
@@ -1095,7 +1096,7 @@ def piecewise_function(range_definitions: List[Tuple[int, int]], last_value: int
 
 
 def score_syzygy_moves(board: chess.Board, scorer: Callable[[chess.syzygy.Tablebase, chess.Board], int],
-                       tablebase: chess.syzygy.Tablebase) -> Dict[chess.Move, int]:
+                       tablebase: chess.syzygy.Tablebase) -> dict[chess.Move, int]:
     moves = {}
     for move in board.legal_moves:
         board_copy = board.copy()
@@ -1108,7 +1109,7 @@ def score_gaviota_moves(board: chess.Board,
                         scorer: Callable[[Union[chess.gaviota.NativeTablebase, chess.gaviota.PythonTablebase],
                                           chess.Board], int],
                         tablebase: Union[chess.gaviota.NativeTablebase, chess.gaviota.PythonTablebase]
-                        ) -> Dict[chess.Move, int]:
+                        ) -> dict[chess.Move, int]:
     moves = {}
     for move in board.legal_moves:
         board_copy = board.copy()

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -55,6 +55,7 @@ restart = True
 
 
 def disable_restart() -> None:
+    """Disable restarting lichess-bot when errors occur. Used during testing."""
     global restart
     restart = False
 

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -29,16 +29,16 @@ from collections import defaultdict
 from http.client import RemoteDisconnected
 from queue import Queue
 from multiprocessing.pool import Pool
-from typing import Dict, Any, Optional, Set, List, Iterator, DefaultDict, Union
+from typing import Dict, Any, Optional, Set, List, Iterator, DefaultDict, Union, MutableSequence
 USER_PROFILE_TYPE = Dict[str, Any]
 EVENT_TYPE = Dict[str, Any]
 PLAY_GAME_ARGS_TYPE = Dict[str, Any]
 EVENT_GETATTR_GAME_TYPE = Dict[str, Any]
 GAME_EVENT_TYPE = Dict[str, Any]
-MULTIPROCESSING_LIST_TYPE = List[model.Challenge]
 CONTROL_QUEUE_TYPE = Queue[EVENT_TYPE]
 CORRESPONDENCE_QUEUE_TYPE = Queue[str]
 LOGGING_QUEUE_TYPE = Queue[logging.LogRecord]
+MULTIPROCESSING_LIST_TYPE = MutableSequence[model.Challenge]
 POOL_TYPE = Pool
 
 logger = logging.getLogger(__name__)
@@ -142,7 +142,7 @@ def start(li: lichess.Lichess, user_profile: USER_PROFILE_TYPE, config: Configur
           log_filename: Optional[str], one_game: bool = False) -> None:
     logger.info(f"You're now connected to {config.url} and awaiting challenges.")
     manager = multiprocessing.Manager()
-    challenge_queue: MULTIPROCESSING_LIST_TYPE = manager.list()  # type: ignore[assignment]
+    challenge_queue: MULTIPROCESSING_LIST_TYPE = manager.list()
     control_queue: CONTROL_QUEUE_TYPE = manager.Queue()
     control_stream = multiprocessing.Process(target=watch_control_stream, args=(control_queue, li))
     control_stream.start()

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -52,6 +52,11 @@ terminated = False
 restart = True
 
 
+def disable_restart() -> None:
+    global restart
+    restart = False
+
+
 def signal_handler(signal: int, frame: Any) -> None:
     global terminated
     logger.debug("Recieved SIGINT. Terminating client.")

--- a/lichess.py
+++ b/lichess.py
@@ -7,10 +7,10 @@ import backoff
 import logging
 from collections import defaultdict
 from timer import Timer
-from typing import Optional, Dict, Union, Any, List, DefaultDict
+from typing import Optional, Union, Any
 import chess.engine
-JSON_REPLY_TYPE = Dict[str, Any]
-REQUESTS_PAYLOAD_TYPE = Dict[str, Any]
+JSON_REPLY_TYPE = dict[str, Any]
+REQUESTS_PAYLOAD_TYPE = dict[str, Any]
 
 ENDPOINTS = {
     "profile": "/api/account",
@@ -64,7 +64,7 @@ class Lichess:
         self.set_user_agent("?")
         self.logging_level = logging_level
         self.max_retries = max_retries
-        self.rate_limit_timers: DefaultDict[str, Timer] = defaultdict(Timer)
+        self.rate_limit_timers: defaultdict[str, Timer] = defaultdict(Timer)
 
     @backoff.on_exception(backoff.constant,
                           (RemoteDisconnected, ConnectionError, HTTPError, ReadTimeout),
@@ -74,7 +74,7 @@ class Lichess:
                           backoff_log_level=logging.DEBUG,
                           giveup_log_level=logging.DEBUG)
     def api_get(self, endpoint_name: str, *template_args: str,
-                params: Optional[Dict[str, str]] = None) -> requests.Response:
+                params: Optional[dict[str, str]] = None) -> requests.Response:
         logging.getLogger("backoff").setLevel(self.logging_level)
         path_template = self.get_path_template(endpoint_name)
         url = urljoin(self.baseUrl, path_template.format(*template_args))
@@ -89,19 +89,19 @@ class Lichess:
         return response
 
     def api_get_json(self, endpoint_name: str, *template_args: str,
-                     params: Optional[Dict[str, str]] = None) -> JSON_REPLY_TYPE:
+                     params: Optional[dict[str, str]] = None) -> JSON_REPLY_TYPE:
         response = self.api_get(endpoint_name, *template_args, params=params)
         json_response: JSON_REPLY_TYPE = response.json()
         return json_response
 
     def api_get_list(self, endpoint_name: str, *template_args: str,
-                     params: Optional[Dict[str, str]] = None) -> List[JSON_REPLY_TYPE]:
+                     params: Optional[dict[str, str]] = None) -> list[JSON_REPLY_TYPE]:
         response = self.api_get(endpoint_name, *template_args, params=params)
-        json_response: List[JSON_REPLY_TYPE] = response.json()
+        json_response: list[JSON_REPLY_TYPE] = response.json()
         return json_response
 
     def api_get_raw(self, endpoint_name: str, *template_args: str,
-                    params: Optional[Dict[str, str]] = None, ) -> str:
+                    params: Optional[dict[str, str]] = None, ) -> str:
         response = self.api_get(endpoint_name, *template_args, params=params)
         return response.text
 
@@ -115,9 +115,9 @@ class Lichess:
     def api_post(self,
                  endpoint_name: str,
                  *template_args: Any,
-                 data: Union[str, Dict[str, str], None] = None,
-                 headers: Optional[Dict[str, str]] = None,
-                 params: Optional[Dict[str, str]] = None,
+                 data: Union[str, dict[str, str], None] = None,
+                 headers: Optional[dict[str, str]] = None,
+                 params: Optional[dict[str, str]] = None,
                  payload: Optional[REQUESTS_PAYLOAD_TYPE] = None,
                  raise_for_status: bool = True) -> JSON_REPLY_TYPE:
         logging.getLogger("backoff").setLevel(self.logging_level)
@@ -197,8 +197,8 @@ class Lichess:
         self.set_user_agent(profile["username"])
         return profile
 
-    def get_ongoing_games(self) -> List[Dict[str, Any]]:
-        ongoing_games: List[Dict[str, Any]] = []
+    def get_ongoing_games(self) -> list[dict[str, Any]]:
+        ongoing_games: list[dict[str, Any]] = []
         try:
             ongoing_games = self.api_get_json("playing")["nowPlaying"]
         except Exception:
@@ -218,7 +218,7 @@ class Lichess:
         except Exception:
             return ""
 
-    def get_online_bots(self) -> List[Dict[str, Any]]:
+    def get_online_bots(self) -> list[dict[str, Any]]:
         try:
             online_bots_str = self.api_get_raw("online_bots")
             online_bots = list(filter(bool, online_bots_str.split("\n")))
@@ -232,7 +232,7 @@ class Lichess:
     def cancel(self, challenge_id: str) -> JSON_REPLY_TYPE:
         return self.api_post("cancel", challenge_id, raise_for_status=False)
 
-    def online_book_get(self, path: str, params: Optional[Dict[str, Any]] = None) -> JSON_REPLY_TYPE:
+    def online_book_get(self, path: str, params: Optional[dict[str, Any]] = None) -> JSON_REPLY_TYPE:
         @backoff.on_exception(backoff.constant,
                               (RemoteDisconnected, ConnectionError, HTTPError, ReadTimeout),
                               max_time=60,

--- a/matchmaking.py
+++ b/matchmaking.py
@@ -6,10 +6,10 @@ from collections import defaultdict
 import lichess
 import datetime
 from config import Configuration, FilterType
-from typing import Dict, Any, Set, Optional, Tuple, List, DefaultDict
+from typing import Dict, Any, Set, Optional, Tuple, List, DefaultDict, Sequence
 USER_PROFILE_TYPE = Dict[str, Any]
 EVENT_TYPE = Dict[str, Any]
-MULTIPROCESSING_LIST_TYPE = List[model.Challenge]
+MULTIPROCESSING_LIST_TYPE = Sequence[model.Challenge]
 
 logger = logging.getLogger(__name__)
 

--- a/model.py
+++ b/model.py
@@ -5,13 +5,14 @@ import datetime
 from enum import Enum
 from timer import Timer
 from config import Configuration
-from typing import Dict, Any, Tuple, List, DefaultDict
+from typing import Any
+from collections import defaultdict
 
 logger = logging.getLogger(__name__)
 
 
 class Challenge:
-    def __init__(self, c_info: Dict[str, Any], user_profile: Dict[str, Any]) -> None:
+    def __init__(self, c_info: dict[str, Any], user_profile: dict[str, Any]) -> None:
         self.id = c_info["id"]
         self.rated = c_info["rated"]
         self.variant = c_info["variant"]["key"]
@@ -53,7 +54,7 @@ class Challenge:
     def is_supported_mode(self, challenge_cfg: Configuration) -> bool:
         return ("rated" if self.rated else "casual") in challenge_cfg.modes
 
-    def is_supported_recent(self, config: Configuration, recent_bot_challenges: DefaultDict[str, List[Timer]]) -> bool:
+    def is_supported_recent(self, config: Configuration, recent_bot_challenges: defaultdict[str, list[Timer]]) -> bool:
         # Filter out old challenges
         recent_bot_challenges[self.challenger.name] = [timer for timer
                                                        in recent_bot_challenges[self.challenger.name]
@@ -67,7 +68,7 @@ class Challenge:
         return "" if requirement_met else decline_reason
 
     def is_supported(self, config: Configuration,
-                     recent_bot_challenges: DefaultDict[str, List[Timer]]) -> Tuple[bool, str]:
+                     recent_bot_challenges: defaultdict[str, list[Timer]]) -> tuple[bool, str]:
         try:
             if self.from_self:
                 return True, ""
@@ -112,7 +113,7 @@ class Termination(str, Enum):
 
 
 class Game:
-    def __init__(self, json: Dict[str, Any], username: str, base_url: str, abort_time: int) -> None:
+    def __init__(self, json: dict[str, Any], username: str, base_url: str, abort_time: int) -> None:
         self.username = username
         self.id: str = json["id"]
         self.speed = json.get("speed")
@@ -126,7 +127,7 @@ class Game:
         self.white = Player(json["white"])
         self.black = Player(json["black"])
         self.initial_fen = json.get("initialFen")
-        self.state: Dict[str, Any] = json["state"]
+        self.state: dict[str, Any] = json["state"]
         self.is_white = (self.white.name or "").lower() == username.lower()
         self.my_color = "white" if self.is_white else "black"
         self.opponent_color = "black" if self.is_white else "white"
@@ -207,7 +208,7 @@ class Game:
 
 
 class Player:
-    def __init__(self, json: Dict[str, Any]) -> None:
+    def __init__(self, json: dict[str, Any]) -> None:
         self.name: str = json.get("name", "")
         self.title = json.get("title")
         self.is_bot = self.title == "BOT"

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ pytest==7.2.2
 pytest-timeout==2.1.0
 flake8==6.0.0
 flake8-markdown==0.4.0
+flake8-docstrings==1.7.0
 mypy==1.2.0
 types-requests==2.28.11.17
 types-PyYAML==6.0.12.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,8 @@ rich==13.3.3
 # Requirements for tests
 pytest==7.2.2
 pytest-timeout==2.1.0
+flake8==6.0.0
+flake8-markdown==0.4.0
+mypy==1.2.0
+types-requests==2.28.11.17
+types-PyYAML==6.0.12.9

--- a/test_bot/test_bot.py
+++ b/test_bot/test_bot.py
@@ -170,7 +170,7 @@ def run_bot(raw_config: Dict[str, Any], logging_level: int) -> str:
     if user_profile.get("title") != "BOT":
         return "0"
     lichess_bot.logger.info(f"Welcome {username}!")
-    lichess_bot.restart = False  # type: ignore[attr-defined]
+    lichess_bot.disable_restart()
 
     thr = threading.Thread(target=thread_for_test)
     thr.start()


### PR DESCRIPTION
On May 1, 2023, lichess-bot officially drops support for Python 3.8 and will require at least Python 3.9 going forward. The main benefit will be to finish type hinting with the `Queue` type. Further changes:
- Use the `MutableSequence` type for `MULTIPROCESSING_LIST_TYPE` that describes the `challenge_queue`. This is slightly more generic than the specific type returned by `multiprocessing.Manager().list()`, but `MutableSequence` is still an accurate description of what it is. Functions that only read the `challenge_queue` can use a `Sequence` type to flag modifications as an error.
- Put all packages for running tests in requirements.txt and delete the separate `pip` lines from the github actions.
- Create a function that sets `restart` to `False` in lichess-bot.py when testing. Functions seem to be more visible to mypy than variables.