### PR TITLE
Add docstrings

### DIFF
--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -42,5 +42,4 @@ jobs:
         flake8-markdown "*.md"
     - name: Lint with flake8-docstrings
       run: |
-        # D212 and D213 conflict with other warni
         flake8 . --count --exit-zero --max-line-length=127 --statistics --select=D

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -28,14 +28,19 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 flake8-markdown
+        pip install flake8 flake8-markdown flake8-docstrings
         pip install -r requirements.txt
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide.
+        # W503 and W504 are mutually exclusive. W504 is considered the best practice now.
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics --ignore=D,W503
     - name: Lint with flake8-markdown
       run: |
         flake8-markdown "*.md"
+    - name: Lint with flake8-docstrings
+      run: |
+        # D212 and D213 conflict with other warni
+        flake8 . --count --exit-zero --max-line-length=127 --statistics --select=D

--- a/.github/workflows/update_version.py
+++ b/.github/workflows/update_version.py
@@ -1,3 +1,4 @@
+"""Automatically updates the lichess-bot version."""
 import yaml
 import datetime
 

--- a/config.py
+++ b/config.py
@@ -32,7 +32,7 @@ class Configuration:
 
     def __getattr__(self, name: str) -> Any:
         """
-        Enables the use of `config.key1.key2`.
+        Enable the use of `config.key1.key2`.
 
         :param name: The key to get its value.
         :return: The value of the key.
@@ -41,7 +41,7 @@ class Configuration:
 
     def lookup(self, name: str) -> Any:
         """
-        Gets the value of a key.
+        Get the value of a key.
 
         :param name: The key to get its value.
         :return: `Configuration` if the value is a `dict` else returns the value.
@@ -67,14 +67,14 @@ class Configuration:
 
 
 def config_assert(assertion: bool, error_message: str) -> None:
-    """:raises: An exception if an assertion is false."""
+    """Raise an exception if an assertion is false."""
     if not assertion:
         raise Exception(error_message)
 
 
 def check_config_section(config: CONFIG_DICT_TYPE, data_name: str, data_type: ABCMeta, subsection: str = "") -> None:
     """
-    Checks the validity of a config section.
+    Check the validity of a config section.
 
     :param config: The config section.
     :param data_name: The key to check its value.
@@ -117,7 +117,7 @@ def set_config_default(config: CONFIG_DICT_TYPE, *sections: str, key: str, defau
 
 def change_value_to_list(config: CONFIG_DICT_TYPE, *sections: str, key: str) -> None:
     """
-    Changes a single value to a list. e.g. 60 becomes [60]. Used to maintain backwards compatibility.
+    Change a single value to a list. e.g. 60 becomes [60]. Used to maintain backwards compatibility.
 
     :param config: The bot's config.
     :param sections: The sections that the key is in.
@@ -134,7 +134,7 @@ def change_value_to_list(config: CONFIG_DICT_TYPE, *sections: str, key: str) -> 
 
 def insert_default_values(CONFIG: CONFIG_DICT_TYPE) -> None:
     """
-    Inserts the default values of most keys to the config if they are missing.
+    Insert the default values of most keys to the config if they are missing.
 
     :param CONFIG: The bot's config.
     """
@@ -235,7 +235,7 @@ def log_config(CONFIG: CONFIG_DICT_TYPE) -> None:
 
 
 def validate_config(CONFIG: CONFIG_DICT_TYPE) -> None:
-    """Checks if the config is valid."""
+    """Check if the config is valid."""
     check_config_section(CONFIG, "token", str)
     check_config_section(CONFIG, "url", str)
     check_config_section(CONFIG, "engine", dict)
@@ -275,7 +275,7 @@ def validate_config(CONFIG: CONFIG_DICT_TYPE) -> None:
 
 def load_config(config_file: str) -> Configuration:
     """
-    Reads the config.
+    Read the config.
 
     :param config_file: The filename of the config (usually `config.yml`).
     :return: A `Configuration` object containing the config.

--- a/config.py
+++ b/config.py
@@ -12,23 +12,48 @@ logger = logging.getLogger(__name__)
 
 
 class DelayType(str, Enum):
+    """
+    Whether we should avoid challenging the same opponent after they have declined our challenge.
+    """
     NONE = "none"
+    """Will still challenge the opponent."""
     COARSE = "coarse"
+    """Won't challenge the opponent for some time."""
     FINE = "fine"
+    """Won't challenge the opponent to a game of the same mode, speed, and variant for some time."""
 
 
 class Configuration:
+    """
+    The config or a sub-config that the bot uses.
+    """
     def __init__(self, parameters: CONFIG_DICT_TYPE) -> None:
+        """
+        :param parameters: A `dict` containing the config for the bot.
+        """
         self.config = parameters
 
     def __getattr__(self, name: str) -> Any:
+        """
+        Enables the use of `config.key1.key2`.
+        :param name: The key to get its value.
+        :return: The value of the key.
+        """
         return self.lookup(name)
 
     def lookup(self, name: str) -> Any:
+        """
+        Gets the value of a key.
+        :param name: The key to get its value.
+        :return: `Configuration` if the value is a `dict` else returns the value.
+        """
         data = self.config.get(name)
         return Configuration(data) if isinstance(data, dict) else data
 
     def items(self) -> Any:
+        """
+        :return: All the key-value pairs in this config.
+        """
         return self.config.items()
 
     def __bool__(self) -> bool:
@@ -42,11 +67,21 @@ class Configuration:
 
 
 def config_assert(assertion: bool, error_message: str) -> None:
+    """
+    :raises: An exception if an assertion is false.
+    """
     if not assertion:
         raise Exception(error_message)
 
 
 def check_config_section(config: CONFIG_DICT_TYPE, data_name: str, data_type: ABCMeta, subsection: str = "") -> None:
+    """
+    Checks the validity of a config section.
+    :param config: The config section.
+    :param data_name: The key to check its value.
+    :param data_type: The expected data type.
+    :param subsection: The subsection of the key.
+    """
     config_part = config[subsection] if subsection else config
     sub = f"`{subsection}` sub" if subsection else ""
     data_location = f"`{data_name}` subsection in `{subsection}`" if subsection else f"Section `{data_name}`"
@@ -58,6 +93,15 @@ def check_config_section(config: CONFIG_DICT_TYPE, data_name: str, data_type: AB
 
 def set_config_default(config: CONFIG_DICT_TYPE, *sections: str, key: str, default: Any,
                        force_empty_values: bool = False) -> CONFIG_DICT_TYPE:
+    """
+    Fill the a specific config key with the default value if it is missing.
+    :param config: The bot's config.
+    :param sections: The sections that the key is in.
+    :param key: The key to set.
+    :param default: The default value.
+    :param force_empty_values: Whether an empty value should be replaced with the default value.
+    :return: The new config with the default value inserted if needed.
+    """
     subconfig = config
     for section in sections:
         subconfig = subconfig.setdefault(section, {})
@@ -72,6 +116,12 @@ def set_config_default(config: CONFIG_DICT_TYPE, *sections: str, key: str, defau
 
 
 def change_value_to_list(config: CONFIG_DICT_TYPE, *sections: str, key: str) -> None:
+    """
+    Changes a single value to a list. e.g. 60 becomes [60]. Used to maintain backwards compatibility.
+    :param config: The bot's config.
+    :param sections: The sections that the key is in.
+    :param key: The key to set.
+    """
     subconfig = set_config_default(config, *sections, key=key, default=[])
 
     if subconfig[key] is None:
@@ -82,6 +132,10 @@ def change_value_to_list(config: CONFIG_DICT_TYPE, *sections: str, key: str) -> 
 
 
 def insert_default_values(CONFIG: CONFIG_DICT_TYPE) -> None:
+    """
+    Inserts the default values of most keys to the config if they are missing.
+    :param CONFIG: The bot's config.
+    """
     set_config_default(CONFIG, key="abort_time", default=20)
     set_config_default(CONFIG, key="move_overhead", default=1000)
     set_config_default(CONFIG, key="rate_limiting_delay", default=0)
@@ -166,6 +220,10 @@ def insert_default_values(CONFIG: CONFIG_DICT_TYPE) -> None:
 
 
 def log_config(CONFIG: CONFIG_DICT_TYPE) -> None:
+    """
+    Log the config to make debugging easier.
+    :param CONFIG: The bot's config.
+    """
     logger_config = CONFIG.copy()
     logger_config["token"] = "logger"
     logger.debug(f"Config:\n{yaml.dump(logger_config, sort_keys=False)}")
@@ -173,6 +231,11 @@ def log_config(CONFIG: CONFIG_DICT_TYPE) -> None:
 
 
 def load_config(config_file: str) -> Configuration:
+    """
+    Reads the config.
+    :param config_file: The filename of the config (usually `config.yml`).
+    :return: A `Configuration` object containing the config.
+    """
     with open(config_file) as stream:
         try:
             CONFIG = yaml.safe_load(stream)

--- a/config.py
+++ b/config.py
@@ -12,6 +12,7 @@ logger = logging.getLogger(__name__)
 
 
 class FilterType(str, Enum):
+    """What to do if the opponent declines our challenge."""
     NONE = "none"
     """Will still challenge the opponent."""
     COARSE = "coarse"
@@ -21,9 +22,7 @@ class FilterType(str, Enum):
 
 
 class Configuration:
-    """
-    The config or a sub-config that the bot uses.
-    """
+    """The config or a sub-config that the bot uses."""
     def __init__(self, parameters: CONFIG_DICT_TYPE) -> None:
         """
         :param parameters: A `dict` containing the config for the bot.
@@ -229,6 +228,9 @@ def log_config(CONFIG: CONFIG_DICT_TYPE) -> None:
 
 
 def validate_config(CONFIG: CONFIG_DICT_TYPE) -> None:
+    """
+    Checks if the config is valid.
+    """
     check_config_section(CONFIG, "token", str)
     check_config_section(CONFIG, "url", str)
     check_config_section(CONFIG, "engine", dict)

--- a/config.py
+++ b/config.py
@@ -1,3 +1,4 @@
+"""Code related to the config that lichess-bot uses."""
 import yaml
 import os
 import os.path
@@ -13,6 +14,7 @@ logger = logging.getLogger(__name__)
 
 class FilterType(str, Enum):
     """What to do if the opponent declines our challenge."""
+
     NONE = "none"
     """Will still challenge the opponent."""
     COARSE = "coarse"
@@ -23,15 +25,15 @@ class FilterType(str, Enum):
 
 class Configuration:
     """The config or a sub-config that the bot uses."""
+
     def __init__(self, parameters: CONFIG_DICT_TYPE) -> None:
-        """
-        :param parameters: A `dict` containing the config for the bot.
-        """
+        """:param parameters: A `dict` containing the config for the bot."""
         self.config = parameters
 
     def __getattr__(self, name: str) -> Any:
         """
         Enables the use of `config.key1.key2`.
+
         :param name: The key to get its value.
         :return: The value of the key.
         """
@@ -40,6 +42,7 @@ class Configuration:
     def lookup(self, name: str) -> Any:
         """
         Gets the value of a key.
+
         :param name: The key to get its value.
         :return: `Configuration` if the value is a `dict` else returns the value.
         """
@@ -47,25 +50,24 @@ class Configuration:
         return Configuration(data) if isinstance(data, dict) else data
 
     def items(self) -> Any:
-        """
-        :return: All the key-value pairs in this config.
-        """
+        """:return: All the key-value pairs in this config."""
         return self.config.items()
 
     def __bool__(self) -> bool:
+        """Whether `self.config` is empty."""
         return bool(self.config)
 
     def __getstate__(self) -> CONFIG_DICT_TYPE:
+        """Get `self.config`."""
         return self.config
 
     def __setstate__(self, d: CONFIG_DICT_TYPE) -> None:
+        """Set `self.config`."""
         self.config = d
 
 
 def config_assert(assertion: bool, error_message: str) -> None:
-    """
-    :raises: An exception if an assertion is false.
-    """
+    """:raises: An exception if an assertion is false."""
     if not assertion:
         raise Exception(error_message)
 
@@ -73,6 +75,7 @@ def config_assert(assertion: bool, error_message: str) -> None:
 def check_config_section(config: CONFIG_DICT_TYPE, data_name: str, data_type: ABCMeta, subsection: str = "") -> None:
     """
     Checks the validity of a config section.
+
     :param config: The config section.
     :param data_name: The key to check its value.
     :param data_type: The expected data type.
@@ -90,7 +93,8 @@ def check_config_section(config: CONFIG_DICT_TYPE, data_name: str, data_type: AB
 def set_config_default(config: CONFIG_DICT_TYPE, *sections: str, key: str, default: Any,
                        force_empty_values: bool = False) -> CONFIG_DICT_TYPE:
     """
-    Fill the a specific config key with the default value if it is missing.
+    Fill a specific config key with the default value if it is missing.
+
     :param config: The bot's config.
     :param sections: The sections that the key is in.
     :param key: The key to set.
@@ -114,6 +118,7 @@ def set_config_default(config: CONFIG_DICT_TYPE, *sections: str, key: str, defau
 def change_value_to_list(config: CONFIG_DICT_TYPE, *sections: str, key: str) -> None:
     """
     Changes a single value to a list. e.g. 60 becomes [60]. Used to maintain backwards compatibility.
+
     :param config: The bot's config.
     :param sections: The sections that the key is in.
     :param key: The key to set.
@@ -130,6 +135,7 @@ def change_value_to_list(config: CONFIG_DICT_TYPE, *sections: str, key: str) -> 
 def insert_default_values(CONFIG: CONFIG_DICT_TYPE) -> None:
     """
     Inserts the default values of most keys to the config if they are missing.
+
     :param CONFIG: The bot's config.
     """
     set_config_default(CONFIG, key="abort_time", default=20)
@@ -219,6 +225,7 @@ def insert_default_values(CONFIG: CONFIG_DICT_TYPE) -> None:
 def log_config(CONFIG: CONFIG_DICT_TYPE) -> None:
     """
     Log the config to make debugging easier.
+
     :param CONFIG: The bot's config.
     """
     logger_config = CONFIG.copy()
@@ -228,9 +235,7 @@ def log_config(CONFIG: CONFIG_DICT_TYPE) -> None:
 
 
 def validate_config(CONFIG: CONFIG_DICT_TYPE) -> None:
-    """
-    Checks if the config is valid.
-    """
+    """Checks if the config is valid."""
     check_config_section(CONFIG, "token", str)
     check_config_section(CONFIG, "url", str)
     check_config_section(CONFIG, "engine", dict)
@@ -271,6 +276,7 @@ def validate_config(CONFIG: CONFIG_DICT_TYPE) -> None:
 def load_config(config_file: str) -> Configuration:
     """
     Reads the config.
+
     :param config_file: The filename of the config (usually `config.yml`).
     :return: A `Configuration` object containing the config.
     """

--- a/config.py
+++ b/config.py
@@ -18,9 +18,12 @@ class FilterType(str, Enum):
     NONE = "none"
     """Will still challenge the opponent."""
     COARSE = "coarse"
-    """Won't challenge the opponent for some time."""
+    """Won't challenge the opponent again."""
     FINE = "fine"
-    """Won't challenge the opponent to a game of the same mode, speed, and variant for some time."""
+    """
+    Won't challenge the opponent to a game of the same mode, speed, and variant
+    based on the reason for the opponent declining the challenge.
+    """
 
 
 class Configuration:

--- a/conversation.py
+++ b/conversation.py
@@ -1,3 +1,4 @@
+"""Allows lichess-bot to send messages to the chat."""
 from __future__ import annotations
 import logging
 import model
@@ -11,9 +12,12 @@ logger = logging.getLogger(__name__)
 
 class Conversation:
     """Enables the bot to communicate with its opponent and the spectators."""
+
     def __init__(self, game: model.Game, engine: EngineWrapper, xhr: Lichess, version: str,
                  challenge_queue: MULTIPROCESSING_LIST_TYPE) -> None:
         """
+        Communication between lichess-bot and the game chats.
+
         :param game: The game that the bot will send messages to.
         :param engine: The engine playing the game.
         :param xhr: A class that is used for communication with lichess.
@@ -31,6 +35,7 @@ class Conversation:
     def react(self, line: ChatLine, game: model.Game) -> None:
         """
         Reacts to the messages sent.
+
         :param line: Information about the message.
         :param game: The game that the command came from.
         """
@@ -41,6 +46,7 @@ class Conversation:
     def command(self, line: ChatLine, game: model.Game, cmd: str) -> None:
         """
         Reacts to the specific commands in the chat.
+
         :param line: Information about the message.
         :param game: The game that the command came from.
         :param cmd: The command to react to.
@@ -71,6 +77,7 @@ class Conversation:
     def send_reply(self, line: ChatLine, reply: str) -> None:
         """
         Sends the reply to the chat.
+
         :param line: Information about the original message that we reply to.
         :param reply: The reply to send.
         """
@@ -78,16 +85,19 @@ class Conversation:
         self.xhr.chat(self.game.id, line.room, reply)
 
     def send_message(self, room: str, message: str) -> None:
+        """Send the message to the chat."""
         if message:
             self.send_reply(ChatLine({"room": room, "username": "", "text": ""}), message)
 
 
 class ChatLine:
     """Information about the message."""
-    def __init__(self, json: Dict[str, str]) -> None:
-        self.room = json["room"]
+
+    def __init__(self, message_info: Dict[str, str]) -> None:
+        """Information about the message."""
+        self.room = message_info["room"]
         """Whether the message was sent in the chat room or in the spectator room."""
-        self.username = json["username"]
+        self.username = message_info["username"]
         """The username of the account that sent the message."""
-        self.text = json["text"]
+        self.text = message_info["text"]
         """The message sent."""

--- a/conversation.py
+++ b/conversation.py
@@ -31,11 +31,22 @@ class Conversation:
     command_prefix = "!"
 
     def react(self, line: ChatLine, game: model.Game) -> None:
+        """
+        Reacts to the messages sent.
+        :param line: Information about the message.
+        :param game: The game that the command came from.
+        """
         logger.info(f'*** {self.game.url()} [{line.room}] {line.username}: {line.text.encode("utf-8")!r}')
         if line.text[0] == self.command_prefix:
             self.command(line, game, line.text[1:].lower())
 
     def command(self, line: ChatLine, game: model.Game, cmd: str) -> None:
+        """
+        Reacts to the specific commands in the chat.
+        :param line: Information about the message.
+        :param game: The game that the command came from.
+        :param cmd: The command to react to.
+        """
         from_self = line.username == self.game.username
         if cmd == "commands" or cmd == "help":
             self.send_reply(line, "Supported commands: !wait (wait a minute for my first move), !name, !howto, !eval, !queue")
@@ -60,6 +71,11 @@ class Conversation:
                 self.send_reply(line, "No challenges queued.")
 
     def send_reply(self, line: ChatLine, reply: str) -> None:
+        """
+        Sends the reply to the chat.
+        :param line: Information about the original message that we reply to.
+        :param reply: The reply to send.
+        """
         logger.info(f'*** {self.game.url()} [{line.room}] {self.game.username}: {reply}')
         self.xhr.chat(self.game.id, line.room, reply)
 
@@ -69,7 +85,13 @@ class Conversation:
 
 
 class ChatLine:
+    """
+    Information about the message.
+    """
     def __init__(self, json: Dict[str, str]) -> None:
         self.room = json["room"]
+        """Whether the message was sent in the chat room or in the spectator room."""
         self.username = json["username"]
+        """The username of the account that sent the message."""
         self.text = json["text"]
+        """The message sent."""

--- a/conversation.py
+++ b/conversation.py
@@ -34,7 +34,7 @@ class Conversation:
 
     def react(self, line: ChatLine, game: model.Game) -> None:
         """
-        Reacts to the messages sent.
+        React to a received message.
 
         :param line: Information about the message.
         :param game: The game that the command came from.

--- a/conversation.py
+++ b/conversation.py
@@ -10,8 +10,18 @@ logger = logging.getLogger(__name__)
 
 
 class Conversation:
+    """
+    Enables the bot to communicate with its opponent and the spectators.
+    """
     def __init__(self, game: model.Game, engine: EngineWrapper, xhr: Lichess, version: str,
                  challenge_queue: MULTIPROCESSING_LIST_TYPE) -> None:
+        """
+        :param game: The game that the bot will send messages to.
+        :param engine: The engine playing the game.
+        :param xhr: A class that is used for communication with lichess.
+        :param version: The lichess-bot version.
+        :param challenge_queue: The active challenges the bot has.
+        """
         self.game = game
         self.engine = engine
         self.xhr = xhr

--- a/conversation.py
+++ b/conversation.py
@@ -10,9 +10,7 @@ logger = logging.getLogger(__name__)
 
 
 class Conversation:
-    """
-    Enables the bot to communicate with its opponent and the spectators.
-    """
+    """Enables the bot to communicate with its opponent and the spectators."""
     def __init__(self, game: model.Game, engine: EngineWrapper, xhr: Lichess, version: str,
                  challenge_queue: MULTIPROCESSING_LIST_TYPE) -> None:
         """
@@ -85,9 +83,7 @@ class Conversation:
 
 
 class ChatLine:
-    """
-    Information about the message.
-    """
+    """Information about the message."""
     def __init__(self, json: Dict[str, str]) -> None:
         self.room = json["room"]
         """Whether the message was sent in the chat room or in the spectator room."""

--- a/conversation.py
+++ b/conversation.py
@@ -76,7 +76,7 @@ class Conversation:
 
     def send_reply(self, line: ChatLine, reply: str) -> None:
         """
-        Sends the reply to the chat.
+        Send the reply to the chat.
 
         :param line: Information about the original message that we reply to.
         :param reply: The reply to send.

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -1,3 +1,4 @@
+"""Provides communication with the engine."""
 from __future__ import annotations
 import os
 import chess.engine
@@ -31,6 +32,7 @@ out_of_online_opening_book_moves: Counter[str] = Counter()
 def create_engine(engine_config: config.Configuration) -> Generator[EngineWrapper, None, None]:
     """
     Creates the engine.
+
     :param engine_config: The options for the engine.
     :return: An engine. Either UCI, XBoard, or Homemade.
     """
@@ -66,9 +68,7 @@ def create_engine(engine_config: config.Configuration) -> Generator[EngineWrappe
 
 
 def remove_managed_options(config: config.Configuration) -> OPTIONS_TYPE:
-    """
-    Removes the options managed by python-chess.
-    """
+    """Removes the options managed by python-chess."""
     def is_managed(key: str) -> bool:
         return chess.engine.Option(key, "", None, None, None, None).is_managed()
 
@@ -76,9 +76,7 @@ def remove_managed_options(config: config.Configuration) -> OPTIONS_TYPE:
 
 
 def translate_termination(game: model.Game, board: chess.Board) -> str:
-    """
-    A human-readable string with the result of the game.
-    """
+    """A human-readable string with the result of the game."""
     winner_color = game.state.get("winner", "")
     termination: Optional[str] = game.state.get("status")
 
@@ -108,11 +106,12 @@ PONDERPV_CHARACTERS = 6  # The length of ", PV: ".
 
 
 class EngineWrapper:
-    """
-    A wrapper used by all engines (UCI, XBoard, Homemade).
-    """
+    """A wrapper used by all engines (UCI, XBoard, Homemade)."""
+
     def __init__(self, options: OPTIONS_TYPE, draw_or_resign: config.Configuration) -> None:
         """
+        A wrapper used by all engines (UCI, XBoard, Homemade).
+
         :param options: The options to send to the engine.
         :param draw_or_resign: Options on whether the bot should resign or offer draws.
         """
@@ -134,6 +133,7 @@ class EngineWrapper:
                   correspondence_move_time: int,
                   engine_cfg: config.Configuration) -> None:
         """
+        Plays a move.
 
         :param board: The current position.
         :param game: The game that the bot is playing.
@@ -209,6 +209,7 @@ class EngineWrapper:
                    root_moves: MOVE) -> chess.engine.PlayResult:
         """
         Tells the engine to search for `movetime` time.
+
         :param board: The current position.
         :param movetime: The time to search for.
         :param ponder: Whether the engine can ponder.
@@ -222,6 +223,7 @@ class EngineWrapper:
                      root_moves: MOVE) -> chess.engine.PlayResult:
         """
         Tells the engine to search for the first move in the game.
+
         :param board: The current position.
         :param movetime: The time to search for.
         :param draw_offered: Whether the bot was offered a draw.
@@ -235,6 +237,7 @@ class EngineWrapper:
                            draw_offered: bool, root_moves: MOVE) -> chess.engine.PlayResult:
         """
         Gets the move to play by the engine.
+
         :param board: The current position.
         :param wtime: The time white has.
         :param btime: The time black has.
@@ -252,9 +255,7 @@ class EngineWrapper:
         return self.search(board, time_limit, ponder, draw_offered, root_moves)
 
     def add_go_commands(self, time_limit: chess.engine.Limit) -> chess.engine.Limit:
-        """
-        Adds extra commands to send to the engine. For example, to search for 1000 nodes or up to depth 10.
-        """
+        """Adds extra commands to send to the engine. For example, to search for 1000 nodes or up to depth 10."""
         movetime = self.go_commands.movetime
         if movetime is not None:
             movetime_sec = float(movetime) / 1000
@@ -265,9 +266,7 @@ class EngineWrapper:
         return time_limit
 
     def offer_draw_or_resign(self, result: chess.engine.PlayResult, board: chess.Board) -> chess.engine.PlayResult:
-        """
-        Offers draw or resigns depending on the score of the engine.
-        """
+        """Offers draw or resigns depending on the score of the engine."""
         def actual(score: chess.engine.PovScore) -> int:
             return score.relative.score(mate_score=40000)
 
@@ -301,6 +300,7 @@ class EngineWrapper:
                root_moves: MOVE) -> chess.engine.PlayResult:
         """
         Tells the engine to search.
+
         :param board: The current position.
         :param time_limit: Conditions for how long the engine can search (e.g. we have 10 seconds and search up to depth 10).
         :param ponder: Whether the engine can ponder.
@@ -325,6 +325,7 @@ class EngineWrapper:
     def comment_index(self, move_stack_index: int) -> int:
         """
         Gets the index of a move for use in `comment_for_board_index`.
+
         :param move_stack_index: The move number.
         :return: The index of the move in `self.move_commentary`.
         """
@@ -336,6 +337,7 @@ class EngineWrapper:
     def comment_for_board_index(self, index: int) -> MOVE_INFO_TYPE:
         """
         Gets the engine comments for a specific move.
+
         :param index: The move number.
         :return: The move comments.
         """
@@ -352,6 +354,7 @@ class EngineWrapper:
     def add_comment(self, move: chess.engine.PlayResult, board: chess.Board) -> None:
         """
         Stores the move's comments.
+
         :param move: The move. Contains the comments in `move.info`.
         :param board: The current position.
         """
@@ -399,6 +402,7 @@ class EngineWrapper:
     def get_stats(self, for_chat: bool = False) -> List[str]:
         """
         Gets the stats returned by the engine.
+
         :param for_chat: Whether the stats will be sent to the game chat, which has a 140 character limit.
         """
         can_index = self.move_commentary and self.move_commentary[-1]
@@ -441,6 +445,7 @@ class EngineWrapper:
         return [f"{to_readable_key(stat)}: {to_readable_value(stat, info)}" for stat in stats if stat in info]
 
     def get_opponent_info(self, game: model.Game) -> None:
+        """Gets the opponent's information and sends it to the engine. Depends on the protocol."""
         pass
 
     def name(self) -> str:
@@ -450,9 +455,11 @@ class EngineWrapper:
         return name
 
     def report_game_result(self, game: model.Game, board: chess.Board) -> None:
+        """Reports the game result to the engine. Depends on the protocol."""
         pass
 
     def stop(self) -> None:
+        """Stops the engine. Depends on the protocol."""
         pass
 
     def get_pid(self) -> str:
@@ -473,9 +480,13 @@ class EngineWrapper:
 
 
 class UCIEngine(EngineWrapper):
+    """The class used to communicate with UCI engines."""
+
     def __init__(self, commands: COMMANDS_TYPE, options: OPTIONS_TYPE, stderr: Optional[int],
                  draw_or_resign: config.Configuration, **popen_args: str) -> None:
         """
+        The class used to communicate with UCI engines.
+
         :param commands: The engine path and commands to send to the engine. e.g. ["engines/engine.exe", "--option1=value1"]
         :param options: The options to send to the engine.
         :param stderr: Whether we should silence the stderr.
@@ -494,8 +505,8 @@ class UCIEngine(EngineWrapper):
     def get_opponent_info(self, game: model.Game) -> None:
         """Gets the opponents info and sends it to the engine."""
         name = game.opponent.name
-        if (name and isinstance(self.engine.protocol, chess.engine.UciProtocol) and
-                "UCI_Opponent" in self.engine.protocol.config):
+        if (name and isinstance(self.engine.protocol, chess.engine.UciProtocol)
+                and "UCI_Opponent" in self.engine.protocol.config):
             rating = game.opponent.rating or "none"
             title = game.opponent.title or "none"
             player_type = "computer" if title == "BOT" else "human"
@@ -508,9 +519,13 @@ class UCIEngine(EngineWrapper):
 
 
 class XBoardEngine(EngineWrapper):
+    """The class used to communicate with XBoard engines."""
+
     def __init__(self, commands: COMMANDS_TYPE, options: OPTIONS_TYPE, stderr: Optional[int],
                  draw_or_resign: config.Configuration, **popen_args: str) -> None:
         """
+        The class used to communicate with XBoard engines.
+
         :param commands: The engine path and commands to send to the engine. e.g. ["engines/engine.exe", "--option1=value1"]
         :param options: The options to send to the engine.
         :param stderr: Whether we should silence the stderr.
@@ -551,8 +566,8 @@ class XBoardEngine(EngineWrapper):
 
     def get_opponent_info(self, game: model.Game) -> None:
         """Gets the opponents info and sends it to the engine."""
-        if (game.opponent.name and isinstance(self.engine.protocol, chess.engine.XBoardProtocol) and
-                self.engine.protocol.features.get("name", True)):
+        if (game.opponent.name and isinstance(self.engine.protocol, chess.engine.XBoardProtocol)
+                and self.engine.protocol.features.get("name", True)):
             title = f"{game.opponent.title} " if game.opponent.title else ""
             self.engine.protocol.send_line(f"name {title}{game.opponent.name}")
         if game.me.rating and game.opponent.rating:
@@ -563,7 +578,7 @@ class XBoardEngine(EngineWrapper):
 
 class MinimalEngine(EngineWrapper):
     """
-    Subclass this to prevent a few random errors
+    Subclass this to prevent a few random errors.
 
     Even though MinimalEngine extends EngineWrapper,
     you don't have to actually wrap an engine.
@@ -572,9 +587,12 @@ class MinimalEngine(EngineWrapper):
     however you can also change other methods like
     `notify`, `first_search`, `get_time_control`, etc.
     """
+
     def __init__(self, commands: COMMANDS_TYPE, options: OPTIONS_TYPE, stderr: Optional[int],
                  draw_or_resign: Configuration, name: Optional[str] = None, **popen_args: str) -> None:
         """
+        An engine that all homemade engines inherit.
+
         :param options: The options to send to the engine.
         :param draw_or_resign: Options on whether the bot should resign or offer draws.
         """
@@ -591,7 +609,7 @@ class MinimalEngine(EngineWrapper):
     def search(self, board: chess.Board, time_limit: chess.engine.Limit, ponder: bool, draw_offered: bool,
                root_moves: MOVE) -> chess.engine.PlayResult:
         """
-        The method to be implemented in your homemade engine
+        The method to be implemented in your homemade engine.
 
         NOTE: This method must return an instance of "chess.engine.PlayResult"
         """
@@ -600,6 +618,7 @@ class MinimalEngine(EngineWrapper):
     def notify(self, method_name: str, *args: Any, **kwargs: Any) -> None:
         """
         The EngineWrapper class sometimes calls methods on "self.engine".
+
         "self.engine" is a filler property that notifies <self>
         whenever an attribute is called.
 
@@ -619,7 +638,9 @@ class FillerEngine:
     This is only used to provide the property "self.engine"
     in "MinimalEngine" which extends "EngineWrapper"
     """
+
     def __init__(self, main_engine: MinimalEngine, name: str = "") -> None:
+        """:param name: The name to send to the chat."""
         self.id: Dict[str, str] = {
             "name": name
         }
@@ -627,6 +648,7 @@ class FillerEngine:
         self.main_engine = main_engine
 
     def __getattr__(self, method_name: str) -> Any:
+        """Provides the property `self.engine`."""
         main_engine = self.main_engine
 
         def method(*args: Any, **kwargs: Any) -> Any:
@@ -640,6 +662,7 @@ class FillerEngine:
 def getHomemadeEngine(name: str) -> Type[MinimalEngine]:
     """
     Get the homemade engine with name `name`. e.g. If `name` is `RandomMove` then we will return `strategies.RandomMove`.
+
     :param name: The name of the homemade engine.
     :return: The engine with this name.
     """
@@ -652,6 +675,7 @@ def choose_move_time(engine: EngineWrapper, board: chess.Board, game: model.Game
                      move_overhead: int, ponder: bool, draw_offered: bool, root_moves: MOVE) -> chess.engine.PlayResult:
     """
     Tells the engine to search in correspondence games.
+
     :param engine: The engine.
     :param board: The current positions.
     :param game: The game that the bot is playing.
@@ -676,6 +700,7 @@ def choose_first_move(engine: EngineWrapper, board: chess.Board, game: model.Gam
                       draw_offered: bool, root_moves: MOVE) -> chess.engine.PlayResult:
     """
     Tells the engine to search for the first move in the game.
+
     :param engine: The engine.
     :param board: The current positions.
     :param game: The game that the bot is playing.
@@ -693,6 +718,7 @@ def choose_move(engine: EngineWrapper, board: chess.Board, game: model.Game, pon
                 start_time: int, move_overhead: int, root_moves: MOVE) -> chess.engine.PlayResult:
     """
     Gets the move to play by the engine.
+
     :param engine: The engine.
     :param board: The current positions.
     :param game: The game that the bot is playing.
@@ -762,6 +788,7 @@ def get_online_move(li: lichess.Lichess, board: chess.Board, game: model.Game, o
                     draw_or_resign_cfg: config.Configuration) -> Union[chess.engine.PlayResult, List[chess.Move]]:
     """
     Get a move from an online source.
+
     If `move_quality` is `suggest`, then it will return a list of moves for the engine to choose from.
     """
     online_egtb_cfg = online_moves_cfg.online_egtb
@@ -908,6 +935,7 @@ def get_online_egtb_move(li: lichess.Lichess, board: chess.Board, game: model.Ga
                          online_egtb_cfg: config.Configuration) -> Tuple[Union[str, List[str], None], int]:
     """
     Gets a move from an online egtb (either by lichess or chessdb).
+
     If `move_quality` is `suggest`, then it will return a list of moves for the engine to choose from.
     """
     use_online_egtb = online_egtb_cfg.enabled
@@ -944,6 +972,7 @@ def get_egtb_move(board: chess.Board, game: model.Game, lichess_bot_tbs: config.
                   draw_or_resign_cfg: config.Configuration) -> Union[chess.engine.PlayResult, List[chess.Move]]:
     """
     Gets a move from a local egtb.
+
     If `move_quality` is `suggest`, then it will return a list of moves for the engine to choose from.
     """
     best_move, wdl = get_syzygy(board, game, lichess_bot_tbs.syzygy)
@@ -969,6 +998,7 @@ def get_lichess_egtb_move(li: lichess.Lichess, game: model.Game, board: chess.Bo
                           variant: str) -> Tuple[Union[str, List[str], None], int]:
     """
     Gets a move from lichess's egtb.
+
     If `move_quality` is `suggest`, then it will return a list of moves for the engine to choose from.
     """
     name_to_wld = {"loss": -2,
@@ -1035,6 +1065,7 @@ def get_chessdb_egtb_move(li: lichess.Lichess, game: model.Game, board: chess.Bo
                           quality: str) -> Tuple[Union[str, List[str], None], int]:
     """
     Gets a move from chessdb's egtb.
+
     If `move_quality` is `suggest`, then it will return a list of moves for the engine to choose from.
     """
     def score_to_wdl(score: int) -> int:
@@ -1098,6 +1129,7 @@ def get_syzygy(board: chess.Board, game: model.Game,
                syzygy_cfg: config.Configuration) -> Tuple[Union[chess.Move, List[chess.Move], None], int]:
     """
     Gets a move from local syzygy egtbs.
+
     If `move_quality` is `suggest`, then it will return a list of moves for the engine to choose from.
     """
     if (not syzygy_cfg.enabled
@@ -1163,6 +1195,7 @@ def get_gaviota(board: chess.Board, game: model.Game,
                 gaviota_cfg: config.Configuration) -> Tuple[Union[chess.Move, List[chess.Move], None], int]:
     """
     Gets a move from local gaviota egtbs.
+
     If `move_quality` is `suggest`, then it will return a list of moves for the engine to choose from.
     """
     if (not gaviota_cfg.enabled
@@ -1235,6 +1268,7 @@ def good_enough_gaviota_moves(good_moves: List[Tuple[chess.Move, int]], best_dtm
                               min_dtm_to_consider_as_wdl_1: int) -> List[Tuple[chess.Move, int]]:
     """
     Gets the moves that are good enough to consider.
+
     :param good_moves: All the moves to choose from.
     :param best_dtm: The best DTM score of a move.
     :param min_dtm_to_consider_as_wdl_1: The minimum DTM score to consider as WDL=1.
@@ -1263,13 +1297,11 @@ def good_enough_gaviota_moves(good_moves: List[Tuple[chess.Move, int]], best_dtm
 
 
 def piecewise_function(range_definitions: List[Tuple[int, int]], last_value: int, position: int) -> int:
-    """ Returns a value according to a position argument
+    """
+    Returns a value according to a position argument.
+
     This function is meant to replace if-elif-else blocks that turn ranges into discrete values. For
-    example,
-
-    piecewise_function([(-20001, 2), (-1, -1), (0, 0), (20000, 1)], 2, score)
-
-    is equivalent to:
+    example, `piecewise_function([(-20001, 2), (-1, -1), (0, 0), (20000, 1)], 2, score)` is equivalent to:
 
     if score < -20000:
         return -2
@@ -1281,7 +1313,6 @@ def piecewise_function(range_definitions: List[Tuple[int, int]], last_value: int
         return 1
     else:
         return 2
-
     Note: We use -20001 and not -20000, because we use <= and not <.
 
     Arguments:
@@ -1297,6 +1328,7 @@ def piecewise_function(range_definitions: List[Tuple[int, int]], last_value: int
         return this value.
     position:
         The value that will be compared to the first element of the range_definitions tuples.
+
     """
     for border, value in range_definitions:
         if position <= border:

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -336,6 +336,8 @@ class EngineWrapper:
     def comment_for_board_index(self, index: int) -> MOVE_INFO_TYPE:
         """
         Gets the engine comments for a specific move.
+        :param index: The move number.
+        :return: The move comments.
         """
         no_info: MOVE_INFO_TYPE = {}
         comment_index = self.comment_index(index)
@@ -348,6 +350,11 @@ class EngineWrapper:
             return no_info
 
     def add_comment(self, move: chess.engine.PlayResult, board: chess.Board) -> None:
+        """
+        Stores the move's comments.
+        :param move: The move. Contains the comments in `move.info`.
+        :param board: The current position.
+        """
         if self.comment_start_index < 0:
             self.comment_start_index = len(board.move_stack)
         move_info: MOVE_INFO_TYPE = dict(move.info.copy()) if move.info else {}
@@ -360,16 +367,12 @@ class EngineWrapper:
         self.move_commentary.append(move_info)
 
     def print_stats(self) -> None:
-        """
-        Prints the engine stats.
-        """
+        """Prints the engine stats."""
         for line in self.get_stats():
             logger.info(line)
 
     def readable_score(self, relative_score: chess.engine.PovScore) -> str:
-        """
-        Converts the score to a more human-readable format.
-        """
+        """Converts the score to a more human-readable format."""
         score = relative_score.relative
         cp_score = score.score()
         if cp_score is None:
@@ -379,16 +382,12 @@ class EngineWrapper:
         return str_score
 
     def readable_wdl(self, wdl: chess.engine.PovWdl) -> str:
-        """
-        Converts the WDL score to a percentage, so it is more human-readable.
-        """
+        """Converts the WDL score to a percentage, so it is more human-readable."""
         wdl_percentage = round(wdl.relative.expectation() * 100, 1)
         return f"{wdl_percentage}%"
 
     def readable_number(self, number: int) -> str:
-        """
-        Converts number to a more human-readable format. e.g. 123456789 -> 123M.
-        """
+        """Converts number to a more human-readable format. e.g. 123456789 -> 123M."""
         if number >= 1e9:
             return f"{round(number / 1e9, 1)}B"
         elif number >= 1e6:

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -535,7 +535,7 @@ class XBoardEngine(EngineWrapper):
 
     def report_game_result(self, game: model.Game, board: chess.Board) -> None:
         """Send the game result to the engine."""
-        # Send final moves, if any, to engine
+        # Send final moves, if any, to engine.
         if isinstance(self.engine.protocol, chess.engine.XBoardProtocol):
             self.engine.protocol._new(board, None, {})
 
@@ -683,7 +683,7 @@ def choose_first_move(engine: EngineWrapper, board: chess.Board, game: model.Gam
     :param root_moves: If it is a list, the engine will only play a move that is in `root_moves`.
     :return: The move to play.
     """
-    # need to hardcode first movetime (10000 ms) since Lichess has 30 sec limit.
+    # Need to hardcode first movetime (10000 ms) since Lichess has 30 sec limit.
     search_time = 10000
     logger.info(f"Searching for time {search_time} for game {game.id}")
     return engine.first_search(board, search_time, draw_offered, root_moves)
@@ -748,7 +748,7 @@ def get_book_move(board: chess.Board, game: model.Game,
                 elif selection == "best_move":
                     move = reader.find(board, minimum_weight=min_weight).move
             except IndexError:
-                # python-chess raises "IndexError" if no entries found
+                # python-chess raises "IndexError" if no entries found.
                 move = None
 
         if move is not None:

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -505,7 +505,7 @@ class UCIEngine(EngineWrapper):
         self.engine.protocol.send_line("stop")
 
     def get_opponent_info(self, game: model.Game) -> None:
-        """Get the opponent's info and sends it to the engine."""
+        """Get the opponent's info and send it to the engine."""
         name = game.opponent.name
         if (name and isinstance(self.engine.protocol, chess.engine.UciProtocol)
                 and "UCI_Opponent" in self.engine.protocol.config):
@@ -567,7 +567,7 @@ class XBoardEngine(EngineWrapper):
         self.engine.protocol.send_line("?")
 
     def get_opponent_info(self, game: model.Game) -> None:
-        """Get the opponent's info and sends it to the engine."""
+        """Get the opponent's info and send it to the engine."""
         if (game.opponent.name and isinstance(self.engine.protocol, chess.engine.XBoardProtocol)
                 and self.engine.protocol.features.get("name", True)):
             title = f"{game.opponent.title} " if game.opponent.title else ""

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -33,6 +33,8 @@ def create_engine(engine_config: config.Configuration) -> Generator[EngineWrappe
     """
     Create the engine.
 
+    Use in a with-block to automatically close the engine when exiting the game.
+
     :param engine_config: The options for the engine.
     :return: An engine. Either UCI, XBoard, or Homemade.
     """
@@ -503,7 +505,7 @@ class UCIEngine(EngineWrapper):
         self.engine.protocol.send_line("stop")
 
     def get_opponent_info(self, game: model.Game) -> None:
-        """Get the opponents info and sends it to the engine."""
+        """Get the opponent's info and sends it to the engine."""
         name = game.opponent.name
         if (name and isinstance(self.engine.protocol, chess.engine.UciProtocol)
                 and "UCI_Opponent" in self.engine.protocol.config):
@@ -565,7 +567,7 @@ class XBoardEngine(EngineWrapper):
         self.engine.protocol.send_line("?")
 
     def get_opponent_info(self, game: model.Game) -> None:
-        """Get the opponents info and sends it to the engine."""
+        """Get the opponent's info and sends it to the engine."""
         if (game.opponent.name and isinstance(self.engine.protocol, chess.engine.XBoardProtocol)
                 and self.engine.protocol.features.get("name", True)):
             title = f"{game.opponent.title} " if game.opponent.title else ""

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -31,7 +31,7 @@ out_of_online_opening_book_moves: Counter[str] = Counter()
 @contextmanager
 def create_engine(engine_config: config.Configuration) -> Generator[EngineWrapper, None, None]:
     """
-    Creates the engine.
+    Create the engine.
 
     :param engine_config: The options for the engine.
     :return: An engine. Either UCI, XBoard, or Homemade.
@@ -68,7 +68,7 @@ def create_engine(engine_config: config.Configuration) -> Generator[EngineWrappe
 
 
 def remove_managed_options(config: config.Configuration) -> OPTIONS_TYPE:
-    """Removes the options managed by python-chess."""
+    """Remove the options managed by python-chess."""
     def is_managed(key: str) -> bool:
         return chess.engine.Option(key, "", None, None, None, None).is_managed()
 
@@ -76,7 +76,7 @@ def remove_managed_options(config: config.Configuration) -> OPTIONS_TYPE:
 
 
 def translate_termination(game: model.Game, board: chess.Board) -> str:
-    """A human-readable string with the result of the game."""
+    """Get a human-readable string with the result of the game."""
     winner_color = game.state.get("winner", "")
     termination: Optional[str] = game.state.get("status")
 
@@ -110,7 +110,7 @@ class EngineWrapper:
 
     def __init__(self, options: OPTIONS_TYPE, draw_or_resign: config.Configuration) -> None:
         """
-        A wrapper used by all engines (UCI, XBoard, Homemade).
+        Initialize the values of the wrapper used by all engines (UCI, XBoard, Homemade).
 
         :param options: The options to send to the engine.
         :param draw_or_resign: Options on whether the bot should resign or offer draws.
@@ -133,7 +133,7 @@ class EngineWrapper:
                   correspondence_move_time: int,
                   engine_cfg: config.Configuration) -> None:
         """
-        Plays a move.
+        Play a move.
 
         :param board: The current position.
         :param game: The game that the bot is playing.
@@ -208,7 +208,7 @@ class EngineWrapper:
     def search_for(self, board: chess.Board, movetime: int, ponder: bool, draw_offered: bool,
                    root_moves: MOVE) -> chess.engine.PlayResult:
         """
-        Tells the engine to search for `movetime` time.
+        Tell the engine to search for `movetime` time.
 
         :param board: The current position.
         :param movetime: The time to search for.
@@ -222,7 +222,7 @@ class EngineWrapper:
     def first_search(self, board: chess.Board, movetime: int, draw_offered: bool,
                      root_moves: MOVE) -> chess.engine.PlayResult:
         """
-        Tells the engine to search for the first move in the game.
+        Tell the engine to search for the first move in the game.
 
         :param board: The current position.
         :param movetime: The time to search for.
@@ -236,7 +236,7 @@ class EngineWrapper:
     def search_with_ponder(self, board: chess.Board, wtime: int, btime: int, winc: int, binc: int, ponder: bool,
                            draw_offered: bool, root_moves: MOVE) -> chess.engine.PlayResult:
         """
-        Gets the move to play by the engine.
+        Get the move to play by the engine.
 
         :param board: The current position.
         :param wtime: The time white has.
@@ -255,7 +255,7 @@ class EngineWrapper:
         return self.search(board, time_limit, ponder, draw_offered, root_moves)
 
     def add_go_commands(self, time_limit: chess.engine.Limit) -> chess.engine.Limit:
-        """Adds extra commands to send to the engine. For example, to search for 1000 nodes or up to depth 10."""
+        """Add extra commands to send to the engine. For example, to search for 1000 nodes or up to depth 10."""
         movetime = self.go_commands.movetime
         if movetime is not None:
             movetime_sec = float(movetime) / 1000
@@ -266,7 +266,7 @@ class EngineWrapper:
         return time_limit
 
     def offer_draw_or_resign(self, result: chess.engine.PlayResult, board: chess.Board) -> chess.engine.PlayResult:
-        """Offers draw or resigns depending on the score of the engine."""
+        """Offer draw or resign depending on the score of the engine."""
         def actual(score: chess.engine.PovScore) -> int:
             return score.relative.score(mate_score=40000)
 
@@ -299,7 +299,7 @@ class EngineWrapper:
     def search(self, board: chess.Board, time_limit: chess.engine.Limit, ponder: bool, draw_offered: bool,
                root_moves: MOVE) -> chess.engine.PlayResult:
         """
-        Tells the engine to search.
+        Tell the engine to search.
 
         :param board: The current position.
         :param time_limit: Conditions for how long the engine can search (e.g. we have 10 seconds and search up to depth 10).
@@ -324,7 +324,7 @@ class EngineWrapper:
 
     def comment_index(self, move_stack_index: int) -> int:
         """
-        Gets the index of a move for use in `comment_for_board_index`.
+        Get the index of a move for use in `comment_for_board_index`.
 
         :param move_stack_index: The move number.
         :return: The index of the move in `self.move_commentary`.
@@ -336,7 +336,7 @@ class EngineWrapper:
 
     def comment_for_board_index(self, index: int) -> MOVE_INFO_TYPE:
         """
-        Gets the engine comments for a specific move.
+        Get the engine comments for a specific move.
 
         :param index: The move number.
         :return: The move comments.
@@ -353,7 +353,7 @@ class EngineWrapper:
 
     def add_comment(self, move: chess.engine.PlayResult, board: chess.Board) -> None:
         """
-        Stores the move's comments.
+        Store the move's comments.
 
         :param move: The move. Contains the comments in `move.info`.
         :param board: The current position.
@@ -370,12 +370,12 @@ class EngineWrapper:
         self.move_commentary.append(move_info)
 
     def print_stats(self) -> None:
-        """Prints the engine stats."""
+        """Print the engine stats."""
         for line in self.get_stats():
             logger.info(line)
 
     def readable_score(self, relative_score: chess.engine.PovScore) -> str:
-        """Converts the score to a more human-readable format."""
+        """Convert the score to a more human-readable format."""
         score = relative_score.relative
         cp_score = score.score()
         if cp_score is None:
@@ -385,12 +385,12 @@ class EngineWrapper:
         return str_score
 
     def readable_wdl(self, wdl: chess.engine.PovWdl) -> str:
-        """Converts the WDL score to a percentage, so it is more human-readable."""
+        """Convert the WDL score to a percentage, so it is more human-readable."""
         wdl_percentage = round(wdl.relative.expectation() * 100, 1)
         return f"{wdl_percentage}%"
 
     def readable_number(self, number: int) -> str:
-        """Converts number to a more human-readable format. e.g. 123456789 -> 123M."""
+        """Convert number to a more human-readable format. e.g. 123456789 -> 123M."""
         if number >= 1e9:
             return f"{round(number / 1e9, 1)}B"
         elif number >= 1e6:
@@ -401,7 +401,7 @@ class EngineWrapper:
 
     def get_stats(self, for_chat: bool = False) -> List[str]:
         """
-        Gets the stats returned by the engine.
+        Get the stats returned by the engine.
 
         :param for_chat: Whether the stats will be sent to the game chat, which has a 140 character limit.
         """
@@ -445,36 +445,36 @@ class EngineWrapper:
         return [f"{to_readable_key(stat)}: {to_readable_value(stat, info)}" for stat in stats if stat in info]
 
     def get_opponent_info(self, game: model.Game) -> None:
-        """Gets the opponent's information and sends it to the engine. Depends on the protocol."""
+        """Get the opponent's information and sends it to the engine. Depends on the protocol."""
         pass
 
     def name(self) -> str:
-        """Gets the name of the engine."""
+        """Get the name of the engine."""
         engine_info: Dict[str, str] = dict(self.engine.id)
         name: str = engine_info["name"]
         return name
 
     def report_game_result(self, game: model.Game, board: chess.Board) -> None:
-        """Reports the game result to the engine. Depends on the protocol."""
+        """Report the game result to the engine. Depends on the protocol."""
         pass
 
     def stop(self) -> None:
-        """Stops the engine. Depends on the protocol."""
+        """Stop the engine. Depends on the protocol."""
         pass
 
     def get_pid(self) -> str:
-        """Gets the pid of the engine."""
+        """Get the pid of the engine."""
         pid = "?"
         if self.engine.transport is not None:
             pid = str(self.engine.transport.get_pid())
         return pid
 
     def ping(self) -> None:
-        """Pings the engine."""
+        """Ping the engine."""
         self.engine.ping()
 
     def quit(self) -> None:
-        """Closes the engine."""
+        """Close the engine."""
         self.engine.quit()
         self.engine.close()
 
@@ -485,7 +485,7 @@ class UCIEngine(EngineWrapper):
     def __init__(self, commands: COMMANDS_TYPE, options: OPTIONS_TYPE, stderr: Optional[int],
                  draw_or_resign: config.Configuration, **popen_args: str) -> None:
         """
-        The class used to communicate with UCI engines.
+        Communicate with UCI engines.
 
         :param commands: The engine path and commands to send to the engine. e.g. ["engines/engine.exe", "--option1=value1"]
         :param options: The options to send to the engine.
@@ -499,11 +499,11 @@ class UCIEngine(EngineWrapper):
         self.engine.configure(options)
 
     def stop(self) -> None:
-        """Tells the engine to stop searching."""
+        """Tell the engine to stop searching."""
         self.engine.protocol.send_line("stop")
 
     def get_opponent_info(self, game: model.Game) -> None:
-        """Gets the opponents info and sends it to the engine."""
+        """Get the opponents info and sends it to the engine."""
         name = game.opponent.name
         if (name and isinstance(self.engine.protocol, chess.engine.UciProtocol)
                 and "UCI_Opponent" in self.engine.protocol.config):
@@ -524,7 +524,7 @@ class XBoardEngine(EngineWrapper):
     def __init__(self, commands: COMMANDS_TYPE, options: OPTIONS_TYPE, stderr: Optional[int],
                  draw_or_resign: config.Configuration, **popen_args: str) -> None:
         """
-        The class used to communicate with XBoard engines.
+        Communicate with XBoard engines.
 
         :param commands: The engine path and commands to send to the engine. e.g. ["engines/engine.exe", "--option1=value1"]
         :param options: The options to send to the engine.
@@ -561,11 +561,11 @@ class XBoardEngine(EngineWrapper):
         self.engine.protocol.send_line(f"result {game.result()}{endgame_message}")
 
     def stop(self) -> None:
-        """Tells the engine to stop searching."""
+        """Tell the engine to stop searching."""
         self.engine.protocol.send_line("?")
 
     def get_opponent_info(self, game: model.Game) -> None:
-        """Gets the opponents info and sends it to the engine."""
+        """Get the opponents info and sends it to the engine."""
         if (game.opponent.name and isinstance(self.engine.protocol, chess.engine.XBoardProtocol)
                 and self.engine.protocol.features.get("name", True)):
             title = f"{game.opponent.title} " if game.opponent.title else ""
@@ -585,13 +585,13 @@ class MinimalEngine(EngineWrapper):
 
     At minimum, just implement `search`,
     however you can also change other methods like
-    `notify`, `first_search`, `get_time_control`, etc.
+    `notify`, etc.
     """
 
     def __init__(self, commands: COMMANDS_TYPE, options: OPTIONS_TYPE, stderr: Optional[int],
                  draw_or_resign: Configuration, name: Optional[str] = None, **popen_args: str) -> None:
         """
-        An engine that all homemade engines inherit.
+        Initialize the values of the engine that all homemade engines inherit.
 
         :param options: The options to send to the engine.
         :param draw_or_resign: Options on whether the bot should resign or offer draws.
@@ -609,14 +609,17 @@ class MinimalEngine(EngineWrapper):
     def search(self, board: chess.Board, time_limit: chess.engine.Limit, ponder: bool, draw_offered: bool,
                root_moves: MOVE) -> chess.engine.PlayResult:
         """
-        The method to be implemented in your homemade engine.
+        Choose a move.
 
+        The method to be implemented in your homemade engine.
         NOTE: This method must return an instance of "chess.engine.PlayResult"
         """
         raise NotImplementedError("The search method is not implemented")
 
     def notify(self, method_name: str, *args: Any, **kwargs: Any) -> None:
         """
+        Enable the use of `self.engine.option1`.
+
         The EngineWrapper class sometimes calls methods on "self.engine".
 
         "self.engine" is a filler property that notifies <self>
@@ -648,7 +651,7 @@ class FillerEngine:
         self.main_engine = main_engine
 
     def __getattr__(self, method_name: str) -> Any:
-        """Provides the property `self.engine`."""
+        """Provide the property `self.engine`."""
         main_engine = self.main_engine
 
         def method(*args: Any, **kwargs: Any) -> Any:
@@ -674,7 +677,7 @@ def getHomemadeEngine(name: str) -> Type[MinimalEngine]:
 def choose_move_time(engine: EngineWrapper, board: chess.Board, game: model.Game, search_time: int, start_time: int,
                      move_overhead: int, ponder: bool, draw_offered: bool, root_moves: MOVE) -> chess.engine.PlayResult:
     """
-    Tells the engine to search in correspondence games.
+    Tell the engine to search in correspondence games.
 
     :param engine: The engine.
     :param board: The current positions.
@@ -699,7 +702,7 @@ def choose_move_time(engine: EngineWrapper, board: chess.Board, game: model.Game
 def choose_first_move(engine: EngineWrapper, board: chess.Board, game: model.Game,
                       draw_offered: bool, root_moves: MOVE) -> chess.engine.PlayResult:
     """
-    Tells the engine to search for the first move in the game.
+    Tell the engine to search for the first move in the game.
 
     :param engine: The engine.
     :param board: The current positions.
@@ -717,7 +720,7 @@ def choose_first_move(engine: EngineWrapper, board: chess.Board, game: model.Gam
 def choose_move(engine: EngineWrapper, board: chess.Board, game: model.Game, ponder: bool, draw_offered: bool,
                 start_time: int, move_overhead: int, root_moves: MOVE) -> chess.engine.PlayResult:
     """
-    Gets the move to play by the engine.
+    Get the move to play by the engine.
 
     :param engine: The engine.
     :param board: The current positions.
@@ -745,7 +748,7 @@ def choose_move(engine: EngineWrapper, board: chess.Board, game: model.Game, pon
 
 
 def check_for_draw_offer(game: model.Game) -> bool:
-    """Checks if the bot was offered a draw."""
+    """Check if the bot was offered a draw."""
     return game.state.get(f"{game.opponent_color[0]}draw", False)
 
 
@@ -835,7 +838,7 @@ def get_online_move(li: lichess.Lichess, board: chess.Board, game: model.Game, o
 
 def get_chessdb_move(li: lichess.Lichess, board: chess.Board, game: model.Game,
                      chessdb_cfg: config.Configuration) -> Tuple[Optional[str], Optional[chess.engine.InfoDict]]:
-    """Gets a move from chessdb.cn's opening book."""
+    """Get a move from chessdb.cn's opening book."""
     wb = "w" if board.turn == chess.WHITE else "b"
     use_chessdb = chessdb_cfg.enabled
     time_left = game.state[f"{wb}time"]
@@ -880,7 +883,7 @@ def get_chessdb_move(li: lichess.Lichess, board: chess.Board, game: model.Game,
 
 def get_lichess_cloud_move(li: lichess.Lichess, board: chess.Board, game: model.Game,
                            lichess_cloud_cfg: config.Configuration) -> Tuple[Optional[str], Optional[chess.engine.InfoDict]]:
-    """Gets the move from the lichess's cloud analysis."""
+    """Get the move from the lichess's cloud analysis."""
     wb = "w" if board.turn == chess.WHITE else "b"
     time_left = game.state[f"{wb}time"]
     min_time = lichess_cloud_cfg.min_time * 1000
@@ -934,7 +937,7 @@ def get_lichess_cloud_move(li: lichess.Lichess, board: chess.Board, game: model.
 def get_online_egtb_move(li: lichess.Lichess, board: chess.Board, game: model.Game,
                          online_egtb_cfg: config.Configuration) -> Tuple[Union[str, List[str], None], int]:
     """
-    Gets a move from an online egtb (either by lichess or chessdb).
+    Get a move from an online egtb (either by lichess or chessdb).
 
     If `move_quality` is `suggest`, then it will return a list of moves for the engine to choose from.
     """
@@ -971,7 +974,7 @@ def get_online_egtb_move(li: lichess.Lichess, board: chess.Board, game: model.Ga
 def get_egtb_move(board: chess.Board, game: model.Game, lichess_bot_tbs: config.Configuration,
                   draw_or_resign_cfg: config.Configuration) -> Union[chess.engine.PlayResult, List[chess.Move]]:
     """
-    Gets a move from a local egtb.
+    Get a move from a local egtb.
 
     If `move_quality` is `suggest`, then it will return a list of moves for the engine to choose from.
     """
@@ -997,7 +1000,7 @@ def get_egtb_move(board: chess.Board, game: model.Game, lichess_bot_tbs: config.
 def get_lichess_egtb_move(li: lichess.Lichess, game: model.Game, board: chess.Board, quality: str,
                           variant: str) -> Tuple[Union[str, List[str], None], int]:
     """
-    Gets a move from lichess's egtb.
+    Get a move from lichess's egtb.
 
     If `move_quality` is `suggest`, then it will return a list of moves for the engine to choose from.
     """
@@ -1064,7 +1067,7 @@ def get_lichess_egtb_move(li: lichess.Lichess, game: model.Game, board: chess.Bo
 def get_chessdb_egtb_move(li: lichess.Lichess, game: model.Game, board: chess.Board,
                           quality: str) -> Tuple[Union[str, List[str], None], int]:
     """
-    Gets a move from chessdb's egtb.
+    Get a move from chessdb's egtb.
 
     If `move_quality` is `suggest`, then it will return a list of moves for the engine to choose from.
     """
@@ -1128,7 +1131,7 @@ def get_chessdb_egtb_move(li: lichess.Lichess, game: model.Game, board: chess.Bo
 def get_syzygy(board: chess.Board, game: model.Game,
                syzygy_cfg: config.Configuration) -> Tuple[Union[chess.Move, List[chess.Move], None], int]:
     """
-    Gets a move from local syzygy egtbs.
+    Get a move from local syzygy egtbs.
 
     If `move_quality` is `suggest`, then it will return a list of moves for the engine to choose from.
     """
@@ -1181,20 +1184,20 @@ def get_syzygy(board: chess.Board, game: model.Game,
 
 
 def dtz_scorer(tablebase: chess.syzygy.Tablebase, board: chess.Board) -> int:
-    """Scores a position based on a syzygy DTZ egtb."""
+    """Score a position based on a syzygy DTZ egtb."""
     dtz = -tablebase.probe_dtz(board)
     return dtz + (1 if dtz > 0 else -1) * board.halfmove_clock * (0 if dtz == 0 else 1)
 
 
 def dtz_to_wdl(dtz: int) -> int:
-    """Converts DTZ scores to syzygy WDL scores."""
+    """Convert DTZ scores to syzygy WDL scores."""
     return piecewise_function([(-100, -1), (-1, -2), (0, 0), (99, 2)], 1, dtz)
 
 
 def get_gaviota(board: chess.Board, game: model.Game,
                 gaviota_cfg: config.Configuration) -> Tuple[Union[chess.Move, List[chess.Move], None], int]:
     """
-    Gets a move from local gaviota egtbs.
+    Get a move from local gaviota egtbs.
 
     If `move_quality` is `suggest`, then it will return a list of moves for the engine to choose from.
     """
@@ -1247,18 +1250,18 @@ def get_gaviota(board: chess.Board, game: model.Game,
 
 
 def dtm_scorer(tablebase: Union[chess.gaviota.NativeTablebase, chess.gaviota.PythonTablebase], board: chess.Board) -> int:
-    """Scores a position based on a gaviota DTM egtb."""
+    """Score a position based on a gaviota DTM egtb."""
     dtm = -tablebase.probe_dtm(board)
     return dtm + (1 if dtm > 0 else -1) * board.halfmove_clock * (0 if dtm == 0 else 1)
 
 
 def dtm_to_gaviota_wdl(dtm: int) -> int:
-    """Converts DTM scores to gaviota WDL scores."""
+    """Convert DTM scores to gaviota WDL scores."""
     return piecewise_function([(-1, -1), (0, 0)], 1, dtm)
 
 
 def dtm_to_wdl(dtm: int, min_dtm_to_consider_as_wdl_1: int) -> int:
-    """Converts DTM scores to syzygy WDL scores."""
+    """Convert DTM scores to syzygy WDL scores."""
     # We use 100 and not min_dtm_to_consider_as_wdl_1, because we want to play it safe and not resign in a
     # position where dtz=-102 (only if resign_for_egtb_minus_two is enabled).
     return piecewise_function([(-100, -1), (-1, -2), (0, 0), (min_dtm_to_consider_as_wdl_1 - 1, 2)], 1, dtm)
@@ -1267,7 +1270,7 @@ def dtm_to_wdl(dtm: int, min_dtm_to_consider_as_wdl_1: int) -> int:
 def good_enough_gaviota_moves(good_moves: List[Tuple[chess.Move, int]], best_dtm: int,
                               min_dtm_to_consider_as_wdl_1: int) -> List[Tuple[chess.Move, int]]:
     """
-    Gets the moves that are good enough to consider.
+    Get the moves that are good enough to consider.
 
     :param good_moves: All the moves to choose from.
     :param best_dtm: The best DTM score of a move.
@@ -1298,7 +1301,7 @@ def good_enough_gaviota_moves(good_moves: List[Tuple[chess.Move, int]], best_dtm
 
 def piecewise_function(range_definitions: List[Tuple[int, int]], last_value: int, position: int) -> int:
     """
-    Returns a value according to a position argument.
+    Return a value according to a position argument.
 
     This function is meant to replace if-elif-else blocks that turn ranges into discrete values. For
     example, `piecewise_function([(-20001, 2), (-1, -1), (0, 0), (20000, 1)], 2, score)` is equivalent to:
@@ -1338,7 +1341,7 @@ def piecewise_function(range_definitions: List[Tuple[int, int]], last_value: int
 
 def score_syzygy_moves(board: chess.Board, scorer: Callable[[chess.syzygy.Tablebase, chess.Board], int],
                        tablebase: chess.syzygy.Tablebase) -> Dict[chess.Move, int]:
-    """Scores all the moves using syzygy egtbs."""
+    """Score all the moves using syzygy egtbs."""
     moves = {}
     for move in board.legal_moves:
         board_copy = board.copy()
@@ -1352,7 +1355,7 @@ def score_gaviota_moves(board: chess.Board,
                                           chess.Board], int],
                         tablebase: Union[chess.gaviota.NativeTablebase, chess.gaviota.PythonTablebase]
                         ) -> Dict[chess.Move, int]:
-    """Scores all the moves using gaviota egtbs."""
+    """Score all the moves using gaviota egtbs."""
     moves = {}
     for move in board.legal_moves:
         board_copy = board.copy()

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -275,7 +275,6 @@ def lichess_bot_main(li: lichess.Lichess,
                       "logging_level": logging_level}
 
     recent_bot_challenges: DefaultDict[str, List[Timer]] = defaultdict(list)
-    one_game = True
 
     with multiprocessing.pool.Pool(max_games + 1) as pool:
         while not (terminated or (one_game and one_game_completed) or restart):

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -209,7 +209,11 @@ def start(li: lichess.Lichess, user_profile: USER_PROFILE_TYPE, config: Configur
 
 
 def log_proc_count(change: str, active_games: Set[str]) -> None:
-    """Logs the number of active games and their IDs."""
+    """
+    Logs the number of active games and their IDs.
+    :param change: Either "Freed", "Used", or "Queued".
+    :param active_games: A set containing the IDs of the active games.
+    """
     symbol = "+++" if change == "Freed" else "---"
     logger.info(f"{symbol} Process {change}. Count: {len(active_games)}. IDs: {active_games or None}")
 
@@ -523,7 +527,7 @@ def play_game(li: lichess.Lichess,
     response = li.get_game_stream(game_id)
     lines = response.iter_lines()
 
-    # Initial response of stream will be the full game info. Store it
+    # Initial response of stream will be the full game info. Store it.
     initial_state = json.loads(next(lines).decode("utf-8"))
     logger.debug(f"Initial state: {initial_state}")
     abort_time = config.abort_time

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -55,7 +55,7 @@ restart = True
 
 
 def signal_handler(signal: int, frame: Any) -> None:
-    """Terminates lichess-bot."""
+    """Terminate lichess-bot."""
     global terminated
     logger.debug("Recieved SIGINT. Terminating client.")
     terminated = True
@@ -70,7 +70,7 @@ def is_final(exception: Exception) -> bool:
 
 
 def upgrade_account(li: lichess.Lichess) -> bool:
-    """Upgrades the account to a BOT account."""
+    """Upgrade the account to a BOT account."""
     if li.upgrade_to_bot_account() is None:
         return False
 
@@ -79,7 +79,7 @@ def upgrade_account(li: lichess.Lichess) -> bool:
 
 
 def watch_control_stream(control_queue: CONTROL_QUEUE_TYPE, li: lichess.Lichess) -> None:
-    """Puts the events in a queue."""
+    """Put the events in a queue."""
     while not terminated:
         try:
             response = li.get_event_stream()
@@ -98,7 +98,7 @@ def watch_control_stream(control_queue: CONTROL_QUEUE_TYPE, li: lichess.Lichess)
 
 def do_correspondence_ping(control_queue: CONTROL_QUEUE_TYPE, period: int) -> None:
     """
-    Tells the engine to check the correspondence games.
+    Tell the engine to check the correspondence games.
 
     :param period: How many seconds to wait before sending a correspondence ping.
     """
@@ -109,7 +109,7 @@ def do_correspondence_ping(control_queue: CONTROL_QUEUE_TYPE, period: int) -> No
 
 def logging_configurer(level: int, filename: Optional[str]) -> None:
     """
-    Configures the logger.
+    Configure the logger.
 
     :param level: The logging level. Either `logging.INFO` or `logging.DEBUG`.
     :param filename: The filename to write the logs to. If it is `None` then the logs aren't written to a file.
@@ -133,7 +133,7 @@ def logging_configurer(level: int, filename: Optional[str]) -> None:
 
 def logging_listener_proc(queue: LOGGING_QUEUE_TYPE, level: int, log_filename: Optional[str]) -> None:
     """
-    Handles events from the logging queue.
+    Handle events from the logging queue.
 
     This allows the logs from inside a thread to be printed.
     They are added to the queue, so they are printed outside the thread.
@@ -150,7 +150,7 @@ def logging_listener_proc(queue: LOGGING_QUEUE_TYPE, level: int, log_filename: O
 
 
 def game_logging_configurer(queue: Union[CONTROL_QUEUE_TYPE, LOGGING_QUEUE_TYPE], level: int) -> None:
-    """Configures the game logger."""
+    """Configure the game logger."""
     h = logging.handlers.QueueHandler(queue)
     root = logging.getLogger()
     root.handlers.clear()
@@ -159,14 +159,14 @@ def game_logging_configurer(queue: Union[CONTROL_QUEUE_TYPE, LOGGING_QUEUE_TYPE]
 
 
 def game_error_handler(error: BaseException) -> None:
-    """Handles game errors."""
+    """Handle game errors."""
     logger.exception("Game ended due to error:", exc_info=error)
 
 
 def start(li: lichess.Lichess, user_profile: USER_PROFILE_TYPE, config: Configuration, logging_level: int,
           log_filename: Optional[str], one_game: bool = False) -> None:
     """
-    Starts lichess-bot.
+    Start lichess-bot.
 
     :param li: Provides communication with lichess.org.
     :param user_profile: Information on our bot.
@@ -215,7 +215,7 @@ def start(li: lichess.Lichess, user_profile: USER_PROFILE_TYPE, config: Configur
 
 def log_proc_count(change: str, active_games: Set[str]) -> None:
     """
-    Logs the number of active games and their IDs.
+    Log the number of active games and their IDs.
 
     :param change: Either "Freed", "Used", or "Queued".
     :param active_games: A set containing the IDs of the active games.
@@ -234,7 +234,7 @@ def lichess_bot_main(li: lichess.Lichess,
                      logging_queue: LOGGING_QUEUE_TYPE,
                      one_game: bool) -> None:
     """
-    Handles all the games and challenges.
+    Handle all the games and challenges.
 
     :param li: Provides communication with lichess.org.
     :param user_profile: Information on our bot.
@@ -327,7 +327,7 @@ def lichess_bot_main(li: lichess.Lichess,
 
 
 def next_event(control_queue: CONTROL_QUEUE_TYPE) -> EVENT_TYPE:
-    """Gets the next event from the control queue."""
+    """Get the next event from the control queue."""
     try:
         event: EVENT_TYPE = control_queue.get()  # type: ignore[attr-defined]
     except InterruptedError:
@@ -354,7 +354,7 @@ def check_in_on_correspondence_games(pool: POOL_TYPE,
                                      play_game_args: PLAY_GAME_ARGS_TYPE,
                                      active_games: Set[str],
                                      max_games: int) -> None:
-    """Starts correspondence games."""
+    """Start correspondence games."""
     global correspondence_games_to_start
 
     if event["type"] == "correspondence_ping":
@@ -374,7 +374,7 @@ def check_in_on_correspondence_games(pool: POOL_TYPE,
 
 def start_low_time_games(low_time_games: List[EVENT_GETATTR_GAME_TYPE], active_games: Set[str], max_games: int,
                          pool: POOL_TYPE, play_game_args: PLAY_GAME_ARGS_TYPE) -> None:
-    """Starts the games based on how much time we have left."""
+    """Start the games based on how much time we have left."""
     low_time_games.sort(key=lambda g: g.get("secondsLeft", math.inf))
     while low_time_games and len(active_games) < max_games:
         game_id = low_time_games.pop(0)["id"]
@@ -383,7 +383,7 @@ def start_low_time_games(low_time_games: List[EVENT_GETATTR_GAME_TYPE], active_g
 
 def accept_challenges(li: lichess.Lichess, challenge_queue: MULTIPROCESSING_LIST_TYPE, active_games: Set[str],
                       max_games: int) -> None:
-    """Accepts a challenge."""
+    """Accept a challenge."""
     while len(active_games) < max_games and challenge_queue:
         chlng = challenge_queue.pop(0)
         if chlng.from_self:
@@ -400,7 +400,7 @@ def accept_challenges(li: lichess.Lichess, challenge_queue: MULTIPROCESSING_LIST
 
 
 def check_online_status(li: lichess.Lichess, user_profile: USER_PROFILE_TYPE, last_check_online_time: Timer) -> None:
-    """Checks if lichess.org thinks the bot is online or not. If it isn't, we restart it."""
+    """Check if lichess.org thinks the bot is online or not. If it isn't, we restart it."""
     global restart
 
     if last_check_online_time.is_expired():
@@ -415,7 +415,7 @@ def check_online_status(li: lichess.Lichess, user_profile: USER_PROFILE_TYPE, la
 
 def sort_challenges(challenge_queue: MULTIPROCESSING_LIST_TYPE, challenge_config: Configuration) -> None:
     """
-    Sorts the challenges.
+    Sort the challenges.
 
     They can be sorted either by rating (the best challenger is accepted first),
     or by time (the first challenger is accepted first).
@@ -427,7 +427,7 @@ def sort_challenges(challenge_queue: MULTIPROCESSING_LIST_TYPE, challenge_config
 
 
 def start_game_thread(active_games: Set[str], game_id: str, play_game_args: PLAY_GAME_ARGS_TYPE, pool: POOL_TYPE) -> None:
-    """Starts a game thread."""
+    """Start a game thread."""
     active_games.add(game_id)
     log_proc_count("Used", active_games)
     play_game_args["game_id"] = game_id
@@ -446,7 +446,7 @@ def start_game(event: EVENT_TYPE,
                active_games: Set[str],
                low_time_games: List[EVENT_GETATTR_GAME_TYPE]) -> None:
     """
-    Starts a game.
+    Start a game.
 
     :param event: The gameStart event.
     :param pool: The pool that the game is added to, so they can be run asynchronously.
@@ -474,7 +474,7 @@ def start_game(event: EVENT_TYPE,
 
 
 def enough_time_to_queue(event: EVENT_TYPE, config: Configuration) -> bool:
-    """Checks whether the correspondence must be started now or if it can wait."""
+    """Check whether the correspondence must be started now or if it can wait."""
     corr_cfg = config.correspondence
     minimum_time = (corr_cfg.checkin_period + corr_cfg.move_time) * 10
     game = event["game"]
@@ -484,7 +484,7 @@ def enough_time_to_queue(event: EVENT_TYPE, config: Configuration) -> bool:
 def handle_challenge(event: EVENT_TYPE, li: lichess.Lichess, challenge_queue: MULTIPROCESSING_LIST_TYPE,
                      challenge_config: Configuration, user_profile: USER_PROFILE_TYPE,
                      matchmaker: matchmaking.Matchmaking, recent_bot_challenges: DefaultDict[str, List[Timer]]) -> None:
-    """Handles incoming challenges. It either accepts, declines, or queues them to accept later."""
+    """Handle incoming challenges. It either accepts, declines, or queues them to accept later."""
     chlng = model.Challenge(event["challenge"], user_profile)
     is_supported, decline_reason = chlng.is_supported(challenge_config, recent_bot_challenges)
     if is_supported:
@@ -500,7 +500,7 @@ def handle_challenge(event: EVENT_TYPE, li: lichess.Lichess, challenge_queue: MU
 
 
 def log_bad_event(event: EVENT_TYPE) -> None:
-    """Logs a bad event."""
+    """Log a bad event."""
     logger.warning("Unable to handle response from lichess.org:")
     logger.warning(event)
     if event.get("error") == "Missing scope":
@@ -518,7 +518,7 @@ def play_game(li: lichess.Lichess,
               logging_queue: LOGGING_QUEUE_TYPE,
               logging_level: int) -> None:
     """
-    Plays a game.
+    Play a game.
 
     :param li: Provides communication with lichess.org.
     :param game_id: The id of the game.
@@ -628,20 +628,20 @@ def play_game(li: lichess.Lichess,
 
 
 def get_greeting(greeting: str, greeting_cfg: Configuration, keyword_map: DefaultDict[str, str]) -> str:
-    """Gets the greeting to send to the chat."""
+    """Get the greeting to send to the chat."""
     greeting_text: str = greeting_cfg.lookup(greeting)
     return greeting_text.format_map(keyword_map)
 
 
 def say_hello(conversation: Conversation, hello: str, hello_spectators: str, board: chess.Board) -> None:
-    """Sends the greetings to the chat rooms."""
+    """Send the greetings to the chat rooms."""
     if len(board.move_stack) < 2:
         conversation.send_message("player", hello)
         conversation.send_message("spectator", hello_spectators)
 
 
 def fake_thinking(config: Configuration, board: chess.Board, game: model.Game) -> None:
-    """Waits some time before starting to search for a move."""
+    """Wait some time before starting to search for a move."""
     if config.fake_think_time and len(board.move_stack) > 9:
         delay = min(game.clock_initial, game.my_remaining_seconds()) * 0.015
         accel = 1 - max(0, min(100, len(board.move_stack) - 20)) / 150
@@ -650,13 +650,13 @@ def fake_thinking(config: Configuration, board: chess.Board, game: model.Game) -
 
 
 def print_move_number(board: chess.Board) -> None:
-    """Logs the move number."""
+    """Log the move number."""
     logger.info("")
     logger.info(f"move: {len(board.move_stack) // 2 + 1}")
 
 
 def next_update(lines: Iterator[bytes]) -> GAME_EVENT_TYPE:
-    """Gets the next game state."""
+    """Get the next game state."""
     binary_chunk = next(lines)
     upd: GAME_EVENT_TYPE = json.loads(binary_chunk.decode("utf-8")) if binary_chunk else {}
     if upd:
@@ -665,7 +665,7 @@ def next_update(lines: Iterator[bytes]) -> GAME_EVENT_TYPE:
 
 
 def setup_board(game: model.Game) -> chess.Board:
-    """Sets up the board."""
+    """Set up the board."""
     if game.variant_name.lower() == "chess960":
         board = chess.Board(game.initial_fen, chess960=True)
     elif game.variant_name == "From Position":
@@ -684,12 +684,12 @@ def setup_board(game: model.Game) -> chess.Board:
 
 
 def is_engine_move(game: model.Game, prior_game: Optional[model.Game], board: chess.Board) -> bool:
-    """Checks whether it is the engine's turn."""
+    """Check whether it is the engine's turn."""
     return game_changed(game, prior_game) and game.is_white == (board.turn == chess.WHITE)
 
 
 def is_game_over(game: model.Game) -> bool:
-    """Checks whether the game is over."""
+    """Check whether the game is over."""
     status: str = game.state["status"]
     return status != "started"
 
@@ -716,7 +716,7 @@ def should_exit_game(board: chess.Board, game: model.Game, prior_game: Optional[
 
 def final_queue_entries(control_queue: CONTROL_QUEUE_TYPE, correspondence_queue: CORRESPONDENCE_QUEUE_TYPE,
                         game: model.Game, is_correspondence: bool) -> None:
-    """Logs the game that ended or we disconnected from, and sends a `local_game_done` for the game."""
+    """Log the game that ended or we disconnected from, and sends a `local_game_done` for the game."""
     if is_correspondence and not is_game_over(game):
         logger.info(f"--- Disconnecting from {game.url()}")
         correspondence_queue.put_nowait(game.id)  # type: ignore[attr-defined]
@@ -727,7 +727,7 @@ def final_queue_entries(control_queue: CONTROL_QUEUE_TYPE, correspondence_queue:
 
 
 def game_changed(current_game: model.Game, prior_game: Optional[model.Game]) -> bool:
-    """Checks whether the current game state is different from the previous game state."""
+    """Check whether the current game state is different from the previous game state."""
     if prior_game is None:
         return True
 
@@ -737,7 +737,7 @@ def game_changed(current_game: model.Game, prior_game: Optional[model.Game]) -> 
 
 
 def tell_user_game_result(game: model.Game, board: chess.Board) -> None:
-    """Logs the game result."""
+    """Log the game result."""
     winner = game.state.get("winner")
     termination = game.state.get("status")
 
@@ -778,7 +778,7 @@ def tell_user_game_result(game: model.Game, board: chess.Board) -> None:
 def try_print_pgn_game_record(li: lichess.Lichess, config: Configuration, game: model.Game, board: chess.Board,
                               engine: engine_wrapper.EngineWrapper) -> None:
     """
-    Calls `print_pgn_game_record` to write the game to a PGN file and handles errors raised by it.
+    Call `print_pgn_game_record` to write the game to a PGN file and handles errors raised by it.
 
     :param li: Provides communication with lichess.org.
     :param config: The config that the bot will use.
@@ -798,7 +798,7 @@ def try_print_pgn_game_record(li: lichess.Lichess, config: Configuration, game: 
 def print_pgn_game_record(li: lichess.Lichess, config: Configuration, game: model.Game, board: chess.Board,
                           engine: engine_wrapper.EngineWrapper) -> None:
     """
-    Writes the game to a PGN file.
+    Write the game to a PGN file.
 
     :param li: Provides communication with lichess.org.
     :param config: The config that the bot will use.
@@ -856,7 +856,7 @@ def print_pgn_game_record(li: lichess.Lichess, config: Configuration, game: mode
 
 def fill_missing_pgn_headers(game_record: chess.pgn.Game, game: model.Game) -> None:
     """
-    Fills the headers missing by the lichess.org PGN with local headers from `game`.
+    Fill the headers missing by the lichess.org PGN with local headers from `game`.
 
     :param game_record: A `chess.pgn.Game` object containing information about the game lichess.org's PGN file.
     :param game: Contains information about the game (e.g. the players' names), which is used to get the local headers.
@@ -870,7 +870,7 @@ def fill_missing_pgn_headers(game_record: chess.pgn.Game, game: model.Game) -> N
 
 def get_headers(game: model.Game) -> Dict[str, Union[str, int]]:
     """
-    Creates local headers to be written in the PGN file.
+    Create local headers to be written in the PGN file.
 
     :param game: Contains information about the game (e.g. the players' names).
     :return: The headers in a dict.
@@ -905,7 +905,7 @@ def get_headers(game: model.Game) -> Dict[str, Union[str, int]]:
 
 
 def intro() -> str:
-    """Returns the intro string."""
+    """Return the intro string."""
     return fr"""
     .   _/|
     .  // o\
@@ -916,7 +916,7 @@ def intro() -> str:
 
 
 def start_lichess_bot() -> None:
-    """Parses arguments passed to lichess-bot.py and starts lichess-bot."""
+    """Parse arguments passed to lichess-bot.py and starts lichess-bot."""
     parser = argparse.ArgumentParser(description="Play on Lichess with a bot")
     parser.add_argument("-u", action="store_true", help="Upgrade your account to a bot account.")
     parser.add_argument("-v", action="store_true", help="Make output more verbose. Include all communication with lichess.")
@@ -947,7 +947,7 @@ def start_lichess_bot() -> None:
 
 
 def check_python_version() -> None:
-    """Raises a warning or an exception if the version isn't supported or is deprecated."""
+    """Raise a warning or an exception if the version isn't supported or is deprecated."""
     def version_numeric(version_str: str) -> List[int]:
         return [int(n) for n in version_str.split(".")]
 

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -1,3 +1,4 @@
+"""The main module that controls lichess-bot."""
 # mypy: disable-error-code=valid-type
 import argparse
 import chess
@@ -98,9 +99,9 @@ def watch_control_stream(control_queue: CONTROL_QUEUE_TYPE, li: lichess.Lichess)
 def do_correspondence_ping(control_queue: CONTROL_QUEUE_TYPE, period: int) -> None:
     """
     Tells the engine to check the correspondence games.
+
     :param period: How many seconds to wait before sending a correspondence ping.
     """
-
     while not terminated:
         time.sleep(period)
         control_queue.put_nowait({"type": "correspondence_ping"})  # type: ignore[attr-defined]
@@ -109,6 +110,7 @@ def do_correspondence_ping(control_queue: CONTROL_QUEUE_TYPE, period: int) -> No
 def logging_configurer(level: int, filename: Optional[str]) -> None:
     """
     Configures the logger.
+
     :param level: The logging level. Either `logging.INFO` or `logging.DEBUG`.
     :param filename: The filename to write the logs to. If it is `None` then the logs aren't written to a file.
     """
@@ -131,7 +133,9 @@ def logging_configurer(level: int, filename: Optional[str]) -> None:
 
 def logging_listener_proc(queue: LOGGING_QUEUE_TYPE, level: int, log_filename: Optional[str]) -> None:
     """
-    Handles events from the logging queue. This allows the logs from inside a thread to be printed.
+    Handles events from the logging queue.
+
+    This allows the logs from inside a thread to be printed.
     They are added to the queue, so they are printed outside the thread.
     """
     logging_configurer(level, log_filename)
@@ -163,6 +167,7 @@ def start(li: lichess.Lichess, user_profile: USER_PROFILE_TYPE, config: Configur
           log_filename: Optional[str], one_game: bool = False) -> None:
     """
     Starts lichess-bot.
+
     :param li: Provides communication with lichess.org.
     :param user_profile: Information on our bot.
     :param config: The config that the bot will use.
@@ -211,6 +216,7 @@ def start(li: lichess.Lichess, user_profile: USER_PROFILE_TYPE, config: Configur
 def log_proc_count(change: str, active_games: Set[str]) -> None:
     """
     Logs the number of active games and their IDs.
+
     :param change: Either "Freed", "Used", or "Queued".
     :param active_games: A set containing the IDs of the active games.
     """
@@ -229,6 +235,7 @@ def lichess_bot_main(li: lichess.Lichess,
                      one_game: bool) -> None:
     """
     Handles all the games and challenges.
+
     :param li: Provides communication with lichess.org.
     :param user_profile: Information on our bot.
     :param config: The config that the bot will use.
@@ -409,6 +416,7 @@ def check_online_status(li: lichess.Lichess, user_profile: USER_PROFILE_TYPE, la
 def sort_challenges(challenge_queue: MULTIPROCESSING_LIST_TYPE, challenge_config: Configuration) -> None:
     """
     Sorts the challenges.
+
     They can be sorted either by rating (the best challenger is accepted first),
     or by time (the first challenger is accepted first).
     """
@@ -439,6 +447,7 @@ def start_game(event: EVENT_TYPE,
                low_time_games: List[EVENT_GETATTR_GAME_TYPE]) -> None:
     """
     Starts a game.
+
     :param event: The gameStart event.
     :param pool: The pool that the game is added to, so they can be run asynchronously.
     :param play_game_args: The args passed to `play_game`.
@@ -510,6 +519,7 @@ def play_game(li: lichess.Lichess,
               logging_level: int) -> None:
     """
     Plays a game.
+
     :param li: Provides communication with lichess.org.
     :param game_id: The id of the game.
     :param control_queue: The control queue that contains events (adds `local_game_done` to the queue).
@@ -520,7 +530,6 @@ def play_game(li: lichess.Lichess,
     :param logging_queue: The logging queue. Used by `logging_listener_proc`.
     :param logging_level: The logging level. Either `logging.INFO` or `logging.DEBUG`.
     """
-
     game_logging_configurer(logging_queue, logging_level)
     logger = logging.getLogger(__name__)
 
@@ -549,7 +558,7 @@ def play_game(li: lichess.Lichess,
         ponder_cfg = correspondence_cfg if is_correspondence else engine_cfg
         can_ponder = ponder_cfg.uci_ponder or ponder_cfg.ponder
         move_overhead = config.move_overhead
-        delay_seconds = config.rate_limiting_delay/1000
+        delay_seconds = config.rate_limiting_delay / 1000
 
         keyword_map: DefaultDict[str, str] = defaultdict(str, me=game.me.name, opponent=game.opponent.name)
         hello = get_greeting("hello", config.greeting, keyword_map)
@@ -641,7 +650,7 @@ def fake_thinking(config: Configuration, board: chess.Board, game: model.Game) -
 
 
 def print_move_number(board: chess.Board) -> None:
-    """Logs the move number"""
+    """Logs the move number."""
     logger.info("")
     logger.info(f"move: {len(board.move_stack) // 2 + 1}")
 
@@ -770,6 +779,7 @@ def try_print_pgn_game_record(li: lichess.Lichess, config: Configuration, game: 
                               engine: engine_wrapper.EngineWrapper) -> None:
     """
     Calls `print_pgn_game_record` to write the game to a PGN file and handles errors raised by it.
+
     :param li: Provides communication with lichess.org.
     :param config: The config that the bot will use.
     :param game: Contains information about the game (e.g. the players' names).
@@ -789,6 +799,7 @@ def print_pgn_game_record(li: lichess.Lichess, config: Configuration, game: mode
                           engine: engine_wrapper.EngineWrapper) -> None:
     """
     Writes the game to a PGN file.
+
     :param li: Provides communication with lichess.org.
     :param config: The config that the bot will use.
     :param game: Contains information about the game (e.g. the players' names).
@@ -846,6 +857,7 @@ def print_pgn_game_record(li: lichess.Lichess, config: Configuration, game: mode
 def fill_missing_pgn_headers(game_record: chess.pgn.Game, game: model.Game) -> None:
     """
     Fills the headers missing by the lichess.org PGN with local headers from `game`.
+
     :param game_record: A `chess.pgn.Game` object containing information about the game lichess.org's PGN file.
     :param game: Contains information about the game (e.g. the players' names), which is used to get the local headers.
     """
@@ -859,6 +871,7 @@ def fill_missing_pgn_headers(game_record: chess.pgn.Game, game: model.Game) -> N
 def get_headers(game: model.Game) -> Dict[str, Union[str, int]]:
     """
     Creates local headers to be written in the PGN file.
+
     :param game: Contains information about the game (e.g. the players' names).
     :return: The headers in a dict.
     """
@@ -892,6 +905,7 @@ def get_headers(game: model.Game) -> Dict[str, Union[str, int]]:
 
 
 def intro() -> str:
+    """Returns the intro string."""
     return fr"""
     .   _/|
     .  // o\
@@ -933,9 +947,7 @@ def start_lichess_bot() -> None:
 
 
 def check_python_version() -> None:
-    """
-    Checks the current python version and raises a warning or an exception if the version isn't supported or is deprecated.
-    """
+    """Raises a warning or an exception if the version isn't supported or is deprecated."""
     def version_numeric(version_str: str) -> List[int]:
         return [int(n) for n in version_str.split(".")]
 

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -764,6 +764,14 @@ def tell_user_game_result(game: model.Game, board: chess.Board) -> None:
 
 def try_print_pgn_game_record(li: lichess.Lichess, config: Configuration, game: model.Game, board: chess.Board,
                               engine: engine_wrapper.EngineWrapper) -> None:
+    """
+    Calls `print_pgn_game_record` to write the game to a PGN file and handles errors raised by it.
+    :param li: Provides communication with lichess.org.
+    :param config: The config that the bot will use.
+    :param game: Contains information about the game (e.g. the players' names).
+    :param board: The board. Contains the moves.
+    :param engine: The engine. Contains information about the moves (e.g. eval, PV, depth).
+    """
     if board is None:
         return
 
@@ -775,6 +783,14 @@ def try_print_pgn_game_record(li: lichess.Lichess, config: Configuration, game: 
 
 def print_pgn_game_record(li: lichess.Lichess, config: Configuration, game: model.Game, board: chess.Board,
                           engine: engine_wrapper.EngineWrapper) -> None:
+    """
+    Writes the game to a PGN file.
+    :param li: Provides communication with lichess.org.
+    :param config: The config that the bot will use.
+    :param game: Contains information about the game (e.g. the players' names).
+    :param board: The board. Contains the moves.
+    :param engine: The engine. Contains information about the moves (e.g. eval, PV, depth).
+    """
     if not config.pgn_directory:
         return
 
@@ -824,6 +840,11 @@ def print_pgn_game_record(li: lichess.Lichess, config: Configuration, game: mode
 
 
 def fill_missing_pgn_headers(game_record: chess.pgn.Game, game: model.Game) -> None:
+    """
+    Fills the headers missing by the lichess.org PGN with local headers from `game`.
+    :param game_record: A `chess.pgn.Game` object containing information about the game lichess.org's PGN file.
+    :param game: Contains information about the game (e.g. the players' names), which is used to get the local headers.
+    """
     local_headers = get_headers(game)
     for header, game_value in local_headers.items():
         record_value = game_record.headers.get(header)
@@ -832,6 +853,11 @@ def fill_missing_pgn_headers(game_record: chess.pgn.Game, game: model.Game) -> N
 
 
 def get_headers(game: model.Game) -> Dict[str, Union[str, int]]:
+    """
+    Creates local headers to be written in the PGN file.
+    :param game: Contains information about the game (e.g. the players' names).
+    :return: The headers in a dict.
+    """
     headers: Dict[str, Union[str, int]] = {}
     headers["Event"] = game.pgn_event()
     headers["Site"] = game.short_url()
@@ -872,6 +898,7 @@ def intro() -> str:
 
 
 def start_lichess_bot() -> None:
+    """Parses arguments passed to lichess-bot.py and starts lichess-bot."""
     parser = argparse.ArgumentParser(description="Play on Lichess with a bot")
     parser.add_argument("-u", action="store_true", help="Upgrade your account to a bot account.")
     parser.add_argument("-v", action="store_true", help="Make output more verbose. Include all communication with lichess.")
@@ -902,6 +929,9 @@ def start_lichess_bot() -> None:
 
 
 def check_python_version() -> None:
+    """
+    Checks the current python version and raises a warning or an exception if the version isn't supported or is deprecated.
+    """
     def version_numeric(version_str: str) -> List[int]:
         return [int(n) for n in version_str.split(".")]
 

--- a/lichess.py
+++ b/lichess.py
@@ -53,7 +53,7 @@ def is_final(exception: Exception) -> bool:
     return isinstance(exception, HTTPError) and exception.response.status_code < 500
 
 
-# docs: https://lichess.org/api
+# Docs: https://lichess.org/api.
 class Lichess:
     def __init__(self, token: str, url: str, version: str, logging_level: int, max_retries: int) -> None:
         """

--- a/lichess.py
+++ b/lichess.py
@@ -1,3 +1,4 @@
+"""Communication with APIs."""
 import json
 import requests
 from urllib.parse import urljoin
@@ -40,6 +41,7 @@ MAX_CHAT_MESSAGE_LEN = 140  # The maximum characters in a chat message.
 
 class RateLimited(RuntimeError):
     """Exception raised when we are rate limited (status code 429)."""
+
     pass
 
 
@@ -55,8 +57,12 @@ def is_final(exception: Exception) -> bool:
 
 # Docs: https://lichess.org/api.
 class Lichess:
+    """Communication with lichess.org (and chessdb.cn for getting moves)."""
+
     def __init__(self, token: str, url: str, version: str, logging_level: int, max_retries: int) -> None:
         """
+        Communication with lichess.org (and chessdb.cn for getting moves).
+
         :param token: The bot's token.
         :param url: The base url (lichess.org).
         :param version: The lichess-bot version running.
@@ -87,6 +93,7 @@ class Lichess:
                 params: Optional[Dict[str, str]] = None) -> requests.Response:
         """
         Send a GET to lichess.org.
+
         :param endpoint_name: The name of the endpoint.
         :param template_args: The values that go in the url (e.g. the challenge id if `endpoint_name` is `accept`).
         :param params: Parameters sent to lichess.org.
@@ -109,6 +116,7 @@ class Lichess:
                      params: Optional[Dict[str, str]] = None) -> JSON_REPLY_TYPE:
         """
         Send a GET to the lichess.org endpoints that return a JSON.
+
         :param endpoint_name: The name of the endpoint.
         :param template_args: The values that go in the url (e.g. the challenge id if `endpoint_name` is `accept`).
         :param params: Parameters sent to lichess.org.
@@ -122,6 +130,7 @@ class Lichess:
                      params: Optional[Dict[str, str]] = None) -> List[JSON_REPLY_TYPE]:
         """
         Send a GET to the lichess.org endpoints that return a list containing JSON.
+
         :param endpoint_name: The name of the endpoint.
         :param template_args: The values that go in the url (e.g. the challenge id if `endpoint_name` is `accept`).
         :param params: Parameters sent to lichess.org.
@@ -135,6 +144,7 @@ class Lichess:
                     params: Optional[Dict[str, str]] = None, ) -> str:
         """
         Send a GET to lichess.org.
+
         :param endpoint_name: The name of the endpoint.
         :param template_args: The values that go in the url (e.g. the challenge id if `endpoint_name` is `accept`).
         :param params: Parameters sent to lichess.org.
@@ -160,6 +170,7 @@ class Lichess:
                  raise_for_status: bool = True) -> JSON_REPLY_TYPE:
         """
         Send a POST to lichess.org.
+
         :param endpoint_name: The name of the endpoint.
         :param template_args: The values that go in the url (e.g. the challenge id if `endpoint_name` is `accept`).
         :param data: Data sent to lichess.org.
@@ -186,6 +197,7 @@ class Lichess:
     def get_path_template(self, endpoint_name: str) -> str:
         """
         Gets the path template given the endpoint name. Will raise an exception if the path template is rate limited.
+
         :param endpoint_name: The name of the endpoint.
         :return: The path template.
         """
@@ -198,6 +210,7 @@ class Lichess:
     def set_rate_limit_delay(self, path_template: str, delay_time: int) -> None:
         """
         Sets a delay to a path template if it was rate limited.
+
         :param path_template: The path template.
         :param delay_time: How long we won't call this endpoint.
         """
@@ -219,6 +232,7 @@ class Lichess:
     def make_move(self, game_id: str, move: chess.engine.PlayResult) -> JSON_REPLY_TYPE:
         """
         Makes a move.
+
         :param game_id: The id of the game.
         :param move: The move to make.
         """
@@ -228,6 +242,7 @@ class Lichess:
     def chat(self, game_id: str, room: str, text: str) -> JSON_REPLY_TYPE:
         """
         Sends a message to the chat.
+
         :param game_id: The id of the game.
         :param room: The room (either chat or spectator room).
         :param text: The text to send.

--- a/lichess.py
+++ b/lichess.py
@@ -46,7 +46,7 @@ class RateLimited(RuntimeError):
 
 
 def is_new_rate_limit(response: requests.models.Response) -> bool:
-    """Checks if the status code is 429, which means that we are rate limited."""
+    """Check if the status code is 429, which means that we are rate limited."""
     return response.status_code == 429
 
 
@@ -196,7 +196,7 @@ class Lichess:
 
     def get_path_template(self, endpoint_name: str) -> str:
         """
-        Gets the path template given the endpoint name. Will raise an exception if the path template is rate limited.
+        Get the path template given the endpoint name. Will raise an exception if the path template is rate limited.
 
         :param endpoint_name: The name of the endpoint.
         :return: The path template.
@@ -209,7 +209,7 @@ class Lichess:
 
     def set_rate_limit_delay(self, path_template: str, delay_time: int) -> None:
         """
-        Sets a delay to a path template if it was rate limited.
+        Set a delay to a path template if it was rate limited.
 
         :param path_template: The path template.
         :param delay_time: How long we won't call this endpoint.
@@ -218,7 +218,7 @@ class Lichess:
         self.rate_limit_timers[path_template] = Timer(delay_time)
 
     def is_rate_limited(self, path_template: str) -> bool:
-        """Checks if a path template is rate limited."""
+        """Check if a path template is rate limited."""
         return not self.rate_limit_timers[path_template].is_expired()
 
     def rate_limit_time_left(self, path_template: str) -> float:
@@ -226,12 +226,12 @@ class Lichess:
         return self.rate_limit_timers[path_template].time_until_expiration()
 
     def upgrade_to_bot_account(self) -> JSON_REPLY_TYPE:
-        """Upgrades the account to a BOT account."""
+        """Upgrade the account to a BOT account."""
         return self.api_post("upgrade")
 
     def make_move(self, game_id: str, move: chess.engine.PlayResult) -> JSON_REPLY_TYPE:
         """
-        Makes a move.
+        Make a move.
 
         :param game_id: The id of the game.
         :param move: The move to make.
@@ -241,7 +241,7 @@ class Lichess:
 
     def chat(self, game_id: str, room: str, text: str) -> JSON_REPLY_TYPE:
         """
-        Sends a message to the chat.
+        Send a message to the chat.
 
         :param game_id: The id of the game.
         :param room: The room (either chat or spectator room).
@@ -261,21 +261,21 @@ class Lichess:
         return self.api_post("abort", game_id)
 
     def get_event_stream(self) -> requests.models.Response:
-        """A stream of the events (e.g. challenge, gameStart)."""
+        """Get a stream of the events (e.g. challenge, gameStart)."""
         url = urljoin(self.baseUrl, ENDPOINTS["stream_event"])
         return requests.get(url, headers=self.header, stream=True, timeout=15)
 
     def get_game_stream(self, game_id: str) -> requests.models.Response:
-        """A stream of the in-game events (e.g. moves by the opponent)."""
+        """Get  stream of the in-game events (e.g. moves by the opponent)."""
         url = urljoin(self.baseUrl, ENDPOINTS["stream"].format(game_id))
         return requests.get(url, headers=self.header, stream=True, timeout=15)
 
     def accept_challenge(self, challenge_id: str) -> JSON_REPLY_TYPE:
-        """Accepts a challenge."""
+        """Accept a challenge."""
         return self.api_post("accept", challenge_id)
 
     def decline_challenge(self, challenge_id: str, reason: str = "generic") -> JSON_REPLY_TYPE:
-        """Declines a challenge."""
+        """Decline a challenge."""
         try:
             return self.api_post("decline", challenge_id,
                                  data=f"reason={reason}",
@@ -286,13 +286,13 @@ class Lichess:
             return {}
 
     def get_profile(self) -> JSON_REPLY_TYPE:
-        """Gets the bot's profile (e.g. username)."""
+        """Get the bot's profile (e.g. username)."""
         profile = self.api_get_json("profile")
         self.set_user_agent(profile["username"])
         return profile
 
     def get_ongoing_games(self) -> List[Dict[str, Any]]:
-        """Gets the bot's ongoing games."""
+        """Get the bot's ongoing games."""
         ongoing_games: List[Dict[str, Any]] = []
         try:
             ongoing_games = self.api_get_json("playing")["nowPlaying"]
@@ -301,23 +301,23 @@ class Lichess:
         return ongoing_games
 
     def resign(self, game_id: str) -> None:
-        """Resigns a game."""
+        """Resign a game."""
         self.api_post("resign", game_id)
 
     def set_user_agent(self, username: str) -> None:
-        """Sets the user agent for communication with lichess.org."""
+        """Set the user agent for communication with lichess.org."""
         self.header.update({"User-Agent": f"lichess-bot/{self.version} user:{username}"})
         self.session.headers.update(self.header)
 
     def get_game_pgn(self, game_id: str) -> str:
-        """Gets the pgn of a game."""
+        """Get the pgn of a game."""
         try:
             return self.api_get_raw("export", game_id)
         except Exception:
             return ""
 
     def get_online_bots(self) -> List[Dict[str, Any]]:
-        """Gets a list of bots that are online."""
+        """Get a list of bots that are online."""
         try:
             online_bots_str = self.api_get_raw("online_bots")
             online_bots = list(filter(bool, online_bots_str.split("\n")))
@@ -326,15 +326,15 @@ class Lichess:
             return []
 
     def challenge(self, username: str, payload: REQUESTS_PAYLOAD_TYPE) -> JSON_REPLY_TYPE:
-        """Creates a challenge."""
+        """Create a challenge."""
         return self.api_post("challenge", username, payload=payload, raise_for_status=False)
 
     def cancel(self, challenge_id: str) -> JSON_REPLY_TYPE:
-        """Cancels a challenge."""
+        """Cancel a challenge."""
         return self.api_post("cancel", challenge_id, raise_for_status=False)
 
     def online_book_get(self, path: str, params: Optional[Dict[str, Any]] = None) -> JSON_REPLY_TYPE:
-        """Gets an external move from online sources (chessdb or lichess.org)."""
+        """Get an external move from online sources (chessdb or lichess.org)."""
         @backoff.on_exception(backoff.constant,
                               (RemoteDisconnected, ConnectionError, HTTPError, ReadTimeout),
                               max_time=60,
@@ -349,10 +349,10 @@ class Lichess:
         return online_book_get()
 
     def is_online(self, user_id: str) -> bool:
-        """Checks if lichess.org thinks the bot is online or not."""
+        """Check if lichess.org thinks the bot is online or not."""
         user = self.api_get_list("status", params={"ids": user_id})
         return bool(user and user[0].get("online"))
 
     def get_public_data(self, user_name: str) -> JSON_REPLY_TYPE:
-        """Gets the public data of a bot."""
+        """Get the public data of a bot."""
         return self.api_get_json("public_data", user_name)

--- a/lichess.py
+++ b/lichess.py
@@ -143,7 +143,7 @@ class Lichess:
     def api_get_raw(self, endpoint_name: str, *template_args: str,
                     params: Optional[Dict[str, str]] = None, ) -> str:
         """
-        Send a GET to lichess.org.
+        Send a GET to lichess.org that returns plain text (UTF-8).
 
         :param endpoint_name: The name of the endpoint.
         :param template_args: The values that go in the url (e.g. the challenge id if `endpoint_name` is `accept`).
@@ -310,7 +310,7 @@ class Lichess:
         self.session.headers.update(self.header)
 
     def get_game_pgn(self, game_id: str) -> str:
-        """Get the pgn of a game."""
+        """Get the PGN (Portable Game Notation) record of a game."""
         try:
             return self.api_get_raw("export", game_id)
         except Exception:

--- a/lichess.py
+++ b/lichess.py
@@ -39,20 +39,30 @@ MAX_CHAT_MESSAGE_LEN = 140  # The maximum characters in a chat message.
 
 
 class RateLimited(RuntimeError):
+    """Exception raised when we are rate limited (status code 429)."""
     pass
 
 
 def is_new_rate_limit(response: requests.models.Response) -> bool:
+    """Checks if the status code is 429, which means that we are rate limited."""
     return response.status_code == 429
 
 
 def is_final(exception: Exception) -> bool:
+    """If `is_final` returns True then we won't retry."""
     return isinstance(exception, HTTPError) and exception.response.status_code < 500
 
 
 # docs: https://lichess.org/api
 class Lichess:
     def __init__(self, token: str, url: str, version: str, logging_level: int, max_retries: int) -> None:
+        """
+        :param token: The bot's token.
+        :param url: The base url (lichess.org).
+        :param version: The lichess-bot version running.
+        :param logging_level: The logging level (logging.INFO or logging.DEBUG).
+        :param max_retries: The maximum amount of retries for online moves (e.g. chessdb's opening book).
+        """
         self.version = version
         self.header = {
             "Authorization": f"Bearer {token}"
@@ -75,6 +85,13 @@ class Lichess:
                           giveup_log_level=logging.DEBUG)
     def api_get(self, endpoint_name: str, *template_args: str,
                 params: Optional[Dict[str, str]] = None) -> requests.Response:
+        """
+        Send a GET to lichess.org.
+        :param endpoint_name: The name of the endpoint.
+        :param template_args: The values that go in the url (e.g. the challenge id if `endpoint_name` is `accept`).
+        :param params: Parameters sent to lichess.org.
+        :return: lichess.org's response.
+        """
         logging.getLogger("backoff").setLevel(self.logging_level)
         path_template = self.get_path_template(endpoint_name)
         url = urljoin(self.baseUrl, path_template.format(*template_args))
@@ -90,18 +107,39 @@ class Lichess:
 
     def api_get_json(self, endpoint_name: str, *template_args: str,
                      params: Optional[Dict[str, str]] = None) -> JSON_REPLY_TYPE:
+        """
+        Send a GET to the lichess.org endpoints that return a JSON.
+        :param endpoint_name: The name of the endpoint.
+        :param template_args: The values that go in the url (e.g. the challenge id if `endpoint_name` is `accept`).
+        :param params: Parameters sent to lichess.org.
+        :return: lichess.org's response in a dict.
+        """
         response = self.api_get(endpoint_name, *template_args, params=params)
         json_response: JSON_REPLY_TYPE = response.json()
         return json_response
 
     def api_get_list(self, endpoint_name: str, *template_args: str,
                      params: Optional[Dict[str, str]] = None) -> List[JSON_REPLY_TYPE]:
+        """
+        Send a GET to the lichess.org endpoints that return a list containing JSON.
+        :param endpoint_name: The name of the endpoint.
+        :param template_args: The values that go in the url (e.g. the challenge id if `endpoint_name` is `accept`).
+        :param params: Parameters sent to lichess.org.
+        :return: lichess.org's response in a list of dicts.
+        """
         response = self.api_get(endpoint_name, *template_args, params=params)
         json_response: List[JSON_REPLY_TYPE] = response.json()
         return json_response
 
     def api_get_raw(self, endpoint_name: str, *template_args: str,
                     params: Optional[Dict[str, str]] = None, ) -> str:
+        """
+        Send a GET to lichess.org.
+        :param endpoint_name: The name of the endpoint.
+        :param template_args: The values that go in the url (e.g. the challenge id if `endpoint_name` is `accept`).
+        :param params: Parameters sent to lichess.org.
+        :return: The text of lichess.org's response.
+        """
         response = self.api_get(endpoint_name, *template_args, params=params)
         return response.text
 
@@ -120,6 +158,17 @@ class Lichess:
                  params: Optional[Dict[str, str]] = None,
                  payload: Optional[REQUESTS_PAYLOAD_TYPE] = None,
                  raise_for_status: bool = True) -> JSON_REPLY_TYPE:
+        """
+        Send a POST to lichess.org.
+        :param endpoint_name: The name of the endpoint.
+        :param template_args: The values that go in the url (e.g. the challenge id if `endpoint_name` is `accept`).
+        :param data: Data sent to lichess.org.
+        :param headers: The headers for the request.
+        :param params: Parameters sent to lichess.org.
+        :param payload: Payload sent to lichess.org.
+        :param raise_for_status: Whether to raise an exception if the response contains an error code.
+        :return: lichess.org's response in a dict.
+        """
         logging.getLogger("backoff").setLevel(self.logging_level)
         path_template = self.get_path_template(endpoint_name)
         url = urljoin(self.baseUrl, path_template.format(*template_args))
@@ -135,6 +184,11 @@ class Lichess:
         return json_response
 
     def get_path_template(self, endpoint_name: str) -> str:
+        """
+        Gets the path template given the endpoint name. Will raise an exception if the path template is rate limited.
+        :param endpoint_name: The name of the endpoint.
+        :return: The path template.
+        """
         path_template = ENDPOINTS[endpoint_name]
         if self.is_rate_limited(path_template):
             raise RateLimited(f"{path_template} is rate-limited. "
@@ -142,23 +196,42 @@ class Lichess:
         return path_template
 
     def set_rate_limit_delay(self, path_template: str, delay_time: int) -> None:
+        """
+        Sets a delay to a path template if it was rate limited.
+        :param path_template: The path template.
+        :param delay_time: How long we won't call this endpoint.
+        """
         logger.warning(f"Endpoint {path_template} is rate limited. Waiting {delay_time} seconds until next request.")
         self.rate_limit_timers[path_template] = Timer(delay_time)
 
     def is_rate_limited(self, path_template: str) -> bool:
+        """Checks if a path template is rate limited."""
         return not self.rate_limit_timers[path_template].is_expired()
 
     def rate_limit_time_left(self, path_template: str) -> float:
+        """How much time is left until we can use the path template normally."""
         return self.rate_limit_timers[path_template].time_until_expiration()
 
     def upgrade_to_bot_account(self) -> JSON_REPLY_TYPE:
+        """Upgrades the account to a BOT account."""
         return self.api_post("upgrade")
 
     def make_move(self, game_id: str, move: chess.engine.PlayResult) -> JSON_REPLY_TYPE:
+        """
+        Makes a move.
+        :param game_id: The id of the game.
+        :param move: The move to make.
+        """
         return self.api_post("move", game_id, move.move,
                              params={"offeringDraw": str(move.draw_offered).lower()})
 
     def chat(self, game_id: str, room: str, text: str) -> JSON_REPLY_TYPE:
+        """
+        Sends a message to the chat.
+        :param game_id: The id of the game.
+        :param room: The room (either chat or spectator room).
+        :param text: The text to send.
+        """
         if len(text) > MAX_CHAT_MESSAGE_LEN:
             logger.warning(f"This chat message is {len(text)} characters, which is longer "
                            f"than the maximum of {MAX_CHAT_MESSAGE_LEN}. It will not be sent.")
@@ -169,20 +242,25 @@ class Lichess:
         return self.api_post("chat", game_id, data=payload)
 
     def abort(self, game_id: str) -> JSON_REPLY_TYPE:
+        """Aborts a game."""
         return self.api_post("abort", game_id)
 
     def get_event_stream(self) -> requests.models.Response:
+        """A stream of the events (e.g. challenge, gameStart)."""
         url = urljoin(self.baseUrl, ENDPOINTS["stream_event"])
         return requests.get(url, headers=self.header, stream=True, timeout=15)
 
     def get_game_stream(self, game_id: str) -> requests.models.Response:
+        """A stream of the in-game events (e.g. moves by the opponent)."""
         url = urljoin(self.baseUrl, ENDPOINTS["stream"].format(game_id))
         return requests.get(url, headers=self.header, stream=True, timeout=15)
 
     def accept_challenge(self, challenge_id: str) -> JSON_REPLY_TYPE:
+        """Accepts a challenge."""
         return self.api_post("accept", challenge_id)
 
     def decline_challenge(self, challenge_id: str, reason: str = "generic") -> JSON_REPLY_TYPE:
+        """Declines a challenge."""
         try:
             return self.api_post("decline", challenge_id,
                                  data=f"reason={reason}",
@@ -193,11 +271,13 @@ class Lichess:
             return {}
 
     def get_profile(self) -> JSON_REPLY_TYPE:
+        """Gets the bot's profile (e.g. username)."""
         profile = self.api_get_json("profile")
         self.set_user_agent(profile["username"])
         return profile
 
     def get_ongoing_games(self) -> List[Dict[str, Any]]:
+        """Gets the bot's ongoing games."""
         ongoing_games: List[Dict[str, Any]] = []
         try:
             ongoing_games = self.api_get_json("playing")["nowPlaying"]
@@ -206,19 +286,23 @@ class Lichess:
         return ongoing_games
 
     def resign(self, game_id: str) -> None:
+        """Resigns a game."""
         self.api_post("resign", game_id)
 
     def set_user_agent(self, username: str) -> None:
+        """Sets the user agent for communication with lichess.org."""
         self.header.update({"User-Agent": f"lichess-bot/{self.version} user:{username}"})
         self.session.headers.update(self.header)
 
     def get_game_pgn(self, game_id: str) -> str:
+        """Gets the pgn of a game."""
         try:
             return self.api_get_raw("export", game_id)
         except Exception:
             return ""
 
     def get_online_bots(self) -> List[Dict[str, Any]]:
+        """Gets a list of bots that are online."""
         try:
             online_bots_str = self.api_get_raw("online_bots")
             online_bots = list(filter(bool, online_bots_str.split("\n")))
@@ -227,12 +311,15 @@ class Lichess:
             return []
 
     def challenge(self, username: str, payload: REQUESTS_PAYLOAD_TYPE) -> JSON_REPLY_TYPE:
+        """Creates a challenge."""
         return self.api_post("challenge", username, payload=payload, raise_for_status=False)
 
     def cancel(self, challenge_id: str) -> JSON_REPLY_TYPE:
+        """Cancels a challenge."""
         return self.api_post("cancel", challenge_id, raise_for_status=False)
 
     def online_book_get(self, path: str, params: Optional[Dict[str, Any]] = None) -> JSON_REPLY_TYPE:
+        """Gets an external move from online sources (chessdb or lichess.org)."""
         @backoff.on_exception(backoff.constant,
                               (RemoteDisconnected, ConnectionError, HTTPError, ReadTimeout),
                               max_time=60,
@@ -247,8 +334,10 @@ class Lichess:
         return online_book_get()
 
     def is_online(self, user_id: str) -> bool:
+        """Checks if lichess.org thinks the bot is online or not."""
         user = self.api_get_list("status", params={"ids": user_id})
         return bool(user and user[0].get("online"))
 
     def get_public_data(self, user_name: str) -> JSON_REPLY_TYPE:
+        """Gets the public data of a bot."""
         return self.api_get_json("public_data", user_name)

--- a/matchmaking.py
+++ b/matchmaking.py
@@ -1,4 +1,4 @@
-"""Challenges other bots."""
+"""Challenge other bots."""
 import random
 import logging
 import model
@@ -21,7 +21,7 @@ one_day_seconds = datetime.timedelta(days=1).total_seconds()
 
 
 def read_daily_challenges() -> DAILY_TIMERS_TYPE:
-    """Reads the challenges we have created in the past 24 hours from a text file."""
+    """Read the challenges we have created in the past 24 hours from a text file."""
     timers: DAILY_TIMERS_TYPE = []
     try:
         with open(daily_challenges_file_name) as file:
@@ -34,17 +34,17 @@ def read_daily_challenges() -> DAILY_TIMERS_TYPE:
 
 
 def write_daily_challenges(daily_challenges: DAILY_TIMERS_TYPE) -> None:
-    """Writes the challenges we have created in the past 24 hours to a text file."""
+    """Write the challenges we have created in the past 24 hours to a text file."""
     with open(daily_challenges_file_name, "w") as file:
         for timer in daily_challenges:
             file.write(timer.starting_timestamp().strftime(timestamp_format))
 
 
 class Matchmaking:
-    """Challenges other bots."""
+    """Challenge other bots."""
 
     def __init__(self, li: lichess.Lichess, config: Configuration, user_profile: USER_PROFILE_TYPE) -> None:
-        """Initializes values needed for matchmaking."""
+        """Initialize values needed for matchmaking."""
         self.li = li
         self.variants = list(filter(lambda variant: variant != "fromPosition", config.challenge.variants))
         self.matchmaking_cfg = config.matchmaking
@@ -80,7 +80,7 @@ class Matchmaking:
 
     def create_challenge(self, username: str, base_time: int, increment: int, days: int, variant: str,
                          mode: str) -> str:
-        """Creates a challenge."""
+        """Create a challenge."""
         params = {"rated": mode == "rated", "variant": variant}
 
         if days:
@@ -123,7 +123,7 @@ class Matchmaking:
         write_daily_challenges(self.daily_challenges)
 
     def perf(self) -> Dict[str, Dict[str, Any]]:
-        """The bot's rating in every variant. Bullet, blitz, rapid etc. are considered different variants."""
+        """Get the bot's rating in every variant. Bullet, blitz, rapid etc. are considered different variants."""
         user_perf: Dict[str, Dict[str, Any]] = self.user_profile["perfs"]
         return user_perf
 
@@ -133,7 +133,7 @@ class Matchmaking:
         return username
 
     def update_user_profile(self) -> None:
-        """Updates our user profile data, to get our latest rating."""
+        """Update our user profile data, to get our latest rating."""
         if self.last_user_profile_update_time.is_expired():
             self.last_user_profile_update_time.reset()
             try:
@@ -142,7 +142,7 @@ class Matchmaking:
                 pass
 
     def choose_opponent(self) -> Tuple[Optional[str], int, int, int, str, str]:
-        """Chooses an opponent."""
+        """Choose an opponent."""
         variant = self.get_random_config_value("challenge_variant", self.variants)
         mode = self.get_random_config_value("challenge_mode", ["casual", "rated"])
 
@@ -205,13 +205,13 @@ class Matchmaking:
         return bot_username, base_time, increment, days, variant, mode
 
     def get_random_config_value(self, parameter: str, choices: List[str]) -> str:
-        """Chooses a random value from `choices` if the parameter value in the config is `random`."""
+        """Choose a random value from `choices` if the parameter value in the config is `random`."""
         value: str = self.matchmaking_cfg.lookup(parameter)
         return value if value != "random" else random.choice(choices)
 
     def challenge(self, active_games: Set[str], challenge_queue: MULTIPROCESSING_LIST_TYPE) -> None:
         """
-        Challenges an opponent.
+        Challenge an opponent.
 
         :param active_games: The games that the bot is playing.
         :param challenge_queue: The queue containing the challenges.
@@ -228,12 +228,12 @@ class Matchmaking:
         self.challenge_id = challenge_id
 
     def game_done(self) -> None:
-        """Resets the timer for when the last game ended, and prints the earliest that the next challenge will be created."""
+        """Reset the timer for when the last game ended, and prints the earliest that the next challenge will be created."""
         self.last_game_ended_delay.reset()
         self.show_earliest_challenge_time()
 
     def show_earliest_challenge_time(self) -> None:
-        """Shows the earliest that the next challenge will be created."""
+        """Show the earliest that the next challenge will be created."""
         postgame_timeout = self.last_game_ended_delay.time_until_expiration()
         time_to_next_challenge = self.min_wait_time - self.last_challenge_created_delay.time_since_reset()
         time_left = max(postgame_timeout, time_to_next_challenge)
@@ -243,13 +243,13 @@ class Matchmaking:
                     f"({len(self.daily_challenges)} {challenges} in last 24 hours)")
 
     def add_to_block_list(self, username: str) -> None:
-        """Adds a bot to the blocklist."""
+        """Add a bot to the blocklist."""
         logger.info(f"Will not challenge {username} again during this session.")
         self.block_list.append(username)
 
     def accepted_challenge(self, event: EVENT_TYPE) -> None:
         """
-        Sets the challenge id to an empty string, if the challenge was accepted.
+        Set the challenge id to an empty string, if the challenge was accepted.
 
         Otherwise, we would attempt to cancel the challenge later.
         """
@@ -258,7 +258,7 @@ class Matchmaking:
 
     def declined_challenge(self, event: EVENT_TYPE) -> None:
         """
-        Handles a challenge that was declined by the opponent.
+        Handle a challenge that was declined by the opponent.
 
         Depends on whether `FilterType` is `NONE`, `COARSE`, or `FINE`.
         """
@@ -296,7 +296,7 @@ class Matchmaking:
 
 def game_category(variant: str, base_time: int, increment: int, days: int) -> str:
     """
-    The game type (e.g. bullet, atomic, correspondence). Lichess has one rating for every variant regardless of time control.
+    Get the game type (e.g. bullet, atomic, correspondence). Lichess has one rating for every variant regardless of time control.
 
     :param variant: The game's variant.
     :param base_time: The base time in seconds.

--- a/matchmaking.py
+++ b/matchmaking.py
@@ -47,7 +47,7 @@ class Matchmaking:
         self.user_profile = user_profile
         self.last_challenge_created_delay = Timer(25)  # The challenge expires 20 seconds after creating it.
         self.last_game_ended_delay = Timer(self.matchmaking_cfg.challenge_timeout * 60)
-        self.last_user_profile_update_time = Timer(5 * 60)  # 5 minutes
+        self.last_user_profile_update_time = Timer(5 * 60)  # 5 minutes.
         self.min_wait_time = 60  # Wait 60 seconds before creating a new challenge to avoid hitting the api rate limits.
         self.challenge_id: str = ""
         self.block_list = self.matchmaking_cfg.block_list.copy()
@@ -169,7 +169,7 @@ class Matchmaking:
             return (bot["username"] != self.username()
                     and bot["username"] not in self.block_list
                     and not bot.get("disabled")
-                    and (allow_tos_violation or not bot.get("tosViolation"))  # Terms of Service
+                    and (allow_tos_violation or not bot.get("tosViolation"))  # Terms of Service violation.
                     and perf.get("games", 0) > 0
                     and min_rating <= perf.get("rating", 0) <= max_rating)
 

--- a/matchmaking.py
+++ b/matchmaking.py
@@ -110,8 +110,9 @@ class Matchmaking:
 
     def update_daily_challenge_record(self) -> None:
         """
-        As the number of challenges in a day increase, the minimum wait time between challenges increases.
+        Record timestamp of latest challenge and update minimum wait time.
 
+        As the number of challenges in a day increase, the minimum wait time between challenges increases.
         0   -  49 challenges --> 1 minute
         50  -  99 challenges --> 2 minutes
         100 - 149 challenges --> 3 minutes

--- a/matchmaking.py
+++ b/matchmaking.py
@@ -296,7 +296,7 @@ class Matchmaking:
 
 def game_category(variant: str, base_time: int, increment: int, days: int) -> str:
     """
-    Get the game type (e.g. bullet, atomic, correspondence). Lichess has one rating for every variant regardless of time control.
+    Get the game type (e.g. bullet, atomic, classical). Lichess has one rating for every variant regardless of time control.
 
     :param variant: The game's variant.
     :param base_time: The base time in seconds.

--- a/matchmaking.py
+++ b/matchmaking.py
@@ -1,3 +1,4 @@
+"""Challenges other bots."""
 import random
 import logging
 import model
@@ -40,7 +41,10 @@ def write_daily_challenges(daily_challenges: DAILY_TIMERS_TYPE) -> None:
 
 
 class Matchmaking:
+    """Challenges other bots."""
+
     def __init__(self, li: lichess.Lichess, config: Configuration, user_profile: USER_PROFILE_TYPE) -> None:
+        """Initializes values needed for matchmaking."""
         self.li = li
         self.variants = list(filter(lambda variant: variant != "fromPosition", config.challenge.variants))
         self.matchmaking_cfg = config.matchmaking
@@ -107,6 +111,7 @@ class Matchmaking:
     def update_daily_challenge_record(self) -> None:
         """
         As the number of challenges in a day increase, the minimum wait time between challenges increases.
+
         0   -  49 challenges --> 1 minute
         50  -  99 challenges --> 2 minutes
         100 - 149 challenges --> 3 minutes
@@ -207,6 +212,7 @@ class Matchmaking:
     def challenge(self, active_games: Set[str], challenge_queue: MULTIPROCESSING_LIST_TYPE) -> None:
         """
         Challenges an opponent.
+
         :param active_games: The games that the bot is playing.
         :param challenge_queue: The queue containing the challenges.
         """
@@ -244,6 +250,7 @@ class Matchmaking:
     def accepted_challenge(self, event: EVENT_TYPE) -> None:
         """
         Sets the challenge id to an empty string, if the challenge was accepted.
+
         Otherwise, we would attempt to cancel the challenge later.
         """
         if self.challenge_id == event["game"]["id"]:
@@ -252,6 +259,7 @@ class Matchmaking:
     def declined_challenge(self, event: EVENT_TYPE) -> None:
         """
         Handles a challenge that was declined by the opponent.
+
         Depends on whether `FilterType` is `NONE`, `COARSE`, or `FINE`.
         """
         challenge = model.Challenge(event["challenge"], self.user_profile)
@@ -288,8 +296,8 @@ class Matchmaking:
 
 def game_category(variant: str, base_time: int, increment: int, days: int) -> str:
     """
-    The game type (e.g. bullet, blitz, atomic, correspondence).
-    Lichess has one rating for every variant regardless of time control.
+    The game type (e.g. bullet, atomic, correspondence). Lichess has one rating for every variant regardless of time control.
+
     :param variant: The game's variant.
     :param base_time: The base time in seconds.
     :param increment: The increment in seconds.

--- a/model.py
+++ b/model.py
@@ -1,4 +1,4 @@
-"""Stores information about a challenge, game or player in a class."""
+"""Store information about a challenge, game or player in a class."""
 import math
 from urllib.parse import urljoin
 import logging
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 
 class Challenge:
-    """Stores information about a challenge."""
+    """Store information about a challenge."""
 
     def __init__(self, challenge_info: Dict[str, Any], user_profile: Dict[str, Any]) -> None:
         """:param user_profile: Information about our bot."""
@@ -29,11 +29,11 @@ class Challenge:
         self.from_self = self.challenger.name == user_profile["username"]
 
     def is_supported_variant(self, challenge_cfg: Configuration) -> bool:
-        """Checks whether the variant is supported."""
+        """Check whether the variant is supported."""
         return self.variant in challenge_cfg.variants
 
     def is_supported_time_control(self, challenge_cfg: Configuration) -> bool:
-        """Checks whether the time control is supported."""
+        """Check whether the time control is supported."""
         speeds = challenge_cfg.time_controls
         increment_max: int = challenge_cfg.max_increment
         increment_min: int = challenge_cfg.min_increment
@@ -57,11 +57,11 @@ class Challenge:
             return days_max == math.inf
 
     def is_supported_mode(self, challenge_cfg: Configuration) -> bool:
-        """Checks whether the mode is supported."""
+        """Check whether the mode is supported."""
         return ("rated" if self.rated else "casual") in challenge_cfg.modes
 
     def is_supported_recent(self, config: Configuration, recent_bot_challenges: DefaultDict[str, List[Timer]]) -> bool:
-        """Checks whether we have played a lot of games with this opponent recently. Only used when the oppoennt is a BOT."""
+        """Check whether we have played a lot of games with this opponent recently. Only used when the oppoennt is a BOT."""
         # Filter out old challenges
         recent_bot_challenges[self.challenger.name] = [timer for timer
                                                        in recent_bot_challenges[self.challenger.name]
@@ -73,7 +73,7 @@ class Challenge:
 
     def decline_due_to(self, requirement_met: bool, decline_reason: str) -> str:
         """
-        The reason lichess-bot declined an incoming challenge.
+        Get the reason lichess-bot declined an incoming challenge.
 
         :param requirement_met: Whether a requirement is met.
         :param decline_reason: The reason we declined the challenge if the requirement wasn't met.
@@ -103,7 +103,7 @@ class Challenge:
             return False, "generic"
 
     def score(self) -> int:
-        """Gives a rating estimate to the opponent."""
+        """Give a rating estimate to the opponent."""
         rated_bonus = 200 if self.rated else 0
         challenger_master_title = self.challenger.title if not self.challenger.is_bot else None
         titled_bonus = 200 if challenger_master_title else 0
@@ -111,15 +111,15 @@ class Challenge:
         return challenger_rating_int + rated_bonus + titled_bonus
 
     def mode(self) -> str:
-        """The mode of the challenge (rated or casual)."""
+        """Get the mode of the challenge (rated or casual)."""
         return "rated" if self.rated else "casual"
 
     def __str__(self) -> str:
-        """A string representation of `Challenge`."""
+        """Get a string representation of `Challenge`."""
         return f"{self.perf_name} {self.mode()} challenge from {self.challenger} ({self.id})"
 
     def __repr__(self) -> str:
-        """A string representation of `Challenge`."""
+        """Get a string representation of `Challenge`."""
         return self.__str__()
 
 
@@ -134,7 +134,7 @@ class Termination(str, Enum):
 
 
 class Game:
-    """Stores information about a game."""
+    """Store information about a game."""
 
     def __init__(self, game_info: Dict[str, Any], username: str, base_url: str, abort_time: int) -> None:
         """:param abort_time: How long to wait before aborting the game."""
@@ -164,22 +164,22 @@ class Game:
         self.disconnect_time = Timer(0)
 
     def url(self) -> str:
-        """The url of the game."""
+        """Get the url of the game."""
         return f"{self.short_url()}/{self.my_color}"
 
     def short_url(self) -> str:
-        """The short url of the game."""
+        """Get the short url of the game."""
         return urljoin(self.base_url, self.id)
 
     def pgn_event(self) -> str:
-        """The event to write in the PGN file."""
+        """Get the event to write in the PGN file."""
         if self.variant_name in ["Standard", "From Position"]:
             return f"{self.mode.title()} {self.perf_name.title()} game"
         else:
             return f"{self.mode.title()} {self.variant_name} game"
 
     def time_control(self) -> str:
-        """The time control of the game."""
+        """Get the time control of the game."""
         return f"{int(self.clock_initial/1000)}+{int(self.clock_increment/1000)}"
 
     def is_abortable(self) -> bool:
@@ -190,7 +190,7 @@ class Game:
 
     def ping(self, abort_in: int, terminate_in: int, disconnect_in: int) -> None:
         """
-        Tells the bot when to abort, terminate, and disconnect from a game.
+        Tell the bot when to abort, terminate, and disconnect from a game.
 
         :param abort_in: How many seconds to wait before aborting.
         :param terminate_in: How many seconds to wait before terminating.
@@ -220,7 +220,7 @@ class Game:
         return (wtime if self.is_white else btime) / 1000
 
     def result(self) -> str:
-        """The result of the game."""
+        """Get the result of the game."""
         class GameEnding(str, Enum):
             WHITE_WINS = "1-0"
             BLACK_WINS = "0-1"
@@ -242,16 +242,16 @@ class Game:
         return result.value
 
     def __str__(self) -> str:
-        """A string representation of `Game`."""
+        """Get a string representation of `Game`."""
         return f"{self.url()} {self.perf_name} vs {self.opponent} ({self.id})"
 
     def __repr__(self) -> str:
-        """A string representation of `Game`."""
+        """Get a string representation of `Game`."""
         return self.__str__()
 
 
 class Player:
-    """Stores information about a player."""
+    """Store information about a player."""
 
     def __init__(self, player_info: Dict[str, Any]) -> None:
         """:param player_info: Contains information about a player."""
@@ -263,7 +263,7 @@ class Player:
         self.aiLevel = player_info.get("aiLevel")
 
     def __str__(self) -> str:
-        """A string representation of `Player`."""
+        """Get a string representation of `Player`."""
         if self.aiLevel:
             return f"AI level {self.aiLevel}"
         else:
@@ -271,5 +271,5 @@ class Player:
             return f'{self.title or ""} {self.name} ({rating})'.strip()
 
     def __repr__(self) -> str:
-        """A string representation of `Player`."""
+        """Get a string representation of `Player`."""
         return self.__str__()

--- a/model.py
+++ b/model.py
@@ -1,3 +1,4 @@
+"""Stores information about a challenge, game or player in a class."""
 import math
 from urllib.parse import urljoin
 import logging
@@ -11,7 +12,10 @@ logger = logging.getLogger(__name__)
 
 
 class Challenge:
+    """Stores information about a challenge."""
+
     def __init__(self, challenge_info: Dict[str, Any], user_profile: Dict[str, Any]) -> None:
+        """:param user_profile: Information about our bot."""
         self.id = challenge_info["id"]
         self.rated = challenge_info["rated"]
         self.variant = challenge_info["variant"]["key"]
@@ -68,6 +72,13 @@ class Challenge:
                 or len(recent_bot_challenges[self.challenger.name]) < max_recent_challenges)
 
     def decline_due_to(self, requirement_met: bool, decline_reason: str) -> str:
+        """
+        The reason lichess-bot declined an incoming challenge.
+
+        :param requirement_met: Whether a requirement is met.
+        :param decline_reason: The reason we declined the challenge if the requirement wasn't met.
+        :return: `decline_reason` if `requirement_met` is false else returns an empty string.
+        """
         return "" if requirement_met else decline_reason
 
     def is_supported(self, config: Configuration,
@@ -104,14 +115,17 @@ class Challenge:
         return "rated" if self.rated else "casual"
 
     def __str__(self) -> str:
+        """A string representation of `Challenge`."""
         return f"{self.perf_name} {self.mode()} challenge from {self.challenger} ({self.id})"
 
     def __repr__(self) -> str:
+        """A string representation of `Challenge`."""
         return self.__str__()
 
 
 class Termination(str, Enum):
     """The possible game terminations."""
+
     MATE = "mate"
     TIMEOUT = "outoftime"
     RESIGN = "resign"
@@ -120,7 +134,10 @@ class Termination(str, Enum):
 
 
 class Game:
+    """Stores information about a game."""
+
     def __init__(self, game_info: Dict[str, Any], username: str, base_url: str, abort_time: int) -> None:
+        """:param abort_time: How long to wait before aborting the game."""
         self.username = username
         self.id: str = game_info["id"]
         self.speed = game_info.get("speed")
@@ -141,7 +158,7 @@ class Game:
         self.me = self.white if self.is_white else self.black
         self.opponent = self.black if self.is_white else self.white
         self.base_url = base_url
-        self.game_start = datetime.datetime.fromtimestamp(game_info["createdAt"]/1000, tz=datetime.timezone.utc)
+        self.game_start = datetime.datetime.fromtimestamp(game_info["createdAt"] / 1000, tz=datetime.timezone.utc)
         self.abort_time = Timer(abort_time)
         self.terminate_time = Timer((self.clock_initial + self.clock_increment) / 1000 + abort_time + 60)
         self.disconnect_time = Timer(0)
@@ -174,6 +191,7 @@ class Game:
     def ping(self, abort_in: int, terminate_in: int, disconnect_in: int) -> None:
         """
         Tells the bot when to abort, terminate, and disconnect from a game.
+
         :param abort_in: How many seconds to wait before aborting.
         :param terminate_in: How many seconds to wait before terminating.
         :param disconnect_in: How many seconds to wait before disconnecting.
@@ -224,17 +242,19 @@ class Game:
         return result.value
 
     def __str__(self) -> str:
+        """A string representation of `Game`."""
         return f"{self.url()} {self.perf_name} vs {self.opponent} ({self.id})"
 
     def __repr__(self) -> str:
+        """A string representation of `Game`."""
         return self.__str__()
 
 
 class Player:
+    """Stores information about a player."""
+
     def __init__(self, player_info: Dict[str, Any]) -> None:
-        """
-        :param player_info: Contains information about a player.
-        """
+        """:param player_info: Contains information about a player."""
         self.name: str = player_info.get("name", "")
         self.title = player_info.get("title")
         self.is_bot = self.title == "BOT"
@@ -243,6 +263,7 @@ class Player:
         self.aiLevel = player_info.get("aiLevel")
 
     def __str__(self) -> str:
+        """A string representation of `Player`."""
         if self.aiLevel:
             return f"AI level {self.aiLevel}"
         else:
@@ -250,4 +271,5 @@ class Player:
             return f'{self.title or ""} {self.name} ({rating})'.strip()
 
     def __repr__(self) -> str:
+        """A string representation of `Player`."""
         return self.__str__()

--- a/strategies.py
+++ b/strategies.py
@@ -1,4 +1,8 @@
-"""Some example strategies for people who want to create a custom, homemade bot."""
+"""
+Some example strategies for people who want to create a custom, homemade bot.
+
+With these classes, bot makers will not have to implement the UCI or XBoard interfaces themselves.
+"""
 
 from __future__ import annotations
 import chess

--- a/strategies.py
+++ b/strategies.py
@@ -17,11 +17,13 @@ class ExampleEngine(MinimalEngine):
 # Strategy names and ideas from tom7's excellent eloWorld video
 
 class RandomMove(ExampleEngine):
+    """Gets a random move."""
     def search(self, board: chess.Board, *args: Any) -> PlayResult:
         return PlayResult(random.choice(list(board.legal_moves)), None)
 
 
 class Alphabetical(ExampleEngine):
+    """Gets the first move when sorted by san representation."""
     def search(self, board: chess.Board, *args: Any) -> PlayResult:
         moves = list(board.legal_moves)
         moves.sort(key=board.san)
@@ -29,7 +31,7 @@ class Alphabetical(ExampleEngine):
 
 
 class FirstMove(ExampleEngine):
-    """Gets the first move when sorted by uci representation"""
+    """Gets the first move when sorted by uci representation."""
     def search(self, board: chess.Board, *args: Any) -> PlayResult:
         moves = list(board.legal_moves)
         moves.sort(key=str)

--- a/strategies.py
+++ b/strategies.py
@@ -17,28 +17,28 @@ class ExampleEngine(MinimalEngine):
 # Strategy names and ideas from tom7's excellent eloWorld video
 
 class RandomMove(ExampleEngine):
-    """Gets a random move."""
+    """Get a random move."""
 
     def search(self, board: chess.Board, *args: Any) -> PlayResult:
-        """Chooses a random move."""
+        """Choose a random move."""
         return PlayResult(random.choice(list(board.legal_moves)), None)
 
 
 class Alphabetical(ExampleEngine):
-    """Gets the first move when sorted by san representation."""
+    """Get the first move when sorted by san representation."""
 
     def search(self, board: chess.Board, *args: Any) -> PlayResult:
-        """Chooses the first move alphabetically."""
+        """Choose the first move alphabetically."""
         moves = list(board.legal_moves)
         moves.sort(key=board.san)
         return PlayResult(moves[0], None)
 
 
 class FirstMove(ExampleEngine):
-    """Gets the first move when sorted by uci representation."""
+    """Get the first move when sorted by uci representation."""
 
     def search(self, board: chess.Board, *args: Any) -> PlayResult:
-        """Chooses the first move alphabetically in uci representation."""
+        """Choose the first move alphabetically in uci representation."""
         moves = list(board.legal_moves)
         moves.sort(key=str)
         return PlayResult(moves[0], None)

--- a/strategies.py
+++ b/strategies.py
@@ -1,6 +1,4 @@
-"""
-Some example strategies for people who want to create a custom, homemade bot.
-"""
+"""Some example strategies for people who want to create a custom, homemade bot."""
 
 from __future__ import annotations
 import chess
@@ -11,6 +9,8 @@ from typing import Any
 
 
 class ExampleEngine(MinimalEngine):
+    """An example engine that all homemade engines inherit."""
+
     pass
 
 
@@ -18,13 +18,17 @@ class ExampleEngine(MinimalEngine):
 
 class RandomMove(ExampleEngine):
     """Gets a random move."""
+
     def search(self, board: chess.Board, *args: Any) -> PlayResult:
+        """Chooses a random move."""
         return PlayResult(random.choice(list(board.legal_moves)), None)
 
 
 class Alphabetical(ExampleEngine):
     """Gets the first move when sorted by san representation."""
+
     def search(self, board: chess.Board, *args: Any) -> PlayResult:
+        """Chooses the first move alphabetically."""
         moves = list(board.legal_moves)
         moves.sort(key=board.san)
         return PlayResult(moves[0], None)
@@ -32,7 +36,9 @@ class Alphabetical(ExampleEngine):
 
 class FirstMove(ExampleEngine):
     """Gets the first move when sorted by uci representation."""
+
     def search(self, board: chess.Board, *args: Any) -> PlayResult:
+        """Chooses the first move alphabetically in uci representation."""
         moves = list(board.legal_moves)
         moves.sort(key=str)
         return PlayResult(moves[0], None)

--- a/test_bot/__init__.py
+++ b/test_bot/__init__.py
@@ -1,0 +1,1 @@
+"""pytest won't search `test_bot/` if there is no `__init__.py` file."""

--- a/test_bot/conftest.py
+++ b/test_bot/conftest.py
@@ -1,11 +1,11 @@
-"""Removes files created when testing lichess-bot."""
+"""Remove files created when testing lichess-bot."""
 import shutil
 import os
 from typing import Any
 
 
 def pytest_sessionfinish(session: Any, exitstatus: Any) -> None:
-    """Removes files created when testing lichess-bot."""
+    """Remove files created when testing lichess-bot."""
     shutil.copyfile("correct_lichess.py", "lichess.py")
     os.remove("correct_lichess.py")
     if os.path.exists("TEMP"):

--- a/test_bot/conftest.py
+++ b/test_bot/conftest.py
@@ -4,6 +4,7 @@ from typing import Any
 
 
 def pytest_sessionfinish(session: Any, exitstatus: Any) -> None:
+    """Removes files created when testing lichess-bot."""
     shutil.copyfile("correct_lichess.py", "lichess.py")
     os.remove("correct_lichess.py")
     if os.path.exists("TEMP"):

--- a/test_bot/conftest.py
+++ b/test_bot/conftest.py
@@ -1,3 +1,4 @@
+"""Removes files created when testing lichess-bot."""
 import shutil
 import os
 from typing import Any

--- a/test_bot/lichess.py
+++ b/test_bot/lichess.py
@@ -1,3 +1,4 @@
+"""Imitates `lichess.py`. Used in tests."""
 import time
 import chess
 import chess.engine
@@ -7,10 +8,13 @@ from typing import Dict, Union, List, Optional, Generator
 
 class GameStream:
     """Imitates lichess.org's GameStream. Used in tests."""
+
     def __init__(self) -> None:
+        """Initializes `self.moves_sent` to an empty string. It stores the moves that we have already sent."""
         self.moves_sent = ""
 
     def iter_lines(self) -> Generator[bytes, None, None]:
+        """Sends the game events to lichess-bot."""
         yield json.dumps(
             {"id": "zzzzzzzz",
              "variant": {"key": "standard",
@@ -81,10 +85,13 @@ class GameStream:
 
 class EventStream:
     """Imitates lichess.org's EventStream. Used in tests."""
+
     def __init__(self, sent_game: bool = False) -> None:
+        """:param sent_game: If we have already sent the `gameStart` event, so we don't send it again."""
         self.sent_game = sent_game
 
     def iter_lines(self) -> Generator[bytes, None, None]:
+        """Sends the events to lichess-bot."""
         if self.sent_game:
             yield b''
             time.sleep(1)
@@ -100,13 +107,16 @@ class EventStream:
 # Docs: https://lichess.org/api.
 class Lichess:
     """Imitates communication with lichess.org."""
+
     def __init__(self, token: str, url: str, version: str) -> None:
+        """Has the same parameters as `lichess.Lichess` to be able to be used in its placed without any modification."""
         self.baseUrl = url
         self.game_accepted = False
         self.moves: List[chess.engine.PlayResult] = []
         self.sent_game = False
 
     def upgrade_to_bot_account(self) -> None:
+        """Isn't used in tests."""
         return
 
     def make_move(self, game_id: str, move: chess.engine.PlayResult) -> None:
@@ -120,26 +130,33 @@ class Lichess:
             file.write("\n".join(contents))
 
     def chat(self, game_id: str, room: str, text: str) -> None:
+        """Isn't used in tests."""
         return
 
     def abort(self, game_id: str) -> None:
+        """Isn't used in tests."""
         return
 
     def get_event_stream(self) -> EventStream:
+        """Sends the `EventStream`."""
         events = EventStream(self.sent_game)
         self.sent_game = True
         return events
 
     def get_game_stream(self, game_id: str) -> GameStream:
+        """Sends the `GameStream`."""
         return GameStream()
 
     def accept_challenge(self, challenge_id: str) -> None:
+        """Sets `self.game_accepted` to true."""
         self.game_accepted = True
 
     def decline_challenge(self, challenge_id: str, reason: str = "generic") -> None:
+        """Isn't used in tests."""
         return
 
     def get_profile(self) -> Dict[str, Union[str, bool, Dict[str, str]]]:
+        """Returns a simple profile for the bot that lichess-bot uses when testing."""
         return {"id": "b",
                 "username": "b",
                 "online": True,
@@ -152,12 +169,15 @@ class Lichess:
                 "perfs": {}}
 
     def get_ongoing_games(self) -> List[str]:
+        """Returns that the bot isn't playing a game."""
         return []
 
     def resign(self, game_id: str) -> None:
+        """Isn't used in tests."""
         return
 
     def get_game_pgn(self, game_id: str) -> str:
+        """Returns a simple PGN."""
         return """
 [Event "Test game"]
 [Site "pytest"]
@@ -171,16 +191,21 @@ class Lichess:
 """
 
     def get_online_bots(self) -> List[Dict[str, Union[str, bool]]]:
+        """Returns that the only bot online is us."""
         return [{"username": "b", "online": True}]
 
     def challenge(self, username: str, params: Dict[str, str]) -> None:
+        """Isn't used in tests."""
         return
 
     def cancel(self, challenge_id: str) -> None:
+        """Isn't used in tests."""
         return
 
     def online_book_get(self, path: str, params: Optional[Dict[str, str]] = None) -> None:
+        """Isn't used in tests."""
         return
 
     def is_online(self, user_id: str) -> bool:
+        """Returns that a bot is online."""
         return True

--- a/test_bot/lichess.py
+++ b/test_bot/lichess.py
@@ -1,4 +1,4 @@
-"""Imitates `lichess.py`. Used in tests."""
+"""Imitate `lichess.py`. Used in tests."""
 import time
 import chess
 import chess.engine
@@ -7,14 +7,14 @@ from typing import Dict, Union, List, Optional, Generator
 
 
 class GameStream:
-    """Imitates lichess.org's GameStream. Used in tests."""
+    """Imitate lichess.org's GameStream. Used in tests."""
 
     def __init__(self) -> None:
-        """Initializes `self.moves_sent` to an empty string. It stores the moves that we have already sent."""
+        """Initialize `self.moves_sent` to an empty string. It stores the moves that we have already sent."""
         self.moves_sent = ""
 
     def iter_lines(self) -> Generator[bytes, None, None]:
-        """Sends the game events to lichess-bot."""
+        """Send the game events to lichess-bot."""
         yield json.dumps(
             {"id": "zzzzzzzz",
              "variant": {"key": "standard",
@@ -84,14 +84,14 @@ class GameStream:
 
 
 class EventStream:
-    """Imitates lichess.org's EventStream. Used in tests."""
+    """Imitate lichess.org's EventStream. Used in tests."""
 
     def __init__(self, sent_game: bool = False) -> None:
         """:param sent_game: If we have already sent the `gameStart` event, so we don't send it again."""
         self.sent_game = sent_game
 
     def iter_lines(self) -> Generator[bytes, None, None]:
-        """Sends the events to lichess-bot."""
+        """Send the events to lichess-bot."""
         if self.sent_game:
             yield b''
             time.sleep(1)
@@ -106,7 +106,7 @@ class EventStream:
 
 # Docs: https://lichess.org/api.
 class Lichess:
-    """Imitates communication with lichess.org."""
+    """Imitate communication with lichess.org."""
 
     def __init__(self, token: str, url: str, version: str) -> None:
         """Has the same parameters as `lichess.Lichess` to be able to be used in its placed without any modification."""
@@ -120,7 +120,7 @@ class Lichess:
         return
 
     def make_move(self, game_id: str, move: chess.engine.PlayResult) -> None:
-        """Writes a move to `./logs/states.txt`, to be read by the opponent."""
+        """Write a move to `./logs/states.txt`, to be read by the opponent."""
         self.moves.append(move)
         uci_move = move.move.uci() if move.move else "error"
         with open("./logs/states.txt") as file:
@@ -138,17 +138,17 @@ class Lichess:
         return
 
     def get_event_stream(self) -> EventStream:
-        """Sends the `EventStream`."""
+        """Send the `EventStream`."""
         events = EventStream(self.sent_game)
         self.sent_game = True
         return events
 
     def get_game_stream(self, game_id: str) -> GameStream:
-        """Sends the `GameStream`."""
+        """Send the `GameStream`."""
         return GameStream()
 
     def accept_challenge(self, challenge_id: str) -> None:
-        """Sets `self.game_accepted` to true."""
+        """Set `self.game_accepted` to true."""
         self.game_accepted = True
 
     def decline_challenge(self, challenge_id: str, reason: str = "generic") -> None:
@@ -156,7 +156,7 @@ class Lichess:
         return
 
     def get_profile(self) -> Dict[str, Union[str, bool, Dict[str, str]]]:
-        """Returns a simple profile for the bot that lichess-bot uses when testing."""
+        """Return a simple profile for the bot that lichess-bot uses when testing."""
         return {"id": "b",
                 "username": "b",
                 "online": True,
@@ -169,7 +169,7 @@ class Lichess:
                 "perfs": {}}
 
     def get_ongoing_games(self) -> List[str]:
-        """Returns that the bot isn't playing a game."""
+        """Return that the bot isn't playing a game."""
         return []
 
     def resign(self, game_id: str) -> None:
@@ -177,7 +177,7 @@ class Lichess:
         return
 
     def get_game_pgn(self, game_id: str) -> str:
-        """Returns a simple PGN."""
+        """Return a simple PGN."""
         return """
 [Event "Test game"]
 [Site "pytest"]
@@ -191,7 +191,7 @@ class Lichess:
 """
 
     def get_online_bots(self) -> List[Dict[str, Union[str, bool]]]:
-        """Returns that the only bot online is us."""
+        """Return that the only bot online is us."""
         return [{"username": "b", "online": True}]
 
     def challenge(self, username: str, params: Dict[str, str]) -> None:
@@ -207,5 +207,5 @@ class Lichess:
         return
 
     def is_online(self, user_id: str) -> bool:
-        """Returns that a bot is online."""
+        """Return that a bot is online."""
         return True

--- a/test_bot/lichess.py
+++ b/test_bot/lichess.py
@@ -97,7 +97,7 @@ class EventStream:
                                      "board": True}}}).encode("utf-8")
 
 
-# docs: https://lichess.org/api
+# Docs: https://lichess.org/api.
 class Lichess:
     """Imitates communication with lichess.org."""
     def __init__(self, token: str, url: str, version: str) -> None:

--- a/test_bot/lichess.py
+++ b/test_bot/lichess.py
@@ -6,6 +6,7 @@ from typing import Dict, Union, List, Optional, Generator
 
 
 class GameStream:
+    """Imitates lichess.org's GameStream. Used in tests."""
     def __init__(self) -> None:
         self.moves_sent = ""
 
@@ -34,10 +35,10 @@ class GameStream:
              "type": "gameFull",
              "state": {"type": "gameState",
                        "moves": "",
-                       "wtime": 60000,
-                       "btime": 60000,
-                       "winc": 2000,
-                       "binc": 2000,
+                       "wtime": 10000,
+                       "btime": 10000,
+                       "winc": 100,
+                       "binc": 100,
                        "status": "started"}}).encode("utf-8")
         time.sleep(1)
         while True:
@@ -66,8 +67,8 @@ class GameStream:
                               "moves": moves,
                               "wtime": int(wtime_int * 1000),
                               "btime": int(wtime_int * 1000),
-                              "winc": 2000,
-                              "binc": 2000}
+                              "winc": 100,
+                              "binc": 100}
             if event == "end":
                 new_game_state["status"] = "outoftime"
                 new_game_state["winner"] = "black"
@@ -79,6 +80,7 @@ class GameStream:
 
 
 class EventStream:
+    """Imitates lichess.org's EventStream. Used in tests."""
     def __init__(self, sent_game: bool = False) -> None:
         self.sent_game = sent_game
 
@@ -97,6 +99,7 @@ class EventStream:
 
 # docs: https://lichess.org/api
 class Lichess:
+    """Imitates communication with lichess.org."""
     def __init__(self, token: str, url: str, version: str) -> None:
         self.baseUrl = url
         self.game_accepted = False
@@ -107,6 +110,7 @@ class Lichess:
         return
 
     def make_move(self, game_id: str, move: chess.engine.PlayResult) -> None:
+        """Writes a move to `./logs/states.txt`, to be read by the opponent."""
         self.moves.append(move)
         uci_move = move.move.uci() if move.move else "error"
         with open("./logs/states.txt") as file:

--- a/test_bot/test_bot.py
+++ b/test_bot/test_bot.py
@@ -1,3 +1,4 @@
+"""Tests lichess-bot."""
 import pytest
 import zipfile
 import requests

--- a/test_bot/test_bot.py
+++ b/test_bot/test_bot.py
@@ -120,7 +120,7 @@ def thread_for_test() -> None:
             with open("./logs/states.txt", "w") as file:
                 file.write(state_str)
 
-        else:  # lichess-bot move
+        else:  # lichess-bot move.
             start_time = time.perf_counter_ns()
             state2 = state_str
             moves_are_correct = False

--- a/test_bot/test_bot.py
+++ b/test_bot/test_bot.py
@@ -1,4 +1,4 @@
-"""Tests lichess-bot."""
+"""Test lichess-bot."""
 import pytest
 import zipfile
 import requests
@@ -26,7 +26,7 @@ stockfish_path = f"./TEMP/sf{file_extension}"
 
 
 def download_sf() -> None:
-    """Downloads Stockfish 14.1."""
+    """Download Stockfish 14.1."""
     windows_or_linux = "win" if platform == "win32" else "linux"
     base_name = f"stockfish_14.1_{windows_or_linux}_x64"
     zip_link = f"https://stockfishchess.org/files/{base_name}.zip"
@@ -42,7 +42,7 @@ def download_sf() -> None:
 
 
 def download_lc0() -> None:
-    """Downloads Leela Chess Zero 0.29.0."""
+    """Download Leela Chess Zero 0.29.0."""
     response = requests.get("https://github.com/LeelaChessZero/lc0/releases/download/v0.29.0/lc0-v0.29.0-windows-cpu-dnnl.zip",
                             allow_redirects=True)
     with open("./TEMP/lc0_zip.zip", "wb") as file:
@@ -52,7 +52,7 @@ def download_lc0() -> None:
 
 
 def download_sjeng() -> None:
-    """Downloads Sjeng."""
+    """Download Sjeng."""
     response = requests.get("https://sjeng.org/ftp/Sjeng112.zip", allow_redirects=True)
     with open("./TEMP/sjeng_zip.zip", "wb") as file:
         file.write(response.content)
@@ -74,7 +74,7 @@ lichess_bot.logger.info("Downloaded engines")
 
 
 def thread_for_test() -> None:
-    """Plays the moves for the opponent of lichess-bot."""
+    """Play the moves for the opponent of lichess-bot."""
     open("./logs/events.txt", "w").close()
     open("./logs/states.txt", "w").close()
     open("./logs/result.txt", "w").close()
@@ -165,7 +165,7 @@ def thread_for_test() -> None:
 
 
 def run_bot(raw_config: Dict[str, Any], logging_level: int) -> str:
-    """Starts lichess-bot."""
+    """Start lichess-bot."""
     config.insert_default_values(raw_config)
     CONFIG = config.Configuration(raw_config)
     lichess_bot.logger.info(lichess_bot.intro())
@@ -190,7 +190,7 @@ def run_bot(raw_config: Dict[str, Any], logging_level: int) -> str:
 
 @pytest.mark.timeout(150, method="thread")
 def test_sf() -> None:
-    """Tests lichess-bot with Stockfish (UCI)."""
+    """Test lichess-bot with Stockfish (UCI)."""
     if platform != "linux" and platform != "win32":
         assert True
         return
@@ -214,7 +214,7 @@ def test_sf() -> None:
 
 @pytest.mark.timeout(150, method="thread")
 def test_lc0() -> None:
-    """Tests lichess-bot with Leela Chess Zero (UCI)."""
+    """Test lichess-bot with Leela Chess Zero (UCI)."""
     if platform != "win32":
         assert True
         return
@@ -241,7 +241,7 @@ def test_lc0() -> None:
 
 @pytest.mark.timeout(150, method="thread")
 def test_sjeng() -> None:
-    """Tests lichess-bot with Sjeng (XBoard)."""
+    """Test lichess-bot with Sjeng (XBoard)."""
     if platform != "win32":
         assert True
         return
@@ -267,7 +267,7 @@ def test_sjeng() -> None:
 
 @pytest.mark.timeout(150, method="thread")
 def test_homemade() -> None:
-    """Tests lichess-bot with a homemade engine running Stockfish (Homemade)."""
+    """Test lichess-bot with a homemade engine running Stockfish (Homemade)."""
     if platform != "linux" and platform != "win32":
         assert True
         return

--- a/test_bot/test_bot.py
+++ b/test_bot/test_bot.py
@@ -25,6 +25,7 @@ stockfish_path = f"./TEMP/sf{file_extension}"
 
 
 def download_sf() -> None:
+    """Downloads Stockfish 14.1."""
     windows_or_linux = "win" if platform == "win32" else "linux"
     base_name = f"stockfish_14.1_{windows_or_linux}_x64"
     zip_link = f"https://stockfishchess.org/files/{base_name}.zip"
@@ -40,6 +41,7 @@ def download_sf() -> None:
 
 
 def download_lc0() -> None:
+    """Downloads Leela Chess Zero 0.29.0."""
     response = requests.get("https://github.com/LeelaChessZero/lc0/releases/download/v0.29.0/lc0-v0.29.0-windows-cpu-dnnl.zip",
                             allow_redirects=True)
     with open("./TEMP/lc0_zip.zip", "wb") as file:
@@ -49,6 +51,7 @@ def download_lc0() -> None:
 
 
 def download_sjeng() -> None:
+    """Downloads Sjeng."""
     response = requests.get("https://sjeng.org/ftp/Sjeng112.zip", allow_redirects=True)
     with open("./TEMP/sjeng_zip.zip", "wb") as file:
         file.write(response.content)
@@ -70,6 +73,7 @@ lichess_bot.logger.info("Downloaded engines")
 
 
 def thread_for_test() -> None:
+    """Plays the moves for the opponent of lichess-bot."""
     open("./logs/events.txt", "w").close()
     open("./logs/states.txt", "w").close()
     open("./logs/result.txt", "w").close()
@@ -160,6 +164,7 @@ def thread_for_test() -> None:
 
 
 def run_bot(raw_config: Dict[str, Any], logging_level: int) -> str:
+    """Starts lichess-bot."""
     config.insert_default_values(raw_config)
     CONFIG = config.Configuration(raw_config)
     lichess_bot.logger.info(lichess_bot.intro())
@@ -184,6 +189,7 @@ def run_bot(raw_config: Dict[str, Any], logging_level: int) -> str:
 
 @pytest.mark.timeout(150, method="thread")
 def test_sf() -> None:
+    """Tests lichess-bot with Stockfish (UCI)."""
     if platform != "linux" and platform != "win32":
         assert True
         return
@@ -207,6 +213,7 @@ def test_sf() -> None:
 
 @pytest.mark.timeout(150, method="thread")
 def test_lc0() -> None:
+    """Tests lichess-bot with Leela Chess Zero (UCI)."""
     if platform != "win32":
         assert True
         return
@@ -233,6 +240,7 @@ def test_lc0() -> None:
 
 @pytest.mark.timeout(150, method="thread")
 def test_sjeng() -> None:
+    """Tests lichess-bot with Sjeng (XBoard)."""
     if platform != "win32":
         assert True
         return
@@ -258,6 +266,7 @@ def test_sjeng() -> None:
 
 @pytest.mark.timeout(150, method="thread")
 def test_homemade() -> None:
+    """Tests lichess-bot with a homemade engine running Stockfish (Homemade)."""
     if platform != "linux" and platform != "win32":
         assert True
         return

--- a/timer.py
+++ b/timer.py
@@ -9,7 +9,7 @@ class Timer:
 
     def __init__(self, duration: float = 0, backdated_start: Optional[datetime.datetime] = None) -> None:
         """
-        A timer for use in lichess-bot.
+        Start the timer.
 
         :param duration: The duration of the timer.
         :param backdated_start: When the timer started. Used to keep the timers between sessions.
@@ -21,11 +21,11 @@ class Timer:
             self.starting_time -= time_already_used.total_seconds()
 
     def is_expired(self) -> bool:
-        """Checks if a timer is expired."""
+        """Check if a timer is expired."""
         return self.time_since_reset() >= self.duration
 
     def reset(self) -> None:
-        """Resets the timer."""
+        """Reset the timer."""
         self.starting_time = time.time()
 
     def time_since_reset(self) -> float:
@@ -37,5 +37,5 @@ class Timer:
         return max(0., self.duration - self.time_since_reset())
 
     def starting_timestamp(self) -> datetime.datetime:
-        """A timestamp of when the timer started."""
+        """When the timer started."""
         return datetime.datetime.now() - datetime.timedelta(seconds=self.time_since_reset())

--- a/timer.py
+++ b/timer.py
@@ -5,6 +5,10 @@ from typing import Optional
 
 class Timer:
     def __init__(self, duration: float = 0, backdated_start: Optional[datetime.datetime] = None) -> None:
+        """
+        :param duration: The duration of the timer.
+        :param backdated_start: When the timer started. Used to keep the timers between sessions.
+        """
         self.duration = duration
         self.reset()
         if backdated_start:
@@ -12,16 +16,21 @@ class Timer:
             self.starting_time -= time_already_used.total_seconds()
 
     def is_expired(self) -> bool:
+        """Checks if a timer is expired."""
         return self.time_since_reset() >= self.duration
 
     def reset(self) -> None:
+        """Resets the timer."""
         self.starting_time = time.time()
 
     def time_since_reset(self) -> float:
+        """How much time has passed."""
         return time.time() - self.starting_time
 
     def time_until_expiration(self) -> float:
+        """How much time is left until it expires."""
         return max(0., self.duration - self.time_since_reset())
 
     def starting_timestamp(self) -> datetime.datetime:
+        """A timestamp of when the timer started."""
         return datetime.datetime.now() - datetime.timedelta(seconds=self.time_since_reset())

--- a/timer.py
+++ b/timer.py
@@ -1,11 +1,16 @@
+"""A timer for use in lichess-bot."""
 import time
 import datetime
 from typing import Optional
 
 
 class Timer:
+    """A timer for use in lichess-bot."""
+
     def __init__(self, duration: float = 0, backdated_start: Optional[datetime.datetime] = None) -> None:
         """
+        A timer for use in lichess-bot.
+
         :param duration: The duration of the timer.
         :param backdated_start: When the timer started. Used to keep the timers between sessions.
         """


### PR DESCRIPTION
Not every parameter has a `:param parameter: parameter description` because I thought that some are self-explanatory. Some parameters are explained in some other parts of the code, so I didn't add a description to avoid repetition. If you think something else needs explaining I will add it. I'm not sure if all the descriptions are correct (mostly for the logging code at the start of `lichess-bot.py`, and the filters at the start of `config.py`).

Uses `flake8-docstrings` which uses PEP257 to find errors in the docstrings. It finds 158 D401 errors.
EDIT: Fixed the errors.