### PR TITLE
Simplify versioning

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -10,8 +10,6 @@ on:
 
 jobs:
   mypy:
-    if: "github.event_name == 'pull_request' || contains(github.event.head_commit.message, 'Auto update version')"
-
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -11,8 +11,6 @@ on:
 
 jobs:
   build:
-    if: "github.event_name == 'pull_request' || contains(github.event.head_commit.message, 'Auto update version')"
-
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -11,8 +11,6 @@ on:
 
 jobs:
   test:
-    if: "github.event_name == 'pull_request' || contains(github.event.head_commit.message, 'Auto update version')"
-
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -6,12 +6,9 @@ on:
 
 jobs:
   versioning:
-      if: "!contains(github.event.head_commit.message, 'Auto update version')"
       runs-on: ubuntu-latest
       steps:
       - uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.VERSION_BOT_TOKEN }}
       - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
If we run `versioning.yml` without a person access token, then github will understand that this is an automated action and won't run workflows on the new commit.