### PR TITLE
Remove all calls to SimpleEngine.protocol.send_line()

### DIFF
--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -163,8 +163,6 @@ class EngineWrapper:
                                         start_time,
                                         move_overhead,
                                         best_move)
-        else:
-            self.stop()
 
         self.add_comment(best_move, board)
         self.print_stats()

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -55,7 +55,6 @@ def create_engine(engine_config: config.Configuration) -> Generator[EngineWrappe
     try:
         yield engine
     finally:
-        engine.stop()
         engine.ping()
         engine.quit()
 
@@ -353,9 +352,6 @@ class EngineWrapper:
     def report_game_result(self, game: model.Game, board: chess.Board) -> None:
         pass
 
-    def stop(self) -> None:
-        pass
-
     def get_pid(self) -> str:
         pid = "?"
         if self.engine.transport is not None:
@@ -377,9 +373,6 @@ class UCIEngine(EngineWrapper):
         self.engine = chess.engine.SimpleEngine.popen_uci(commands, timeout=10., debug=False, setpgrp=False, stderr=stderr,
                                                           **popen_args)
         self.engine.configure(options)
-
-    def stop(self) -> None:
-        self.engine.protocol.send_line("stop")
 
     def get_opponent_info(self, game: model.Game) -> None:
         name = game.opponent.name
@@ -424,9 +417,6 @@ class XBoardEngine(EngineWrapper):
             endgame_message = " {" + endgame_message + "}"
 
         self.engine.protocol.send_line(f"result {game.result()}{endgame_message}")
-
-    def stop(self) -> None:
-        self.engine.protocol.send_line("?")
 
     def get_opponent_info(self, game: model.Game) -> None:
         if (game.opponent.name and isinstance(self.engine.protocol, chess.engine.XBoardProtocol) and

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -398,16 +398,6 @@ class XBoardEngine(EngineWrapper):
                     logger.debug(f"No paths found for egt type: {egt_type}.")
         self.engine.configure(options)
 
-    def get_opponent_info(self, game: model.Game) -> None:
-        if (game.opponent.name and isinstance(self.engine.protocol, chess.engine.XBoardProtocol) and
-                self.engine.protocol.features.get("name", True)):
-            title = f"{game.opponent.title} " if game.opponent.title else ""
-            self.engine.protocol.send_line(f"name {title}{game.opponent.name}")
-        if game.me.rating and game.opponent.rating:
-            self.engine.protocol.send_line(f"rating {game.me.rating} {game.opponent.rating}")
-        if game.opponent.title == "BOT":
-            self.engine.protocol.send_line("computer")
-
 
 class MinimalEngine(EngineWrapper):
     """

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -505,7 +505,6 @@ def play_game(li: lichess.Lichess,
                                          engine_cfg)
                         time.sleep(delay_seconds)
                     elif is_game_over(game):
-                        engine.report_game_result(game, board)
                         tell_user_game_result(game, board)
                         conversation.send_message("player", goodbye)
                         conversation.send_message("spectator", goodbye_spectators)


### PR DESCRIPTION
It is incorrect to call the method `SimpleEngine.protocol.send_line()` outside the context of the event loop used within the other `SimpleEngine` methods. Within lichess-bot, these calls are found within the methods `stop()` and recursively in `report_game_result()` for both `UCIEngine`. In about 10% of `play_game()` threads when lichess-bot is run on Windows, something doesn't get shut down correctly after the game finishes and the debug logged gets spammed by these messages once per second forever:
```
<IocpProactor overlapped#=1 result#=0> is running after closing for 1.0 seconds
<IocpProactor overlapped#=1 result#=0> is running after closing for 2.0 seconds
<IocpProactor overlapped#=1 result#=0> is running after closing for 3.0 seconds
...
```
After deleting the methods, these messages no longer appear in the logs.

`XBoardEngine.get_opponent_info()` also has this problem, but it will be fixed with PR #657.

The main consequence of this change is that the final moves in a game will not be sent to the engines and `result` (e.g., `result 1-0 {White mates}`) commands will not be sent to XBoard engines. I don't think this is a big deal since PGN files are written out after every game if the user chooses. I'll probably create a PR in python-chess to restore this behavior at a later date.

Another consequence--specifically from deleting the `stop()` command on line 168 of engine_wrapper.py in the `play_move()` method--is that a pondering engine will not be stopped if a book/online move is found. I don't think this will happen with any frequency since it should be rare that a position with no book/db entry (resulting in an engine move with pondering) is followed by a position that has an entry.