### PR TITLE
Merge block list into challenge filters

### DIFF
--- a/matchmaking.py
+++ b/matchmaking.py
@@ -251,12 +251,28 @@ class Matchmaking:
         self.add_challenge_filter(username, "")
 
     def in_block_list(self, username: str) -> bool:
+        """Check if an opponent is in the block list to prevent future challenges."""
         return not self.should_accept_challenge(username, "")
 
     def add_challenge_filter(self, username: str, game_aspect: str) -> None:
+        """
+        Prevent creating another challenge when an opponent has decline a challenge.
+
+        :param username: The name of the opponent.
+        :param game_aspect: The aspect of a game (time control, chess variant, etc.)
+        that caused the opponent to decline a challenge. If the parameter is empty,
+        that is equivalent to adding the opponent to the block list.
+        """
         self.challenge_type_acceptable[(username, game_aspect)] = False
 
     def should_accept_challenge(self, username: str, game_aspect: str) -> bool:
+        """
+        Whether a bot is likely to accept a challenge to a game.
+
+        :param username: The name of the opponent.
+        :param game_aspect: A category of the challenge type (time control, chess variant, etc.) to test for acceptance.
+        If game_aspect is empty, this is equivalent to checking if the opponent is in the block list.
+        """
         return self.challenge_type_acceptable[(username, game_aspect)]
 
     def accepted_challenge(self, event: EVENT_TYPE) -> None:

--- a/matchmaking.py
+++ b/matchmaking.py
@@ -247,7 +247,6 @@ class Matchmaking:
 
     def add_to_block_list(self, username: str) -> None:
         """Add a bot to the blocklist."""
-        logger.info(f"Will not challenge {username} again during this session.")
         self.add_challenge_filter(username, "")
 
     def in_block_list(self, username: str) -> bool:

--- a/matchmaking.py
+++ b/matchmaking.py
@@ -253,8 +253,8 @@ class Matchmaking:
     def in_block_list(self, username: str) -> bool:
         return not self.should_accept_challenge(username, "")
 
-    def add_challenge_filter(self, username: str, reason: str) -> None:
-        self.challenge_type_acceptable[(username, reason)] = False
+    def add_challenge_filter(self, username: str, game_aspect: str) -> None:
+        self.challenge_type_acceptable[(username, game_aspect)] = False
 
     def should_accept_challenge(self, username: str, game_aspect: str) -> bool:
         return self.challenge_type_acceptable[(username, game_aspect)]


### PR DESCRIPTION
Now that the matchmaking challenge filters use `bool` instead of `Timer`, there is no need for a separate block list in the Matchmaking class.

Also, add more methods to make filtering easier to work with.