### PR TITLE
Refactor engine move search functions and methods

### DIFF
--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -262,7 +262,6 @@ class EngineWrapper:
         :return: The move to play.
         """
         time_limit = self.add_go_commands(time_limit)
-        result: chess.engine.PlayResult
         result = self.engine.play(board,
                                   time_limit,
                                   info=chess.engine.INFO_ALL,


### PR DESCRIPTION
No change in behavior. The refactoring took place in steps:

1. Since each of the `EngineWrapper.search_*()` methods consisted of creating a `chess.engine.Limit` before calling `EngineWrapper.search()`, move the `Limit` creation to the `choose_*_move()` free functions called from `EngineWrapper.play_move()` and call `search()` from there.
2. All the various `choose_*_move()` free functions do is create a `Limit` and call `EngineWrapper.search()`. So, remove the call to `search()` and have these functions return the `Limit`. Call `search()` once within `play_move()` with the appropriate time limit.

The result is a reduction in repeated code and the number of arguments being passed around.