### PR TITLE
Fix difference in Linux/Windows handling of cwd

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Within the file `config.yml`:
 - Enter the executable name in the `engine: name` field (In Windows you may need to type a name with ".exe", like "lczero.exe")
 - If you want the engine to run in a different directory (e.g., if the engine needs to read or write files at a certain location), enter that directory in the `engine: working_dir` field.
   - If this field is blank or missing, the current directory will be used.
+  - IMPORTANT NOTE: If this field is used, the running engine will look for files and directories (Syzygy tablebases, for example) relative to this path, not the `engine: dir` field.
 - Leave the `weights` field empty or see [LeelaChessZero section](#leelachesszero) for Neural Nets
 
 As an optional convenience, there is a folder named `engines` within the lichess-bot folder where you can copy your engine and all the files it needs. This is the default executable location in the `config.yml.default` file.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Within the file `config.yml`:
 - Enter the executable name in the `engine: name` field (In Windows you may need to type a name with ".exe", like "lczero.exe")
 - If you want the engine to run in a different directory (e.g., if the engine needs to read or write files at a certain location), enter that directory in the `engine: working_dir` field.
   - If this field is blank or missing, the current directory will be used.
-  - IMPORTANT NOTE: If this field is used, the running engine will look for files and directories (Syzygy tablebases, for example) relative to this path, not the `engine: dir` field.
+  - IMPORTANT NOTE: If this field is used, the running engine will look for files and directories (Syzygy tablebases, for example) relative to this path, not the directory where lichess-bot was launched. Files and folders specified with absolute paths are unaffected.
 - Leave the `weights` field empty or see [LeelaChessZero section](#leelachesszero) for Neural Nets
 
 As an optional convenience, there is a folder named `engines` within the lichess-bot folder where you can copy your engine and all the files it needs. This is the default executable location in the `config.yml.default` file.

--- a/config.yml.default
+++ b/config.yml.default
@@ -5,6 +5,7 @@ engine:                      # Engine settings.
   dir: "./engines/"          # Directory containing the engine. This can be an absolute path or one relative to lichess-bot/.
   name: "engine_name"        # Binary name of the engine to use.
   working_dir: ""            # Directory where the chess engine will read and write files. If blank or missing, the current directory is used.
+                             # NOTE: If working_dir is set, the engine will look for files and directories relative to this directory, not the engine: dir directory.
   protocol: "uci"            # "uci", "xboard" or "homemade"
   ponder: true               # Think on opponent's time.
 

--- a/config.yml.default
+++ b/config.yml.default
@@ -5,7 +5,7 @@ engine:                      # Engine settings.
   dir: "./engines/"          # Directory containing the engine. This can be an absolute path or one relative to lichess-bot/.
   name: "engine_name"        # Binary name of the engine to use.
   working_dir: ""            # Directory where the chess engine will read and write files. If blank or missing, the current directory is used.
-                             # NOTE: If working_dir is set, the engine will look for files and directories relative to this directory, not the engine: dir directory.
+                             # NOTE: If working_dir is set, the engine will look for files and directories relative to this directory, not where lichess-bot was launched. Absolute paths are unaffected.
   protocol: "uci"            # "uci", "xboard" or "homemade"
   ponder: true               # Think on opponent's time.
 

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -40,7 +40,7 @@ def create_engine(engine_config: config.Configuration) -> Generator[EngineWrappe
     :return: An engine. Either UCI, XBoard, or Homemade.
     """
     cfg = engine_config.engine
-    engine_path = os.path.join(cfg.dir, cfg.name)
+    engine_path = os.path.abspath(os.path.join(cfg.dir, cfg.name))
     engine_type = cfg.protocol
     commands = [engine_path]
     if cfg.engine_options:


### PR DESCRIPTION
When a user has the engine: working_dir: field set in their config file, the behavior of popen when opening the engine executable is different on Windows and Linux. In Linux, the current working directory (cwd) is changed before starting the executable. In Windows, it's the reverse. This means that Linux clients will not be able to find the executable if engine: working_dir is different than the cwd when lichess-bot starts.

These changes fix the problem by making the path to the engine absolute before starting the process. Also, the documentation is updated to notify users that the cwd change means relative paths to files are now relative to the working_dir.

Closes #707