### PR TITLE
Update README.md due to PEP 668

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A bridge between [Lichess Bot API](https://lichess.org/api#tag/Bot) and bots.
 - Navigate to the directory in cmd/Terminal: `cd lichess-bot`.
 - Install pip: `apt install python3-pip`.
   - In non-Ubuntu distros, replace `apt` with the correct package manager (`pacman` in Arch, `dnf` in Fedora, `brew` in Mac, etc.), package name, and installation command.
-- Install virtualenv: `pip install virtualenv`.
+- Install virtualenv: `apt install python3-virtualenv`.
 - Setup virtualenv: `apt install python3-venv`.
 ```
 python3 -m venv venv # If this fails you probably need to add Python3 to your PATH.


### PR DESCRIPTION
Due to conflicts with python modules that are installed from Linux package managers, some Python modules can't be installed through `pip` outside of a virtual environment. Due to [PEP 668](https://peps.python.org/pep-0668/), attempting to use `pip` to install `virtualenv` will fail with a warning about the module being "externally managed." This change updates the README to change the instructions for installing `virtualenv` from `pip` to the OS package manager.