### PR TITLE
Do not run versioning.yml in forks

### DIFF
--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   versioning:
+      if: "!contains(github.event.head_commit.message, 'Auto update version')"
       runs-on: ubuntu-latest
       steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
When a fork is synced with `lichess-bot-devs/lichess-bot` the workflows are run, and `versioning.yml` fails. Can also act as a failsafe if GitHub ever changes its behavior on when workflows are run.