### PR TITLE
Print traceback & function parameters when backing off

### DIFF
--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -506,7 +506,8 @@ def handle_challenge(event: EVENT_TYPE, li: lichess.Lichess, challenge_queue: MU
         li.decline_challenge(chlng.id, reason=decline_reason)
 
 
-@backoff.on_exception(backoff.expo, BaseException, max_time=600, giveup=is_final)  # type: ignore[arg-type]
+@backoff.on_exception(backoff.expo, BaseException, max_time=600, giveup=is_final,  # type: ignore[arg-type]
+                      on_backoff=lichess.backoff_handler)
 def play_game(li: lichess.Lichess,
               game_id: str,
               control_queue: CONTROL_QUEUE_TYPE,

--- a/lichess.py
+++ b/lichess.py
@@ -13,6 +13,7 @@ from typing import Optional, Union, Any
 import chess.engine
 JSON_REPLY_TYPE = dict[str, Any]
 REQUESTS_PAYLOAD_TYPE = dict[str, Any]
+BACKOFF_DETAILS_TYPE = dict[str, Any]
 
 ENDPOINTS = {
     "profile": "/api/account",
@@ -57,7 +58,7 @@ def is_final(exception: Exception) -> bool:
     return isinstance(exception, HTTPError) and exception.response.status_code < 500
 
 
-def backoff_handler(details):
+def backoff_handler(details: BACKOFF_DETAILS_TYPE) -> None:
     logger.debug("Backing off {wait:0.1f} seconds after {tries} tries "
                  "calling function {target} with args {args} and kwargs {kwargs}".format(**details))
     logger.debug(f"Exception: {traceback.format_exc()}")

--- a/lichess.py
+++ b/lichess.py
@@ -13,7 +13,6 @@ from typing import Optional, Union, Any
 import chess.engine
 JSON_REPLY_TYPE = dict[str, Any]
 REQUESTS_PAYLOAD_TYPE = dict[str, Any]
-BACKOFF_DETAILS_TYPE = dict[str, Any]
 
 ENDPOINTS = {
     "profile": "/api/account",
@@ -58,7 +57,7 @@ def is_final(exception: Exception) -> bool:
     return isinstance(exception, HTTPError) and exception.response.status_code < 500
 
 
-def backoff_handler(details: BACKOFF_DETAILS_TYPE) -> None:
+def backoff_handler(details: Any) -> None:
     logger.debug("Backing off {wait:0.1f} seconds after {tries} tries "
                  "calling function {target} with args {args} and kwargs {kwargs}".format(**details))
     logger.debug(f"Exception: {traceback.format_exc()}")

--- a/lichess.py
+++ b/lichess.py
@@ -58,6 +58,7 @@ def is_final(exception: Exception) -> bool:
 
 
 def backoff_handler(details: Any) -> None:
+    """Log exceptions inside functions with the backoff decorator."""
     logger.debug("Backing off {wait:0.1f} seconds after {tries} tries "
                  "calling function {target} with args {args} and kwargs {kwargs}".format(**details))
     logger.debug(f"Exception: {traceback.format_exc()}")

--- a/test_bot/lichess.py
+++ b/test_bot/lichess.py
@@ -11,6 +11,7 @@ logger = logging.getLogger(__name__)
 
 
 def backoff_handler(details: Any) -> None:
+    """Log exceptions inside functions with the backoff decorator."""
     logger.debug("Backing off {wait:0.1f} seconds after {tries} tries "
                  "calling function {target} with args {args} and kwargs {kwargs}".format(**details))
     logger.debug(f"Exception: {traceback.format_exc()}")

--- a/test_bot/lichess.py
+++ b/test_bot/lichess.py
@@ -3,7 +3,18 @@ import time
 import chess
 import chess.engine
 import json
-from typing import Dict, Union, List, Optional, Generator
+import logging
+import traceback
+from typing import Union, Any, Optional, Generator
+BACKOFF_DETAILS_TYPE = dict[str, Any]
+
+logger = logging.getLogger(__name__)
+
+
+def backoff_handler(details: BACKOFF_DETAILS_TYPE) -> None:
+    logger.debug("Backing off {wait:0.1f} seconds after {tries} tries "
+                 "calling function {target} with args {args} and kwargs {kwargs}".format(**details))
+    logger.debug(f"Exception: {traceback.format_exc()}")
 
 
 class GameStream:
@@ -112,7 +123,7 @@ class Lichess:
         """Has the same parameters as `lichess.Lichess` to be able to be used in its placed without any modification."""
         self.baseUrl = url
         self.game_accepted = False
-        self.moves: List[chess.engine.PlayResult] = []
+        self.moves: list[chess.engine.PlayResult] = []
         self.sent_game = False
 
     def upgrade_to_bot_account(self) -> None:
@@ -155,7 +166,7 @@ class Lichess:
         """Isn't used in tests."""
         return
 
-    def get_profile(self) -> Dict[str, Union[str, bool, Dict[str, str]]]:
+    def get_profile(self) -> dict[str, Union[str, bool, dict[str, str]]]:
         """Return a simple profile for the bot that lichess-bot uses when testing."""
         return {"id": "b",
                 "username": "b",
@@ -168,7 +179,7 @@ class Lichess:
                 "followsYou": False,
                 "perfs": {}}
 
-    def get_ongoing_games(self) -> List[str]:
+    def get_ongoing_games(self) -> list[str]:
         """Return that the bot isn't playing a game."""
         return []
 
@@ -190,11 +201,11 @@ class Lichess:
 *
 """
 
-    def get_online_bots(self) -> List[Dict[str, Union[str, bool]]]:
+    def get_online_bots(self) -> list[dict[str, Union[str, bool]]]:
         """Return that the only bot online is us."""
         return [{"username": "b", "online": True}]
 
-    def challenge(self, username: str, params: Dict[str, str]) -> None:
+    def challenge(self, username: str, params: dict[str, str]) -> None:
         """Isn't used in tests."""
         return
 
@@ -202,7 +213,7 @@ class Lichess:
         """Isn't used in tests."""
         return
 
-    def online_book_get(self, path: str, params: Optional[Dict[str, str]] = None) -> None:
+    def online_book_get(self, path: str, params: Optional[dict[str, str]] = None) -> None:
         """Isn't used in tests."""
         return
 

--- a/test_bot/lichess.py
+++ b/test_bot/lichess.py
@@ -6,12 +6,11 @@ import json
 import logging
 import traceback
 from typing import Union, Any, Optional, Generator
-BACKOFF_DETAILS_TYPE = dict[str, Any]
 
 logger = logging.getLogger(__name__)
 
 
-def backoff_handler(details: BACKOFF_DETAILS_TYPE) -> None:
+def backoff_handler(details: Any) -> None:
     logger.debug("Backing off {wait:0.1f} seconds after {tries} tries "
                  "calling function {target} with args {args} and kwargs {kwargs}".format(**details))
     logger.debug(f"Exception: {traceback.format_exc()}")

--- a/test_bot/test_bot.py
+++ b/test_bot/test_bot.py
@@ -13,7 +13,7 @@ import stat
 import shutil
 import importlib
 import config
-from typing import Dict, Any
+from typing import Any
 if __name__ == "__main__":
     sys.exit(f"The script {os.path.basename(__file__)} should only be run by pytest.")
 shutil.copyfile("lichess.py", "correct_lichess.py")
@@ -69,7 +69,7 @@ if platform == "win32":
     download_lc0()
     download_sjeng()
 logging_level = lichess_bot.logging.DEBUG
-lichess_bot.logging_configurer(logging_level, None)
+lichess_bot.logging_configurer(logging_level, None, None)
 lichess_bot.logger.info("Downloaded engines")
 
 
@@ -164,7 +164,7 @@ def thread_for_test() -> None:
         file.write("1" if win else "0")
 
 
-def run_bot(raw_config: Dict[str, Any], logging_level: int) -> str:
+def run_bot(raw_config: dict[str, Any], logging_level: int) -> str:
     """Start lichess-bot."""
     config.insert_default_values(raw_config)
     CONFIG = config.Configuration(raw_config)
@@ -180,7 +180,7 @@ def run_bot(raw_config: Dict[str, Any], logging_level: int) -> str:
 
     thr = threading.Thread(target=thread_for_test)
     thr.start()
-    lichess_bot.start(li, user_profile, CONFIG, logging_level, None, one_game=True)
+    lichess_bot.start(li, user_profile, CONFIG, logging_level, None, None, one_game=True)
     thr.join()
 
     with open("./logs/result.txt") as file:

--- a/test_bot/test_bot.py
+++ b/test_bot/test_bot.py
@@ -69,7 +69,7 @@ if platform == "win32":
     download_lc0()
     download_sjeng()
 logging_level = lichess_bot.logging.DEBUG
-lichess_bot.logging_configurer(logging_level, None, None)
+lichess_bot.logging_configurer(logging_level, None)
 lichess_bot.logger.info("Downloaded engines")
 
 
@@ -180,7 +180,7 @@ def run_bot(raw_config: dict[str, Any], logging_level: int) -> str:
 
     thr = threading.Thread(target=thread_for_test)
     thr.start()
-    lichess_bot.start(li, user_profile, CONFIG, logging_level, None, None, one_game=True)
+    lichess_bot.start(li, user_profile, CONFIG, logging_level, None, one_game=True)
     thr.join()
 
     with open("./logs/result.txt") as file:


### PR DESCRIPTION
This will make debugging easier. For example in #732 we only get `2023-06-13 22:00:20,075 backoff INFO Backing off play_game(...) for 3.3s (ValueError: end of string while looking for conversion specifier)` instead of the full traceback.