### PR TITLE
Fix token test

### DIFF
--- a/lichess.py
+++ b/lichess.py
@@ -90,7 +90,7 @@ class Lichess:
             raise RuntimeError("Token in config file is not recognized by lichess. "
                                "Please check that it was copied correctly into your configuration file.")
 
-        scopes = token_info["scopes"].split(",")
+        scopes = token_info["scopes"]
         if "bot:play" not in scopes:
             raise RuntimeError("Please use an API access token for your bot that "
                                'has the scope "Play games with the bot API (bot:play)". '


### PR DESCRIPTION
Can also be fixed by adding a space after the coma, or by using `.strip()`, but I chose this method because it is less likely to give us problems in the future when something changes again.
closes #740 