### PR TITLE
Deprecate move quality "good" for EGTBs

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Besides the above, there are many possible options within `config.yml` for confi
         - `move_quality`: Choice of `"all"` (`chessdb_book` only), `"good"`, `"best"`, or `"suggest"` (`online_egtb` only).
             - `all`: Choose a random move from all legal moves.
             - `best`: Choose only the highest scoring move.
-            - `good`: Choose randomly from the top moves. In `lichess_cloud_analysis`, the top moves list is controlled by `max_score_difference`. In `chessdb_book`, the top list is controlled by the online source.
+            - `good`: Choose randomly from the top moves. In `lichess_cloud_analysis`, the top moves list is controlled by `max_score_difference`. In `chessdb_book`, the top list is controlled by the online source. For `online_egtb`, `good` is deprecated and will be removed soon.
             - `suggest`: Let the engine choose between the top moves. The top moves are the all the moves that `"good"` could have returned. Can't be used with XBoard engines.
     - Configurations only in `chessdb_book` and `lichess_cloud_analysis`:
         - `min_depth`: The minimum search depth for a move evaluation for a database move to be accepted.
@@ -116,9 +116,9 @@ Besides the above, there are many possible options within `config.yml` for confi
         - `enabled`: Whether to use the tablebases at all.
         - `paths`: The paths to the tablebases.
         - `max_pieces`: The maximum number of pieces in the current board for which the tablebase will be consulted.
-        - `move_quality`: Choice of `"good"`, or `"best"`.
+        - `move_quality`: Choice of `good`, `best`, or `suggest`.
             - `best`: Choose only the highest scoring move. When using `syzygy`, if `.*tbz` files are not provided, the bot will attempt to get a move using `move_quality` = `good`.
-            - `good`: Choose randomly from the top moves.
+            - `good`: DEPRECATED. Will be removed soon. Choose randomly from the top moves.
             - `suggest`: Let the engine choose between the top moves. The top moves are the all the moves that `"good"` could have returned. Can't be used with XBoard engines.
     - Configurations only in `gaviota`:
         - `min_dtm_to_consider_as_wdl_1`: The minimum DTM to consider as syzygy WDL=1/-1. Setting it to 100 will disable it.

--- a/config.py
+++ b/config.py
@@ -267,8 +267,13 @@ def validate_config(CONFIG: CONFIG_DICT_TYPE) -> None:
             online_section = (CONFIG["engine"].get(section) or {}).get(subsection) or {}
             config_assert(online_section.get("move_quality") != "suggest" or not online_section.get("enabled"),
                           f"XBoard engines can't be used with `move_quality` set to `suggest` in {subsection}.")
-            if online_section.get("move_quality") == "good":
-                raise DeprecationWarning("`move_quality` `good` is deprecated and will be removed soon.")
+
+    for section, subsection in (("online_moves", "online_egtb"),
+                                ("lichess_bot_tbs", "syzygy"),
+                                ("lichess_bot_tbs", "gaviota")):
+        online_section = (CONFIG["engine"].get(section) or {}).get(subsection) or {}
+        if online_section.get("move_quality") == "good":
+            logger.warning(DeprecationWarning(f"`move_quality` `good` in {subsection} is deprecated and will be removed soon."))
 
     matchmaking = CONFIG.get("matchmaking") or {}
     matchmaking_enabled = matchmaking.get("allow_matchmaking") or False

--- a/config.py
+++ b/config.py
@@ -267,6 +267,8 @@ def validate_config(CONFIG: CONFIG_DICT_TYPE) -> None:
             online_section = (CONFIG["engine"].get(section) or {}).get(subsection) or {}
             config_assert(online_section.get("move_quality") != "suggest" or not online_section.get("enabled"),
                           f"XBoard engines can't be used with `move_quality` set to `suggest` in {subsection}.")
+            if online_section.get("move_quality") == "good":
+                raise DeprecationWarning("`move_quality` `good` is deprecated and will be removed soon.")
 
     matchmaking = CONFIG.get("matchmaking") or {}
     matchmaking_enabled = matchmaking.get("allow_matchmaking") or False

--- a/config.py
+++ b/config.py
@@ -273,7 +273,8 @@ def validate_config(CONFIG: CONFIG_DICT_TYPE) -> None:
                                 ("lichess_bot_tbs", "gaviota")):
         online_section = (CONFIG["engine"].get(section) or {}).get(subsection) or {}
         if online_section.get("move_quality") == "good":
-            logger.warning(DeprecationWarning(f"`move_quality` `good` in {subsection} is deprecated and will be removed soon."))
+            logger.warning(
+                DeprecationWarning(f"`move_quality` `good` in {subsection} is deprecated and will be removed soon."))
 
     matchmaking = CONFIG.get("matchmaking") or {}
     matchmaking_enabled = matchmaking.get("allow_matchmaking") or False

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -875,8 +875,6 @@ def get_online_egtb_move(li: lichess.Lichess, board: chess.Board, game: model.Ga
         return None, -3
 
     quality = online_egtb_cfg.move_quality
-    if quality == "good":
-        logger.warning(DeprecationWarning("`move_quality` `good` is deprecated and will be removed soon."))
     variant = "standard" if board.uci_variant == "chess" else str(board.uci_variant)
 
     try:
@@ -897,8 +895,6 @@ def get_egtb_move(board: chess.Board, game: model.Game, lichess_bot_tbs: config.
 
     If `move_quality` is `suggest`, then it will return a list of moves for the engine to choose from.
     """
-    if lichess_bot_tbs.syzygy.move_quality == "good" or lichess_bot_tbs.gaviota.move_quality == "good":
-        logger.warning(DeprecationWarning("`move_quality` `good` is deprecated and will be removed soon."))
     best_move, wdl = get_syzygy(board, game, lichess_bot_tbs.syzygy)
     if best_move is None:
         best_move, wdl = get_gaviota(board, game, lichess_bot_tbs.gaviota)

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -876,7 +876,7 @@ def get_online_egtb_move(li: lichess.Lichess, board: chess.Board, game: model.Ga
 
     quality = online_egtb_cfg.move_quality
     if quality == "good":
-        raise DeprecationWarning("`move_quality` `good` is deprecated and will be removed soon.")
+        logger.warning(DeprecationWarning("`move_quality` `good` is deprecated and will be removed soon."))
     variant = "standard" if board.uci_variant == "chess" else str(board.uci_variant)
 
     try:
@@ -1061,7 +1061,7 @@ def get_syzygy(board: chess.Board, game: model.Game,
     move: Union[chess.Move, list[chess.Move]]
     move_quality = syzygy_cfg.move_quality
     if move_quality == "good":
-        raise DeprecationWarning("`move_quality` `good` is deprecated and will be removed soon.")
+        logger.warning(DeprecationWarning("`move_quality` `good` is deprecated and will be removed soon."))
     with chess.syzygy.open_tablebase(syzygy_cfg.paths[0]) as tablebase:
         for path in syzygy_cfg.paths[1:]:
             tablebase.add_directory(path)
@@ -1130,7 +1130,7 @@ def get_gaviota(board: chess.Board, game: model.Game,
     move: Union[chess.Move, list[chess.Move]]
     move_quality = gaviota_cfg.move_quality
     if move_quality == "good":
-        raise DeprecationWarning("`move_quality` `good` is deprecated and will be removed soon.")
+        logger.warning(DeprecationWarning("`move_quality` `good` is deprecated and will be removed soon."))
     # Since gaviota TBs use dtm and not dtz, we have to put a limit where after it the position are considered to have
     # a syzygy wdl=1/-1, so the positions are draws under the 50 move rule. We use min_dtm_to_consider_as_wdl_1 as a
     # second limit, because if a position has 5 pieces and dtm=110 it may take 98 half-moves, to go down to 4 pieces and

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -897,6 +897,8 @@ def get_egtb_move(board: chess.Board, game: model.Game, lichess_bot_tbs: config.
 
     If `move_quality` is `suggest`, then it will return a list of moves for the engine to choose from.
     """
+    if lichess_bot_tbs.syzygy.move_quality == "good" or lichess_bot_tbs.gaviota.move_quality == "good":
+        logger.warning(DeprecationWarning("`move_quality` `good` is deprecated and will be removed soon."))
     best_move, wdl = get_syzygy(board, game, lichess_bot_tbs.syzygy)
     if best_move is None:
         best_move, wdl = get_gaviota(board, game, lichess_bot_tbs.gaviota)
@@ -1060,8 +1062,6 @@ def get_syzygy(board: chess.Board, game: model.Game,
         return None, -3
     move: Union[chess.Move, list[chess.Move]]
     move_quality = syzygy_cfg.move_quality
-    if move_quality == "good":
-        logger.warning(DeprecationWarning("`move_quality` `good` is deprecated and will be removed soon."))
     with chess.syzygy.open_tablebase(syzygy_cfg.paths[0]) as tablebase:
         for path in syzygy_cfg.paths[1:]:
             tablebase.add_directory(path)
@@ -1129,8 +1129,6 @@ def get_gaviota(board: chess.Board, game: model.Game,
         return None, -3
     move: Union[chess.Move, list[chess.Move]]
     move_quality = gaviota_cfg.move_quality
-    if move_quality == "good":
-        logger.warning(DeprecationWarning("`move_quality` `good` is deprecated and will be removed soon."))
     # Since gaviota TBs use dtm and not dtz, we have to put a limit where after it the position are considered to have
     # a syzygy wdl=1/-1, so the positions are draws under the 50 move rule. We use min_dtm_to_consider_as_wdl_1 as a
     # second limit, because if a position has 5 pieces and dtm=110 it may take 98 half-moves, to go down to 4 pieces and

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -875,6 +875,8 @@ def get_online_egtb_move(li: lichess.Lichess, board: chess.Board, game: model.Ga
         return None, -3
 
     quality = online_egtb_cfg.move_quality
+    if quality == "good":
+        raise DeprecationWarning("`move_quality` `good` is deprecated and will be removed soon.")
     variant = "standard" if board.uci_variant == "chess" else str(board.uci_variant)
 
     try:
@@ -1058,6 +1060,8 @@ def get_syzygy(board: chess.Board, game: model.Game,
         return None, -3
     move: Union[chess.Move, list[chess.Move]]
     move_quality = syzygy_cfg.move_quality
+    if move_quality == "good":
+        raise DeprecationWarning("`move_quality` `good` is deprecated and will be removed soon.")
     with chess.syzygy.open_tablebase(syzygy_cfg.paths[0]) as tablebase:
         for path in syzygy_cfg.paths[1:]:
             tablebase.add_directory(path)
@@ -1076,24 +1080,25 @@ def get_syzygy(board: chess.Board, game: model.Game,
                 logger.info(f"Suggesting moves from syzygy (wdl: {best_wdl}) for game {game.id}")
                 return move, best_wdl
             else:
+                # There can be multiple moves with the same dtz.
                 best_dtz = min([dtz for chess_move, dtz in good_moves])
                 best_moves = [chess_move for chess_move, dtz in good_moves if dtz == best_dtz]
                 move = random.choice(best_moves)
                 logger.info(f"Got move {move.uci()} from syzygy (wdl: {best_wdl}, dtz: {best_dtz}) for game {game.id}")
                 return move, best_wdl
         except KeyError:
-            # Attempt to only get the WDL score. It returns a move of quality="good", even if quality is set to "best".
+            # Attempt to only get the WDL score. It returns a move of quality="suggest", even if quality is set to "best".
             try:
                 moves = score_syzygy_moves(board, lambda tablebase, b: -tablebase.probe_wdl(b), tablebase)
                 best_wdl = max(moves.values())
                 good_chess_moves = [chess_move for chess_move, wdl in moves.items() if wdl == best_wdl]
-                logger.debug("Found a move using 'move_quality'='good'. We didn't find an '.rtbz' file for this endgame."
+                logger.debug("Found a move using 'move_quality'='suggest'. We didn't find an '.rtbz' file for this endgame."
                              if move_quality == "best" else "")
-                if move_quality == "suggest" and len(good_chess_moves) > 1:
+                if len(good_chess_moves) > 1:
                     move = good_chess_moves
                     logger.info(f"Suggesting moves from syzygy (wdl: {best_wdl}) for game {game.id}")
                 else:
-                    move = random.choice(good_chess_moves)
+                    move = good_chess_moves[0]
                     logger.info(f"Got move {move.uci()} from syzygy (wdl: {best_wdl}) for game {game.id}")
                 return move, best_wdl
             except KeyError:
@@ -1124,6 +1129,8 @@ def get_gaviota(board: chess.Board, game: model.Game,
         return None, -3
     move: Union[chess.Move, list[chess.Move]]
     move_quality = gaviota_cfg.move_quality
+    if move_quality == "good":
+        raise DeprecationWarning("`move_quality` `good` is deprecated and will be removed soon.")
     # Since gaviota TBs use dtm and not dtz, we have to put a limit where after it the position are considered to have
     # a syzygy wdl=1/-1, so the positions are draws under the 50 move rule. We use min_dtm_to_consider_as_wdl_1 as a
     # second limit, because if a position has 5 pieces and dtm=110 it may take 98 half-moves, to go down to 4 pieces and

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -1087,12 +1087,12 @@ def get_syzygy(board: chess.Board, game: model.Game,
                 logger.info(f"Got move {move.uci()} from syzygy (wdl: {best_wdl}, dtz: {best_dtz}) for game {game.id}")
                 return move, best_wdl
         except KeyError:
-            # Attempt to only get the WDL score. It returns a move of quality="suggest", even if quality is set to "best".
+            # Attempt to only get the WDL score. It returns moves of quality="suggest", even if quality is set to "best".
             try:
                 moves = score_syzygy_moves(board, lambda tablebase, b: -tablebase.probe_wdl(b), tablebase)
                 best_wdl = max(moves.values())
                 good_chess_moves = [chess_move for chess_move, wdl in moves.items() if wdl == best_wdl]
-                logger.debug("Found a move using 'move_quality'='suggest'. We didn't find an '.rtbz' file for this endgame."
+                logger.debug("Found moves using 'move_quality'='suggest'. We didn't find an '.rtbz' file for this endgame."
                              if move_quality == "best" else "")
                 if len(good_chess_moves) > 1:
                     move = good_chess_moves


### PR DESCRIPTION
Move quality `good` can lead to 3-fold repetition. Example: https://lichess.org/HoJ22Ge7/white#130