### PR TITLE
Use split() to test for proper tokens

### DIFF
--- a/lichess.py
+++ b/lichess.py
@@ -99,7 +99,7 @@ class Lichess:
                                "Please check that it was copied correctly into your configuration file.")
 
         scopes = token_info["scopes"]
-        if "bot:play" not in scopes:
+        if "bot:play" not in scopes.split(","):
             raise RuntimeError("Please use an API access token for your bot that "
                                'has the scope "Play games with the bot API (bot:play)". '
                                f"The current token has: {scopes}.")


### PR DESCRIPTION
The Lichess API for listing token scopes was fixed with the following commit to remove spaces from the scope list: https://github.com/lichess-org/lila/commit/f7324609d13609084b0cbc150065c51342fe2661