### PR TITLE
Fail python-build.yml if there are any errors

### DIFF
--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -33,10 +33,10 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide.
         # W503 and W504 are mutually exclusive. W504 is considered the best practice now.
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics --ignore=D,W503
+        flake8 . --count --max-complexity=10 --max-line-length=127 --statistics --ignore=D,W503
     - name: Lint with flake8-markdown
       run: |
         flake8-markdown "*.md"
     - name: Lint with flake8-docstrings
       run: |
-        flake8 . --count --exit-zero --max-line-length=127 --statistics --select=D
+        flake8 . --count --max-line-length=127 --statistics --select=D

--- a/test_bot/test_bot.py
+++ b/test_bot/test_bot.py
@@ -29,7 +29,7 @@ def download_sf() -> None:
     """Download Stockfish 15"""
     windows_or_linux = "win" if platform == "win32" else "linux"
     base_name = f"stockfish_15_{windows_or_linux}_x64"
-    exec_name = f"stockfish_15_x64"
+    exec_name = "stockfish_15_x64"
     zip_link = f"https://files.stockfishchess.org/files/{base_name}.zip"
     response = requests.get(zip_link, allow_redirects=True)
     with open("./TEMP/sf_zip.zip", "wb") as file:

--- a/test_bot/test_bot.py
+++ b/test_bot/test_bot.py
@@ -26,7 +26,7 @@ stockfish_path = f"./TEMP/sf{file_extension}"
 
 
 def download_sf() -> None:
-    """Download Stockfish 15"""
+    """Download Stockfish 15."""
     windows_or_linux = "win" if platform == "win32" else "linux"
     base_name = f"stockfish_15_{windows_or_linux}_x64"
     exec_name = "stockfish_15_x64"


### PR DESCRIPTION
Instead of warning, fail the tests. This will make it easier to spot flake8 errors.