### PR TITLE
Remove versioning dependency

### DIFF
--- a/.github/workflows/update_version.py
+++ b/.github/workflows/update_version.py
@@ -1,6 +1,7 @@
 """Automatically updates the lichess-bot version."""
 import yaml
 import datetime
+import os
 
 with open("versioning.yml") as version_file:
     versioning_info = yaml.safe_load(version_file)
@@ -20,3 +21,6 @@ versioning_info["lichess_bot_version"] = new_version
 
 with open("versioning.yml", "w") as version_file:
     yaml.dump(versioning_info, version_file, sort_keys=False)
+
+with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+    print(f"new_version={new_version}", file=fh)

--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -19,18 +19,13 @@ jobs:
           python -m pip install --upgrade pip
           pip install PyYAML
       - name: Update version
+        id: new-version
         run: python .github/workflows/update_version.py
-      - name: Get version
-        id: yaml-data
-        uses: jbutcher5/read-yaml@main
-        with:
-          file: 'versioning.yml'
-          key-path: '["lichess_bot_version"]'
       - name: Auto update version
         run: |
           git config --global user.email "123640915+Version-BOT@users.noreply.github.com"
           git config --global user.name "Version-BOT"
           git remote set-url origin ${{ secrets.version_bot_ssh }}
           git add versioning.yml
-          git commit -m "Auto update version to ${{ steps.yaml-data.outputs.data }}"
+          git commit -m "Auto update version to ${{ steps.new-version.outputs.new_version }}"
           git push origin HEAD:master


### PR DESCRIPTION
- Removes versioning dependency `jbutcher5/read-yaml` which was archived
- Doesn't use the deprecated `set-output` command used by `jbutcher5/read-yaml` (https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)