### PR TITLE
Create allowed list

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ will precede the `go` command to start thinking with `sd 5`. The other `go_comma
     -casual
 ```
   - `block_list`: An indented list of usernames from which the challenges are always declined. If this option is not present, then the list is considered empty.
+  - `allow_list`: An indented list of usernames from which challenges are exclusively accepted. A challenge from a user not on this list is declined. If this option is not present or empty, any user's challenge may be accepted.
   - `recent_bot_challenge_age`: Maximum age of a bot challenge to be considered recent in seconds
   - `max_recent_bot_challenges`: Maximum number of recent challenges that can be accepted from the same bot
 - `greeting`: Send messages via chat to the bot's opponent. The string `{me}` will be replaced by the bot's lichess account name. The string `{opponent}` will be replaced by the opponent's lichess account name. Any other word between curly brackets will be removed. If you want to put a curly bracket in the message, use two: `{{` or `}}`.

--- a/config.py
+++ b/config.py
@@ -200,6 +200,7 @@ def insert_default_values(CONFIG: CONFIG_DICT_TYPE) -> None:
     set_config_default(CONFIG, "challenge", key="max_days", default=math.inf)
     set_config_default(CONFIG, "challenge", key="min_days", default=1)
     set_config_default(CONFIG, "challenge", key="block_list", default=[], force_empty_values=True)
+    set_config_default(CONFIG, "challenge", key="allow_list", default=[], force_empty_values=True)
     set_config_default(CONFIG, "correspondence", key="checkin_period", default=600)
     set_config_default(CONFIG, "correspondence", key="move_time", default=60, force_empty_values=True)
     set_config_default(CONFIG, "correspondence", key="disconnect_time", default=300)

--- a/config.yml.default
+++ b/config.yml.default
@@ -155,6 +155,9 @@ challenge:                   # Incoming challenges.
 # block_list:                # List of users from which the challenges are always declined.
 #   - user1
 #   - user2
+# allow_list:                # List of users from which challenges are exclusively accepted, all others being declined. If empty, challenges from all users may be accepted.
+#   - user3
+#   - user4
 # recent_bot_challenge_age: 60 # Maximum age of a bot challenge to be considered recent in seconds
 # max_recent_bot_challenges: 2 # Maximum number of recent challenges that can be accepted from the same bot
 

--- a/model.py
+++ b/model.py
@@ -89,7 +89,7 @@ class Challenge:
             if self.from_self:
                 return True, ""
 
-            allowed_opponents = list(filter(None, config.allow_list)) or [self.challenger.name]
+            allowed_opponents: list[str] = list(filter(None, config.allow_list)) or [self.challenger.name]
             decline_reason = (self.decline_due_to(config.accept_bot or not self.challenger.is_bot, "noBot")
                               or self.decline_due_to(not config.only_bot or self.challenger.is_bot, "onlyBot")
                               or self.decline_due_to(self.is_supported_time_control(config), "timeControl")

--- a/model.py
+++ b/model.py
@@ -89,12 +89,14 @@ class Challenge:
             if self.from_self:
                 return True, ""
 
+            allowed_opponents = list(filter(None, config.allow_list)) or [self.challenger.name]
             decline_reason = (self.decline_due_to(config.accept_bot or not self.challenger.is_bot, "noBot")
                               or self.decline_due_to(not config.only_bot or self.challenger.is_bot, "onlyBot")
                               or self.decline_due_to(self.is_supported_time_control(config), "timeControl")
                               or self.decline_due_to(self.is_supported_variant(config), "variant")
                               or self.decline_due_to(self.is_supported_mode(config), "casual" if self.rated else "rated")
                               or self.decline_due_to(self.challenger.name not in config.block_list, "generic")
+                              or self.decline_due_to(self.challenger.name in config.allow_list, "generic")
                               or self.decline_due_to(self.is_supported_recent(config, recent_bot_challenges), "later"))
 
             return not decline_reason, decline_reason

--- a/model.py
+++ b/model.py
@@ -96,7 +96,7 @@ class Challenge:
                               or self.decline_due_to(self.is_supported_variant(config), "variant")
                               or self.decline_due_to(self.is_supported_mode(config), "casual" if self.rated else "rated")
                               or self.decline_due_to(self.challenger.name not in config.block_list, "generic")
-                              or self.decline_due_to(self.challenger.name in config.allow_list, "generic")
+                              or self.decline_due_to(self.challenger.name in allowed_opponents, "generic")
                               or self.decline_due_to(self.is_supported_recent(config, recent_bot_challenges), "later"))
 
             return not decline_reason, decline_reason


### PR DESCRIPTION
With this change, a user can create a list of other users who are allowed to challenge their bot. This may be useful when participating in tournaments so computer resources are not taken up by other games.