### PR TITLE
Don't download engines for every test in GitHub

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -28,6 +28,20 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
+    - name: Restore engines
+      id: cache-temp-restore
+      uses: actions/cache/restore@v3
+      with:
+        path: |
+          TEMP
+        key: ${{ matrix.os }}-primes
     - name: Test with pytest
       run: |
         pytest
+    - name: Save engines
+      id: cache-temp-save
+      uses: actions/cache/save@v3
+      with:
+        path: |
+          TEMP
+        key: ${{ steps.cache-temp-restore.outputs.cache-primary-key }}

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -37,7 +37,7 @@ jobs:
         key: ${{ matrix.os }}-engines
     - name: Test with pytest
       run: |
-        pytest
+        pytest --log-cli-level=10
     - name: Save engines
       id: cache-temp-save
       uses: actions/cache/save@v3

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -34,7 +34,7 @@ jobs:
       with:
         path: |
           TEMP
-        key: ${{ matrix.os }}-primes
+        key: ${{ matrix.os }}-engines
     - name: Test with pytest
       run: |
         pytest

--- a/test_bot/conftest.py
+++ b/test_bot/conftest.py
@@ -8,7 +8,7 @@ def pytest_sessionfinish(session: Any, exitstatus: Any) -> None:
     """Remove files created when testing lichess-bot."""
     shutil.copyfile("correct_lichess.py", "lichess.py")
     os.remove("correct_lichess.py")
-    if os.path.exists("TEMP"):
+    if os.path.exists("TEMP") and not os.getenv("GITHUB_ACTIONS"):
         shutil.rmtree("TEMP")
     if os.path.exists("logs"):
         shutil.rmtree("logs")

--- a/test_bot/test_bot.py
+++ b/test_bot/test_bot.py
@@ -68,9 +68,8 @@ def download_sjeng() -> None:
     shutil.copyfile("./TEMP/Release/Sjeng112.exe", "./TEMP/sjeng.exe")
 
 
-if os.path.exists("TEMP"):
-    shutil.rmtree("TEMP")
-os.mkdir("TEMP")
+if not os.path.exists("TEMP"):
+    os.mkdir("TEMP")
 download_sf()
 if platform == "win32":
     download_lc0()

--- a/test_bot/test_bot.py
+++ b/test_bot/test_bot.py
@@ -27,6 +27,8 @@ stockfish_path = f"./TEMP/sf{file_extension}"
 
 def download_sf() -> None:
     """Download Stockfish 15."""
+    if os.path.exists(stockfish_path):
+        return
     windows_or_linux = "win" if platform == "win32" else "linux"
     base_name = f"stockfish_15_{windows_or_linux}_x64"
     exec_name = "stockfish_15_x64"
@@ -44,6 +46,8 @@ def download_sf() -> None:
 
 def download_lc0() -> None:
     """Download Leela Chess Zero 0.29.0."""
+    if os.path.exists("./TEMP/lc0.exe"):
+        return
     response = requests.get("https://github.com/LeelaChessZero/lc0/releases/download/v0.29.0/lc0-v0.29.0-windows-cpu-dnnl.zip",
                             allow_redirects=True)
     with open("./TEMP/lc0_zip.zip", "wb") as file:
@@ -54,6 +58,8 @@ def download_lc0() -> None:
 
 def download_sjeng() -> None:
     """Download Sjeng."""
+    if os.path.exists("./TEMP/sjeng.exe"):
+        return
     response = requests.get("https://sjeng.org/ftp/Sjeng112.zip", allow_redirects=True)
     with open("./TEMP/sjeng_zip.zip", "wb") as file:
         file.write(response.content)


### PR DESCRIPTION
Uses GitHub workflow cache to cache the engines and restore them. Idea by @MarkZH. This will prevent overwhelming the servers the engines are hosted with requests.