### PR TITLE
Separate Standard and Chess960 Books

### DIFF
--- a/config.yml.default
+++ b/config.yml.default
@@ -19,7 +19,7 @@ engine:                      # Engine settings.
 #       - engines/atomicbook1.bin
 #       - engines/atomicbook2.bin
 #     etc.
-#     Use the same pattern for 'giveaway' (antichess), 'crazyhouse', 'horde', 'kingofthehill', 'racingkings' and '3check' as well.
+#     Use the same pattern for 'chess960', 'giveaway' (antichess), 'crazyhouse', 'horde', 'kingofthehill', 'racingkings' and '3check' as well.
     min_weight: 1            # Does not select moves with weight below min_weight (min 0, max: 65535).
     selection: "weighted_random" # Move selection is one of "weighted_random", "uniform_random" or "best_move" (but not below the min_weight in the 2nd and 3rd case).
     max_depth: 8             # How many moves from the start to take from the book.

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -682,7 +682,12 @@ def get_book_move(board: chess.Board, game: model.Game,
     if not use_book or len(board.move_stack) > max_game_length:
         return no_book_move
 
-    variant = "standard" if board.uci_variant == "chess" else str(board.uci_variant)
+    if board.chess960:
+        variant = "chess960"
+    elif board.uci_variant == "chess":
+        variant = "standard"
+    else:
+        str(board.uci_variant)
     config.change_value_to_list(polyglot_cfg.config, "book", key=variant)
     books = polyglot_cfg.book.lookup(variant)
 

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -684,10 +684,9 @@ def get_book_move(board: chess.Board, game: model.Game,
 
     if board.chess960:
         variant = "chess960"
-    elif board.uci_variant == "chess":
-        variant = "standard"
     else:
-        str(board.uci_variant)
+        variant = "standard" if board.uci_variant == "chess" else str(board.uci_variant)
+
     config.change_value_to_list(polyglot_cfg.config, "book", key=variant)
     books = polyglot_cfg.book.lookup(variant)
 


### PR DESCRIPTION
Previously to add a book for chess960, it had to be added in the 'standard' section. With this change there's a separate section for standard and chess960 opening books.