### PR TITLE
Option to require increment for bullet games

### DIFF
--- a/config.yml.default
+++ b/config.yml.default
@@ -160,6 +160,7 @@ challenge:                         # Incoming challenges.
 #   - user4
 # recent_bot_challenge_age: 60     # Maximum age of a bot challenge to be considered recent in seconds
 # max_recent_bot_challenges: 2     # Maximum number of recent challenges that can be accepted from the same bot
+  bullet_requires_increment: False # Require that bullet game challenges have a non-zero increment
 
 greeting:
   # Optional substitution keywords (include curly braces):

--- a/config.yml.default
+++ b/config.yml.default
@@ -160,7 +160,7 @@ challenge:                         # Incoming challenges.
 #   - user4
 # recent_bot_challenge_age: 60     # Maximum age of a bot challenge to be considered recent in seconds
 # max_recent_bot_challenges: 2     # Maximum number of recent challenges that can be accepted from the same bot
-  bullet_requires_increment: False # Require that bullet game challenges have a non-zero increment
+  bullet_requires_increment: False # Require that bullet game challenges from bots have a non-zero increment
 
 greeting:
   # Optional substitution keywords (include curly braces):

--- a/model.py
+++ b/model.py
@@ -46,7 +46,9 @@ class Challenge:
         if self.speed not in speeds:
             return False
 
-        require_non_zero_increment = self.speed == "bullet" and challenge_cfg.bullet_requires_increment
+        require_non_zero_increment = (self.challenger.is_bot
+                                      and self.speed == "bullet"
+                                      and challenge_cfg.bullet_requires_increment)
         increment_min = max(increment_min, 1 if require_non_zero_increment else 0)
 
         if self.base is not None and self.increment is not None:

--- a/model.py
+++ b/model.py
@@ -46,6 +46,9 @@ class Challenge:
         if self.speed not in speeds:
             return False
 
+        require_non_zero_increment = self.speed == "bullet" and challenge_cfg.bullet_requires_increment
+        increment_min = max(increment_min, 1 if require_non_zero_increment else 0)
+
         if self.base is not None and self.increment is not None:
             # Normal clock game
             return (increment_min <= self.increment <= increment_max


### PR DESCRIPTION
This option prevents opponents from taking advantage of engines that time out often during short games by requiring challenges to have a minimum one-second increment for bullet games.

Closes #770