### PR TITLE
Unbridle fake_think_time

### DIFF
--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -673,9 +673,9 @@ def say_hello(conversation: Conversation, hello: str, hello_spectators: str, boa
 def fake_thinking(config: Configuration, board: chess.Board, game: model.Game) -> None:
     """Wait some time before starting to search for a move."""
     if config.fake_think_time and len(board.move_stack) > 9:
-        delay = min(game.clock_initial, game.my_remaining_seconds()) * 0.015
-        accel = 1 - max(0, min(100, len(board.move_stack) - 20)) / 150
-        sleep = min(5, delay * accel)
+        delay = game.my_remaining_seconds() * 0.025
+        accel = 0.99 ** (len(board.move_stack) - 10)
+        sleep = delay * accel
         time.sleep(sleep)
 
 


### PR DESCRIPTION
This adresses 4 problems I have experienced with the current formula:
- min(initial, remaining) is replaced by remaining. Indeed, time usage should increase when the remaining time increases above the initial time, as a result of accumulated increments.
- the accel formula is replaced by a smooth one, with the terminal condition preserved: accel = 1/3 for 120 half-moves played, but that is unfloored and slowly decayes towards zero beyond that. Just a slight difference that accel starts immediately from 10, instead of 20. This is more coherent, as the whole logic starts at 10 (for which accel=1, then accel decays by 1% for each ply).
- remove the cap of 5 seconds, which is an arbitrary value that corresponds to nothing. In long time control this made no sense.
- increase the fraction of remaining time (before accel factor) from 0.15 ~= 1/67 to 0.025 = 1/40.

Hopefully, the new formulas are more elegant and easier to understand.