### PR TITLE
Add source field to the engine info

### DIFF
--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -227,8 +227,6 @@ class EngineWrapper:
         # Use null_score to have no effect on draw/resign decisions
         null_score = chess.engine.PovScore(chess.engine.Mate(1), board.turn)
         self.scores.append(result.info.get("score", null_score))
-        print(result.info)
-        result.info["string"] = "Engine"
         result = self.offer_draw_or_resign(result, board)
         return result
 

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -676,7 +676,6 @@ def get_online_move(li: lichess.Lichess, board: chess.Board, game: model.Game, o
     max_out_of_book_moves = online_moves_cfg.max_out_of_book_moves
     offer_draw = False
     resign = False
-    comment: Optional[chess.engine.InfoDict] = None
     best_move, wdl, comment = get_online_egtb_move(li, board, game, online_egtb_cfg)
     if best_move is not None:
         can_offer_draw = draw_or_resign_cfg.offer_draw_enabled
@@ -989,7 +988,7 @@ def get_lichess_egtb_move(li: lichess.Lichess, game: model.Game, board: chess.Bo
                 dtm *= -1
             logger.info(f"Got move {move} from tablebase.lichess.ovh (wdl: {wdl}, dtz: {dtz}, dtm: {dtm}) for game {game.id}")
 
-        return move, wdl, {"source": "Lichess Online EGTB"}
+        return move, wdl, {"source": "Lichess EGTB"}
     return None, -3, None
 
 

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -308,6 +308,7 @@ class EngineWrapper:
         return str(number)
 
     def to_readable_value(self, stat: str, info: MOVE_INFO_TYPE) -> str:
+        """Change a value to a more human-readable format."""
         readable: dict[str, Callable[[Any], str]] = {"score": self.readable_score, "wdl": self.readable_wdl,
                                                      "hashfull": lambda x: f"{round(x / 10, 1)}%",
                                                      "nodes": self.readable_number,

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -78,7 +78,7 @@ def remove_managed_options(config: config.Configuration) -> OPTIONS_TYPE:
     return {name: value for (name, value) in config.items() if not is_managed(name)}
 
 
-PONDERPV_CHARACTERS = 6  # The length of ", PV: ".
+PONDERPV_CHARACTERS = 6  # The length of ", Pv: ".
 
 
 class EngineWrapper:
@@ -342,22 +342,22 @@ class EngineWrapper:
         if "Source" not in info:
             info["Source"] = "Engine"
 
-        stats = ["Source", "Evaluation", "Winrate", "Depth", "Nodes", "Speed", "PV"]
-        if for_chat and "PV" in info:
+        stats = ["Source", "Evaluation", "Winrate", "Depth", "Nodes", "Speed", "Pv"]
+        if for_chat and "Pv" in info:
             bot_stats = [f"{stat}: {to_readable_value(stat, info)}"
-                         for stat in stats if stat in info and stat != "PV"]
+                         for stat in stats if stat in info and stat != "Pv"]
             len_bot_stats = len(", ".join(bot_stats)) + PONDERPV_CHARACTERS
-            ponder_pv = info["PV"].split()
+            ponder_pv = info["Pv"].split()
             try:
                 while len(" ".join(ponder_pv)) + len_bot_stats > lichess.MAX_CHAT_MESSAGE_LEN:
                     ponder_pv.pop()
                 if ponder_pv[-1].endswith("."):
                     ponder_pv.pop()
-                info["PV"] = " ".join(ponder_pv)
+                info["Pv"] = " ".join(ponder_pv)
             except IndexError:
                 pass
-            if not info["PV"]:
-                info.pop("PV")
+            if not info["Pv"]:
+                info.pop("Pv")
         return [f"{stat}: {to_readable_value(stat, info)}" for stat in stats if stat in info]
 
     def get_opponent_info(self, game: model.Game) -> None:


### PR DESCRIPTION
Adds a new field in the engine info called `source`. Possible options are: `Engine`, `Opening Book`, `Lichess EGTB`, `ChessDB EGTB`, `Lichess Opening Explorer (Masters)`, `Lichess Opening Explorer (Player)`, `Lichess Opening Explorer (Lichess)`, `ChessDB`, `Lichess Cloud Analysis`, `Syzygy EGTB`, `Gaviota EGTB`.

closes #792