### PR TITLE
Reset logging config before exiting

### DIFF
--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -250,6 +250,7 @@ def start(li: lichess.Lichess, user_profile: USER_PROFILE_TYPE, config: Configur
         control_stream.join()
         correspondence_pinger.terminate()
         correspondence_pinger.join()
+        logging_configurer(logging_level, log_filename, auto_log_filename, False)
         logging_listener.terminate()
         logging_listener.join()
 


### PR DESCRIPTION
Because the main thread logs to a queue that is then handled by a listener process, terminating the listener process stops logging for the rest of the program. This means that, if lichess-bot is stopped by an exception, then the exception logging at the bottom of the file (line 1029) does not do anything.

This change reverts the main thread back to direct logging before terminating the logging queue thread.