### PR TITLE
Replace ints and floats with datetime.timedeltas

### DIFF
--- a/conversation.py
+++ b/conversation.py
@@ -5,6 +5,7 @@ import model
 from engine_wrapper import EngineWrapper
 from lichess import Lichess
 from collections.abc import Sequence
+from timer import seconds
 MULTIPROCESSING_LIST_TYPE = Sequence[model.Challenge]
 
 logger = logging.getLogger(__name__)
@@ -53,7 +54,7 @@ class Conversation:
         if cmd == "commands" or cmd == "help":
             self.send_reply(line, "Supported commands: !wait (wait a minute for my first move), !name, !howto, !eval, !queue")
         elif cmd == "wait" and self.game.is_abortable():
-            self.game.ping(60, 120, 120)
+            self.game.ping(seconds(60), seconds(120), seconds(120))
             self.send_reply(line, "Waiting 60 seconds...")
         elif cmd == "name":
             name = self.game.me.name

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -9,6 +9,7 @@ import chess
 import subprocess
 import logging
 import datetime
+import time
 import random
 from collections import Counter
 from collections.abc import Generator, Callable
@@ -109,7 +110,7 @@ class EngineWrapper:
                   is_correspondence: bool,
                   correspondence_move_time: datetime.timedelta,
                   engine_cfg: config.Configuration,
-                  min_time: float) -> None:
+                  min_time: datetime.timedelta) -> None:
         """
         Play a move.
 
@@ -160,9 +161,9 @@ class EngineWrapper:
             best_move = self.search(board, time_limit, can_ponder, draw_offered, best_move)
 
         # Heed min_time
-        elapsed = (time.perf_counter_ns() - start_time) / 1e9
+        elapsed = datetime.datetime.now() - start_time
         if elapsed < min_time:
-            time.sleep(min_time - elapsed)
+            time.sleep((min_time - elapsed).total_seconds())
 
         self.add_comment(best_move, board)
         self.print_stats()

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -104,7 +104,7 @@ class EngineWrapper:
                   board: chess.Board,
                   game: model.Game,
                   li: lichess.Lichess,
-                  start_time: datetime.datetime,
+                  start_time: float,
                   move_overhead: datetime.timedelta,
                   can_ponder: bool,
                   is_correspondence: bool,
@@ -161,7 +161,7 @@ class EngineWrapper:
             best_move = self.search(board, time_limit, can_ponder, draw_offered, best_move)
 
         # Heed min_time
-        elapsed = datetime.datetime.now() - start_time
+        elapsed = seconds(time.perf_counter() - start_time)
         if elapsed < min_time:
             time.sleep((min_time - elapsed).total_seconds())
 
@@ -579,7 +579,7 @@ def getHomemadeEngine(name: str) -> type[MinimalEngine]:
 
 
 def single_move_time(board: chess.Board, game: model.Game, search_time: datetime.timedelta,
-                     start_time: datetime.datetime, move_overhead: datetime.timedelta) -> chess.engine.Limit:
+                     start_time: float, move_overhead: datetime.timedelta) -> chess.engine.Limit:
     """
     Calculate time to search in correspondence games.
 
@@ -590,7 +590,7 @@ def single_move_time(board: chess.Board, game: model.Game, search_time: datetime
     :param move_overhead: The time it takes to communicate between the engine and lichess-bot.
     :return: The time to choose a move.
     """
-    pre_move_time = datetime.datetime.now() - start_time
+    pre_move_time = seconds(time.perf_counter() - start_time)
     overhead = pre_move_time + move_overhead
     wb = "w" if board.turn == chess.WHITE else "b"
     clock_time = max(msec(0), msec(game.state[f"{wb}time"]) - overhead)
@@ -614,7 +614,7 @@ def first_move_time(game: model.Game) -> chess.engine.Limit:
 
 def game_clock_time(board: chess.Board,
                     game: model.Game,
-                    start_time: datetime.datetime,
+                    start_time: float,
                     move_overhead: datetime.timedelta) -> chess.engine.Limit:
     """
     Get the time to play by the engine in realtime games.
@@ -625,7 +625,7 @@ def game_clock_time(board: chess.Board,
     :param move_overhead: The time it takes to communicate between the engine and lichess-bot.
     :return: The time to play a move.
     """
-    pre_move_time = datetime.datetime.now() - start_time
+    pre_move_time = seconds(time.perf_counter() - start_time)
     overhead = pre_move_time + move_overhead
     times = {side: msec(game.state[side]) for side in ["wtime", "btime"]}
     wb = "w" if board.turn == chess.WHITE else "b"

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -8,7 +8,7 @@ import chess.gaviota
 import chess
 import subprocess
 import logging
-import time
+import datetime
 import random
 from collections import Counter
 from collections.abc import Generator, Callable
@@ -102,11 +102,11 @@ class EngineWrapper:
                   board: chess.Board,
                   game: model.Game,
                   li: lichess.Lichess,
-                  start_time: int,
-                  move_overhead: int,
+                  start_time: datetime.datetime,
+                  move_overhead: datetime.timedelta,
                   can_ponder: bool,
                   is_correspondence: bool,
-                  correspondence_move_time: int,
+                  correspondence_move_time: datetime.timedelta,
                   engine_cfg: config.Configuration) -> None:
         """
         Play a move.
@@ -167,7 +167,7 @@ class EngineWrapper:
         """Add extra commands to send to the engine. For example, to search for 1000 nodes or up to depth 10."""
         movetime = self.go_commands.movetime
         if movetime is not None:
-            movetime_sec = float(movetime) / 1000
+            movetime_sec = datetime.timedelta(seconds=movetime) / datetime.timedelta(milliseconds=1)
             if time_limit.time is None or time_limit.time > movetime_sec:
                 time_limit.time = movetime_sec
         time_limit.depth = self.go_commands.depth
@@ -561,8 +561,8 @@ def getHomemadeEngine(name: str) -> type[MinimalEngine]:
     return engine
 
 
-def single_move_time(board: chess.Board, game: model.Game, search_time: int,
-                     start_time: int, move_overhead: int) -> chess.engine.Limit:
+def single_move_time(board: chess.Board, game: model.Game, search_time: datetime.timedelta,
+                     start_time: datetime.datetime, move_overhead: datetime.timedelta) -> chess.engine.Limit:
     """
     Calculate time to search in correspondence games.
 
@@ -573,13 +573,13 @@ def single_move_time(board: chess.Board, game: model.Game, search_time: int,
     :param move_overhead: The time it takes to communicate between the engine and lichess-bot.
     :return: The time to choose a move.
     """
-    pre_move_time = int((time.perf_counter_ns() - start_time) / 1e6)
+    pre_move_time = datetime.datetime.now() - start_time
     overhead = pre_move_time + move_overhead
     wb = "w" if board.turn == chess.WHITE else "b"
-    clock_time = max(0, game.state[f"{wb}time"] - overhead)
+    clock_time = max(datetime.timedelta(), datetime.timedelta(milliseconds=game.state[f"{wb}time"]) - overhead)
     search_time = min(search_time, clock_time)
-    logger.info(f"Searching for time {search_time} for game {game.id}")
-    return chess.engine.Limit(time=search_time / 1000, clock_id="correspondence")
+    logger.info(f"Searching for time {search_time.total_seconds()} seconds for game {game.id}")
+    return chess.engine.Limit(time=search_time.total_seconds(), clock_id="correspondence")
 
 
 def first_move_time(game: model.Game) -> chess.engine.Limit:
@@ -589,13 +589,16 @@ def first_move_time(game: model.Game) -> chess.engine.Limit:
     :param game: The game that the bot is playing.
     :return: The time to choose the first move.
     """
-    # Need to hardcode first movetime (10000 ms) since Lichess has 30 sec limit.
-    search_time = 10000
-    logger.info(f"Searching for time {search_time} for game {game.id}")
-    return chess.engine.Limit(time=search_time / 1000, clock_id="first move")
+    # Need to hardcode first movetime (10 s) since Lichess has 30 sec limit.
+    search_time = 10
+    logger.info(f"Searching for time {search_time} seconds for game {game.id}")
+    return chess.engine.Limit(time=search_time, clock_id="first move")
 
 
-def game_clock_time(board: chess.Board, game: model.Game, start_time: int, move_overhead: int) -> chess.engine.Limit:
+def game_clock_time(board: chess.Board,
+                    game: model.Game,
+                    start_time: datetime.datetime,
+                    move_overhead: datetime.timedelta) -> chess.engine.Limit:
     """
     Get the time to play by the engine in realtime games.
 
@@ -605,10 +608,10 @@ def game_clock_time(board: chess.Board, game: model.Game, start_time: int, move_
     :param move_overhead: The time it takes to communicate between the engine and lichess-bot.
     :return: The time to play a move.
     """
-    pre_move_time = int((time.perf_counter_ns() - start_time) / 1e6)
+    pre_move_time = datetime.datetime.now() - start_time
     overhead = pre_move_time + move_overhead
     wb = "w" if board.turn == chess.WHITE else "b"
-    game.state[f"{wb}time"] = max(0, game.state[f"{wb}time"] - overhead)
+    game.state[f"{wb}time"] = max(0., game.state[f"{wb}time"] - overhead / datetime.timedelta(milliseconds=1))
     logger.info("Searching for wtime {wtime} btime {btime}".format_map(game.state) + f" for game {game.id}")
     return chess.engine.Limit(white_clock=game.state["wtime"] / 1000,
                               black_clock=game.state["btime"] / 1000,
@@ -719,8 +722,8 @@ def get_chessdb_move(li: lichess.Lichess, board: chess.Board, game: model.Game,
     """Get a move from chessdb.cn's opening book."""
     wb = "w" if board.turn == chess.WHITE else "b"
     use_chessdb = chessdb_cfg.enabled
-    time_left = game.state[f"{wb}time"]
-    min_time = chessdb_cfg.min_time * 1000
+    time_left = datetime.timedelta(milliseconds=game.state[f"{wb}time"])
+    min_time = datetime.timedelta(seconds=chessdb_cfg.min_time)
     if not use_chessdb or time_left < min_time or board.uci_variant != "chess":
         return None, None
 
@@ -759,8 +762,8 @@ def get_lichess_cloud_move(li: lichess.Lichess, board: chess.Board, game: model.
                            lichess_cloud_cfg: config.Configuration) -> tuple[Optional[str], Optional[chess.engine.InfoDict]]:
     """Get a move from the lichess's cloud analysis."""
     wb = "w" if board.turn == chess.WHITE else "b"
-    time_left = game.state[f"{wb}time"]
-    min_time = lichess_cloud_cfg.min_time * 1000
+    time_left = datetime.timedelta(milliseconds=game.state[f"{wb}time"])
+    min_time = datetime.timedelta(seconds=lichess_cloud_cfg.min_time)
     use_lichess_cloud = lichess_cloud_cfg.enabled
     if not use_lichess_cloud or time_left < min_time:
         return None, None
@@ -812,8 +815,8 @@ def get_opening_explorer_move(li: lichess.Lichess, board: chess.Board, game: mod
                               opening_explorer_cfg: config.Configuration) -> Optional[str]:
     """Get a move from lichess's opening explorer."""
     wb = "w" if board.turn == chess.WHITE else "b"
-    time_left = game.state[f"{wb}time"]
-    min_time = opening_explorer_cfg.min_time * 1000
+    time_left = datetime.timedelta(milliseconds=game.state[f"{wb}time"])
+    min_time = datetime.timedelta(seconds=opening_explorer_cfg.min_time)
     source = opening_explorer_cfg.source
     if not opening_explorer_cfg.enabled or time_left < min_time or source == "master" and board.uci_variant != "chess":
         return None
@@ -864,9 +867,9 @@ def get_online_egtb_move(li: lichess.Lichess, board: chess.Board, game: model.Ga
     wb = "w" if board.turn == chess.WHITE else "b"
     pieces = chess.popcount(board.occupied)
     source = online_egtb_cfg.source
-    minimum_time = online_egtb_cfg.min_time * 1000
+    minimum_time = datetime.timedelta(seconds=online_egtb_cfg.min_time)
     if (not use_online_egtb
-            or game.state[f"{wb}time"] < minimum_time
+            or datetime.timedelta(milliseconds=game.state[f"{wb}time"]) < minimum_time
             or board.uci_variant not in ["chess", "antichess", "atomic"]
             and source == "lichess"
             or board.uci_variant != "chess"

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -17,7 +17,7 @@ import config
 import model
 import lichess
 from config import Configuration
-from timer import msec, seconds
+from timer import msec, seconds, msec_str, sec_str
 from typing import Any, Optional, Union
 OPTIONS_TYPE = dict[str, Any]
 MOVE_INFO_TYPE = dict[str, Any]
@@ -579,7 +579,7 @@ def single_move_time(board: chess.Board, game: model.Game, search_time: datetime
     wb = "w" if board.turn == chess.WHITE else "b"
     clock_time = max(msec(0), msec(game.state[f"{wb}time"]) - overhead)
     search_time = min(search_time, clock_time)
-    logger.info(f"Searching for time {search_time.total_seconds()} seconds for game {game.id}")
+    logger.info(f"Searching for time {sec_str(search_time)} seconds for game {game.id}")
     return chess.engine.Limit(time=search_time.total_seconds(), clock_id="correspondence")
 
 
@@ -592,7 +592,7 @@ def first_move_time(game: model.Game) -> chess.engine.Limit:
     """
     # Need to hardcode first movetime since Lichess has 30 sec limit.
     search_time = seconds(10)
-    logger.info(f"Searching for time {search_time} seconds for game {game.id}")
+    logger.info(f"Searching for time {sec_str(search_time)} seconds for game {game.id}")
     return chess.engine.Limit(time=search_time.total_seconds(), clock_id="first move")
 
 
@@ -614,7 +614,7 @@ def game_clock_time(board: chess.Board,
     times = {side: msec(game.state[side]) for side in ["wtime", "btime"]}
     wb = "w" if board.turn == chess.WHITE else "b"
     times[f"{wb}time"] = max(msec(0), times[f"{wb}time"] - overhead)
-    logger.info("Searching for wtime {wtime} btime {btime}".format_map(times) + f" for game {game.id}")
+    logger.info(f"Searching for wtime {msec_str(times['wtime'])} btime {msec_str(times['btime'])} for game {game.id}")
     return chess.engine.Limit(white_clock=times["wtime"].total_seconds(),
                               black_clock=times["btime"].total_seconds(),
                               white_inc=msec(game.state["winc"]).total_seconds(),

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -18,7 +18,7 @@ import config
 import model
 import lichess
 from config import Configuration
-from timer import Timer, msec, seconds, msec_str, sec_str
+from timer import Timer, msec, seconds, msec_str, sec_str, to_seconds
 from typing import Any, Optional, Union
 OPTIONS_TYPE = dict[str, Any]
 MOVE_INFO_TYPE = dict[str, Any]
@@ -163,7 +163,7 @@ class EngineWrapper:
         # Heed min_time
         elapsed = setup_timer.time_since_reset()
         if elapsed < min_time:
-            time.sleep((min_time - elapsed).total_seconds())
+            time.sleep(to_seconds(min_time - elapsed))
 
         self.add_comment(best_move, board)
         self.print_stats()
@@ -178,7 +178,7 @@ class EngineWrapper:
         if movetime_cfg is not None:
             movetime = msec(movetime_cfg)
             if time_limit.time is None or seconds(time_limit.time) > movetime:
-                time_limit.time = movetime.total_seconds()
+                time_limit.time = to_seconds(movetime)
         time_limit.depth = self.go_commands.depth
         time_limit.nodes = self.go_commands.nodes
         return time_limit
@@ -596,7 +596,7 @@ def single_move_time(board: chess.Board, game: model.Game, search_time: datetime
     clock_time = max(msec(0), msec(game.state[f"{wb}time"]) - overhead)
     search_time = min(search_time, clock_time)
     logger.info(f"Searching for time {sec_str(search_time)} seconds for game {game.id}")
-    return chess.engine.Limit(time=search_time.total_seconds(), clock_id="correspondence")
+    return chess.engine.Limit(time=to_seconds(search_time), clock_id="correspondence")
 
 
 def first_move_time(game: model.Game) -> chess.engine.Limit:
@@ -609,7 +609,7 @@ def first_move_time(game: model.Game) -> chess.engine.Limit:
     # Need to hardcode first movetime since Lichess has 30 sec limit.
     search_time = seconds(10)
     logger.info(f"Searching for time {sec_str(search_time)} seconds for game {game.id}")
-    return chess.engine.Limit(time=search_time.total_seconds(), clock_id="first move")
+    return chess.engine.Limit(time=to_seconds(search_time), clock_id="first move")
 
 
 def game_clock_time(board: chess.Board,
@@ -631,10 +631,10 @@ def game_clock_time(board: chess.Board,
     wb = "w" if board.turn == chess.WHITE else "b"
     times[f"{wb}time"] = max(msec(0), times[f"{wb}time"] - overhead)
     logger.info(f"Searching for wtime {msec_str(times['wtime'])} btime {msec_str(times['btime'])} for game {game.id}")
-    return chess.engine.Limit(white_clock=times["wtime"].total_seconds(),
-                              black_clock=times["btime"].total_seconds(),
-                              white_inc=msec(game.state["winc"]).total_seconds(),
-                              black_inc=msec(game.state["binc"]).total_seconds(),
+    return chess.engine.Limit(white_clock=to_seconds(times["wtime"]),
+                              black_clock=to_seconds(times["btime"]),
+                              white_inc=to_seconds(msec(game.state["winc"])),
+                              black_inc=to_seconds(msec(game.state["binc"])),
                               clock_id="real time")
 
 

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -616,13 +616,13 @@ def play_game(li: lichess.Lichess,
                     if not is_game_over(game) and is_engine_move(game, prior_game, board):
                         disconnect_time = correspondence_disconnect_time
                         say_hello(conversation, hello, hello_spectators, board)
-                        start_time = time.perf_counter()
+                        setup_timer = Timer()
                         print_move_number(board)
                         move_attempted = True
                         engine.play_move(board,
                                          game,
                                          li,
-                                         start_time,
+                                         setup_timer,
                                          move_overhead,
                                          can_ponder,
                                          is_correspondence,

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -629,7 +629,7 @@ def play_game(li: lichess.Lichess,
                                          correspondence_move_time,
                                          engine_cfg,
                                          fake_think_time(config, board, game))
-                        time.sleep(delay_seconds)
+                        time.sleep(delay_seconds.total_seconds())
                     elif is_game_over(game):
                         tell_user_game_result(game, board)
                         engine.send_game_result(game, board)
@@ -673,12 +673,12 @@ def say_hello(conversation: Conversation, hello: str, hello_spectators: str, boa
         conversation.send_message("spectator", hello_spectators)
 
 
-def fake_think_time(config: Configuration, board: chess.Board, game: model.Game) -> float:
+def fake_think_time(config: Configuration, board: chess.Board, game: model.Game) -> datetime.timedelta:
     """Calculate how much time we should wait for fake_think_time."""
-    sleep = 0.0
+    sleep = seconds(0.0)
 
     if config.fake_think_time and len(board.move_stack) > 9:
-        remaining = max(0, game.my_remaining_seconds() - config.move_overhead / 1000)
+        remaining = max(seconds(0), game.my_remaining_seconds() - msec(config.move_overhead))
         delay = remaining * 0.025
         accel = 0.99 ** (len(board.move_stack) - 10)
         sleep = delay * accel

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -591,7 +591,7 @@ def play_game(li: lichess.Lichess,
         ponder_cfg = correspondence_cfg if is_correspondence else engine_cfg
         can_ponder = ponder_cfg.uci_ponder or ponder_cfg.ponder
         move_overhead = msec(config.move_overhead)
-        delay_seconds = msec(config.rate_limiting_delay)
+        delay = msec(config.rate_limiting_delay)
 
         keyword_map: defaultdict[str, str] = defaultdict(str, me=game.me.name, opponent=game.opponent.name)
         hello = get_greeting("hello", config.greeting, keyword_map)
@@ -629,7 +629,7 @@ def play_game(li: lichess.Lichess,
                                          correspondence_move_time,
                                          engine_cfg,
                                          fake_think_time(config, board, game))
-                        time.sleep(delay_seconds.total_seconds())
+                        time.sleep(delay.total_seconds())
                     elif is_game_over(game):
                         tell_user_game_result(game, board)
                         engine.send_game_result(game, board)

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -616,7 +616,7 @@ def play_game(li: lichess.Lichess,
                     if not is_game_over(game) and is_engine_move(game, prior_game, board):
                         disconnect_time = correspondence_disconnect_time
                         say_hello(conversation, hello, hello_spectators, board)
-                        start_time = datetime.datetime.now()
+                        start_time = time.perf_counter()
                         print_move_number(board)
                         move_attempted = True
                         engine.play_move(board,

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -678,7 +678,7 @@ def fake_think_time(config: Configuration, board: chess.Board, game: model.Game)
     sleep = seconds(0.0)
 
     if config.fake_think_time and len(board.move_stack) > 9:
-        remaining = max(seconds(0), game.my_remaining_seconds() - msec(config.move_overhead))
+        remaining = max(seconds(0), game.my_remaining_time() - msec(config.move_overhead))
         delay = remaining * 0.025
         accel = 0.99 ** (len(board.move_stack) - 10)
         sleep = delay * accel

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -24,7 +24,7 @@ import yaml
 import traceback
 from config import load_config, Configuration
 from conversation import Conversation, ChatLine
-from timer import Timer, seconds, msec, hours
+from timer import Timer, seconds, msec, hours, to_seconds
 from requests.exceptions import ChunkedEncodingError, ConnectionError, HTTPError, ReadTimeout
 from asyncio.exceptions import TimeoutError as MoveTimeout
 from rich.logging import RichHandler
@@ -113,7 +113,7 @@ def do_correspondence_ping(control_queue: CONTROL_QUEUE_TYPE, period: datetime.t
     :param period: How many seconds to wait before sending a correspondence ping.
     """
     while not terminated:
-        time.sleep(period.total_seconds())
+        time.sleep(to_seconds(period))
         control_queue.put_nowait({"type": "correspondence_ping"})
 
 
@@ -629,7 +629,7 @@ def play_game(li: lichess.Lichess,
                                          correspondence_move_time,
                                          engine_cfg,
                                          fake_think_time(config, board, game))
-                        time.sleep(delay.total_seconds())
+                        time.sleep(to_seconds(delay))
                     elif is_game_over(game):
                         tell_user_game_result(game, board)
                         engine.send_game_result(game, board)

--- a/lichess.py
+++ b/lichess.py
@@ -9,7 +9,7 @@ import logging
 import traceback
 from collections import defaultdict
 import datetime
-from timer import Timer
+from timer import Timer, seconds
 from typing import Optional, Union, Any
 import chess.engine
 JSON_REPLY_TYPE = dict[str, Any]
@@ -132,7 +132,7 @@ class Lichess:
         response = self.session.get(url, params=params, timeout=timeout, stream=stream)
 
         if is_new_rate_limit(response):
-            delay = datetime.timedelta(seconds=1 if endpoint_name == "move" else 60)
+            delay = seconds(1 if endpoint_name == "move" else 60)
             self.set_rate_limit_delay(path_template, delay)
 
         response.raise_for_status()
@@ -214,7 +214,7 @@ class Lichess:
         response = self.session.post(url, data=data, headers=headers, params=params, json=payload, timeout=2)
 
         if is_new_rate_limit(response):
-            self.set_rate_limit_delay(path_template, datetime.timedelta(seconds=60))
+            self.set_rate_limit_delay(path_template, seconds(60))
 
         if raise_for_status:
             response.raise_for_status()

--- a/lichess.py
+++ b/lichess.py
@@ -9,7 +9,7 @@ import logging
 import traceback
 from collections import defaultdict
 import datetime
-from timer import Timer, seconds
+from timer import Timer, seconds, sec_str
 from typing import Optional, Union, Any
 import chess.engine
 JSON_REPLY_TYPE = dict[str, Any]
@@ -232,7 +232,7 @@ class Lichess:
         path_template = ENDPOINTS[endpoint_name]
         if self.is_rate_limited(path_template):
             raise RateLimited(f"{path_template} is rate-limited. "
-                              f"Will retry in {self.rate_limit_time_left(path_template).total_seconds()} seconds.")
+                              f"Will retry in {sec_str(self.rate_limit_time_left(path_template))} seconds.")
         return path_template
 
     def set_rate_limit_delay(self, path_template: str, delay_time: datetime.timedelta) -> None:

--- a/lichess.py
+++ b/lichess.py
@@ -8,6 +8,7 @@ import backoff
 import logging
 import traceback
 from collections import defaultdict
+import datetime
 from timer import Timer
 from typing import Optional, Union, Any
 import chess.engine
@@ -131,7 +132,7 @@ class Lichess:
         response = self.session.get(url, params=params, timeout=timeout, stream=stream)
 
         if is_new_rate_limit(response):
-            delay = 1 if endpoint_name == "move" else 60
+            delay = datetime.timedelta(seconds=1 if endpoint_name == "move" else 60)
             self.set_rate_limit_delay(path_template, delay)
 
         response.raise_for_status()
@@ -213,7 +214,7 @@ class Lichess:
         response = self.session.post(url, data=data, headers=headers, params=params, json=payload, timeout=2)
 
         if is_new_rate_limit(response):
-            self.set_rate_limit_delay(path_template, 60)
+            self.set_rate_limit_delay(path_template, datetime.timedelta(seconds=60))
 
         if raise_for_status:
             response.raise_for_status()
@@ -231,10 +232,10 @@ class Lichess:
         path_template = ENDPOINTS[endpoint_name]
         if self.is_rate_limited(path_template):
             raise RateLimited(f"{path_template} is rate-limited. "
-                              f"Will retry in {int(self.rate_limit_time_left(path_template))} seconds.")
+                              f"Will retry in {self.rate_limit_time_left(path_template).total_seconds()} seconds.")
         return path_template
 
-    def set_rate_limit_delay(self, path_template: str, delay_time: int) -> None:
+    def set_rate_limit_delay(self, path_template: str, delay_time: datetime.timedelta) -> None:
         """
         Set a delay to a path template if it was rate limited.
 
@@ -248,7 +249,7 @@ class Lichess:
         """Check if a path template is rate limited."""
         return not self.rate_limit_timers[path_template].is_expired()
 
-    def rate_limit_time_left(self, path_template: str) -> float:
+    def rate_limit_time_left(self, path_template: str) -> datetime.timedelta:
         """How much time is left until we can use the path template normally."""
         return self.rate_limit_timers[path_template].time_until_expiration()
 

--- a/matchmaking.py
+++ b/matchmaking.py
@@ -2,7 +2,7 @@
 import random
 import logging
 import model
-from timer import Timer
+from timer import Timer, seconds, minutes, days
 from collections import defaultdict
 from collections.abc import Sequence
 import lichess
@@ -18,6 +18,7 @@ logger = logging.getLogger(__name__)
 
 daily_challenges_file_name = "daily_challenge_times.txt"
 
+
 def read_daily_challenges() -> DAILY_TIMERS_TYPE:
     """Read the challenges we have created in the past 24 hours from a text file."""
     timers: DAILY_TIMERS_TYPE = []
@@ -28,7 +29,7 @@ def read_daily_challenges() -> DAILY_TIMERS_TYPE:
                     timestamp = float(line)
                 except ValueError:
                     timestamp = None
-                timers.append(Timer(datetime.timedelta(days=1), timestamp))
+                timers.append(Timer(days(1), timestamp))
     except FileNotFoundError:
         pass
 
@@ -51,10 +52,10 @@ class Matchmaking:
         self.variants = list(filter(lambda variant: variant != "fromPosition", config.challenge.variants))
         self.matchmaking_cfg = config.matchmaking
         self.user_profile = user_profile
-        self.last_challenge_created_delay = Timer(datetime.timedelta(seconds=25))  # Challenges expire after 20 seconds.
-        self.last_game_ended_delay = Timer(datetime.timedelta(minutes=self.matchmaking_cfg.challenge_timeout))
-        self.last_user_profile_update_time = Timer(datetime.timedelta(minutes=5))
-        self.min_wait_time = datetime.timedelta(seconds=60)  # Wait before new challenge to avoid api rate limits.
+        self.last_challenge_created_delay = Timer(seconds(25))  # Challenges expire after 20 seconds.
+        self.last_game_ended_delay = Timer(minutes(self.matchmaking_cfg.challenge_timeout))
+        self.last_user_profile_update_time = Timer(minutes(5))
+        self.min_wait_time = seconds(60)  # Wait before new challenge to avoid api rate limits.
         self.challenge_id: str = ""
         self.daily_challenges: DAILY_TIMERS_TYPE = read_daily_challenges()
 
@@ -125,8 +126,8 @@ class Matchmaking:
         etc.
         """
         self.daily_challenges = [timer for timer in self.daily_challenges if not timer.is_expired()]
-        self.daily_challenges.append(Timer(datetime.timedelta(days=1)))
-        self.min_wait_time = datetime.timedelta(seconds=60) * ((len(self.daily_challenges) // 50) + 1)
+        self.daily_challenges.append(Timer(days(1)))
+        self.min_wait_time = seconds(60) * ((len(self.daily_challenges) // 50) + 1)
         write_daily_challenges(self.daily_challenges)
 
     def perf(self) -> dict[str, dict[str, Any]]:

--- a/matchmaking.py
+++ b/matchmaking.py
@@ -17,8 +17,6 @@ DAILY_TIMERS_TYPE = list[Timer]
 logger = logging.getLogger(__name__)
 
 daily_challenges_file_name = "daily_challenge_times.txt"
-timestamp_format = "%Y-%m-%d %H:%M:%S\n"
-
 
 def read_daily_challenges() -> DAILY_TIMERS_TYPE:
     """Read the challenges we have created in the past 24 hours from a text file."""
@@ -26,7 +24,11 @@ def read_daily_challenges() -> DAILY_TIMERS_TYPE:
     try:
         with open(daily_challenges_file_name) as file:
             for line in file:
-                timers.append(Timer(datetime.timedelta(days=1), datetime.datetime.strptime(line, timestamp_format)))
+                try:
+                    timestamp = float(line)
+                except ValueError:
+                    timestamp = None
+                timers.append(Timer(datetime.timedelta(days=1), timestamp))
     except FileNotFoundError:
         pass
 
@@ -37,7 +39,7 @@ def write_daily_challenges(daily_challenges: DAILY_TIMERS_TYPE) -> None:
     """Write the challenges we have created in the past 24 hours to a text file."""
     with open(daily_challenges_file_name, "w") as file:
         for timer in daily_challenges:
-            file.write(timer.starting_timestamp().strftime(timestamp_format))
+            file.write(f"{timer.starting_timestamp()}\n")
 
 
 class Matchmaking:

--- a/matchmaking.py
+++ b/matchmaking.py
@@ -17,6 +17,7 @@ DAILY_TIMERS_TYPE = list[Timer]
 logger = logging.getLogger(__name__)
 
 daily_challenges_file_name = "daily_challenge_times.txt"
+timestamp_format = "%Y-%m-%d %H:%M:%S\n"
 
 
 def read_daily_challenges() -> DAILY_TIMERS_TYPE:
@@ -25,11 +26,7 @@ def read_daily_challenges() -> DAILY_TIMERS_TYPE:
     try:
         with open(daily_challenges_file_name) as file:
             for line in file:
-                try:
-                    timestamp = float(line)
-                except ValueError:
-                    timestamp = None
-                timers.append(Timer(days(1), timestamp))
+                timers.append(Timer(days(1), datetime.datetime.strptime(line, timestamp_format)))
     except FileNotFoundError:
         pass
 
@@ -40,7 +37,7 @@ def write_daily_challenges(daily_challenges: DAILY_TIMERS_TYPE) -> None:
     """Write the challenges we have created in the past 24 hours to a text file."""
     with open(daily_challenges_file_name, "w") as file:
         for timer in daily_challenges:
-            file.write(f"{timer.starting_timestamp()}\n")
+            file.write(f"{timer.starting_timestamp(timestamp_format)}\n")
 
 
 class Matchmaking:

--- a/matchmaking.py
+++ b/matchmaking.py
@@ -37,7 +37,7 @@ def write_daily_challenges(daily_challenges: DAILY_TIMERS_TYPE) -> None:
     """Write the challenges we have created in the past 24 hours to a text file."""
     with open(daily_challenges_file_name, "w") as file:
         for timer in daily_challenges:
-            file.write(f"{timer.starting_timestamp(timestamp_format)}\n")
+            file.write(timer.starting_timestamp(timestamp_format))
 
 
 class Matchmaking:

--- a/model.py
+++ b/model.py
@@ -222,7 +222,7 @@ class Game:
         """Whether we should disconnect form the game."""
         return self.disconnect_time.is_expired()
 
-    def my_remaining_seconds(self) -> datetime.timedelta:
+    def my_remaining_time(self) -> datetime.timedelta:
         """How many seconds we have left."""
         wtime = msec(self.state["wtime"])
         btime = msec(self.state["btime"])

--- a/model.py
+++ b/model.py
@@ -150,7 +150,7 @@ class Game:
         self.id: str = game_info["id"]
         self.speed = game_info.get("speed")
         clock = game_info.get("clock") or {}
-        ten_years_in_ms = 1000 * 3600 * 24 * 365 * 10
+        ten_years_in_ms = 10 * datetime.timedelta(days=365) / datetime.timedelta(milliseconds=1)
         self.clock_initial = clock.get("initial", ten_years_in_ms)
         self.clock_increment = clock.get("increment", 0)
         self.perf_name = (game_info.get("perf") or {}).get("name", "{perf?}")
@@ -223,9 +223,9 @@ class Game:
 
     def my_remaining_seconds(self) -> float:
         """How many seconds we have left."""
-        wtime: int = self.state["wtime"]
-        btime: int = self.state["btime"]
-        return (wtime if self.is_white else btime) / 1000
+        wtime = datetime.timedelta(milliseconds=self.state["wtime"])
+        btime = datetime.timedelta(milliseconds=self.state["btime"])
+        return (wtime if self.is_white else btime).total_seconds()
 
     def result(self) -> str:
         """Get the result of the game."""

--- a/model.py
+++ b/model.py
@@ -222,11 +222,11 @@ class Game:
         """Whether we should disconnect form the game."""
         return self.disconnect_time.is_expired()
 
-    def my_remaining_seconds(self) -> float:
+    def my_remaining_seconds(self) -> datetime.timedelta:
         """How many seconds we have left."""
         wtime = msec(self.state["wtime"])
         btime = msec(self.state["btime"])
-        return (wtime if self.is_white else btime).total_seconds()
+        return wtime if self.is_white else btime
 
     def result(self) -> str:
         """Get the result of the game."""

--- a/model.py
+++ b/model.py
@@ -4,7 +4,7 @@ from urllib.parse import urljoin
 import logging
 import datetime
 from enum import Enum
-from timer import Timer, msec, seconds, days, sec_str
+from timer import Timer, msec, seconds, sec_str, to_msec, to_seconds, years
 from config import Configuration
 from typing import Any
 from collections import defaultdict
@@ -150,7 +150,7 @@ class Game:
         self.id: str = game_info["id"]
         self.speed = game_info.get("speed")
         clock = game_info.get("clock") or {}
-        ten_years_in_ms = 10 * days(365) / msec(1)
+        ten_years_in_ms = to_msec(years(10))
         self.clock_initial = msec(clock.get("initial", ten_years_in_ms))
         self.clock_increment = msec(clock.get("increment", 0))
         self.perf_name = (game_info.get("perf") or {}).get("name", "{perf?}")
@@ -166,7 +166,7 @@ class Game:
         self.me = self.white if self.is_white else self.black
         self.opponent = self.black if self.is_white else self.white
         self.base_url = base_url
-        self.game_start = datetime.datetime.fromtimestamp(msec(game_info["createdAt"]).total_seconds(),
+        self.game_start = datetime.datetime.fromtimestamp(to_seconds(msec(game_info["createdAt"])),
                                                           tz=datetime.timezone.utc)
         self.abort_time = Timer(abort_time)
         self.terminate_time = Timer(self.clock_initial + self.clock_increment + abort_time + seconds(60))

--- a/model.py
+++ b/model.py
@@ -4,7 +4,7 @@ from urllib.parse import urljoin
 import logging
 import datetime
 from enum import Enum
-from timer import Timer, msec, seconds, days
+from timer import Timer, msec, seconds, days, sec_str
 from config import Configuration
 from typing import Any
 from collections import defaultdict
@@ -189,7 +189,7 @@ class Game:
 
     def time_control(self) -> str:
         """Get the time control of the game."""
-        return f"{int(self.clock_initial.total_seconds())}+{int(self.clock_increment.total_seconds())}"
+        return f"{sec_str(self.clock_initial)}+{sec_str(self.clock_increment)}"
 
     def is_abortable(self) -> bool:
         """Whether the game can be aborted."""

--- a/test_bot/lichess.py
+++ b/test_bot/lichess.py
@@ -5,7 +5,7 @@ import chess.engine
 import json
 import logging
 import traceback
-from timer import msec, seconds
+from timer import seconds, to_msec
 from typing import Union, Any, Optional, Generator
 
 logger = logging.getLogger(__name__)
@@ -80,8 +80,8 @@ class GameStream:
             time.sleep(0.1)
             new_game_state = {"type": "gameState",
                               "moves": moves,
-                              "wtime": int(wtime / msec(1)),
-                              "btime": int(btime / msec(1)),
+                              "wtime": int(to_msec(wtime)),
+                              "btime": int(to_msec(btime)),
                               "winc": 100,
                               "binc": 100}
             if event == "end":

--- a/test_bot/lichess.py
+++ b/test_bot/lichess.py
@@ -5,6 +5,7 @@ import chess.engine
 import json
 import logging
 import traceback
+from timer import msec, seconds
 from typing import Union, Any, Optional, Generator
 
 logger = logging.getLogger(__name__)
@@ -68,7 +69,7 @@ class GameStream:
                     board = chess.Board()
                     for move in moves.split():
                         board.push_uci(move)
-                    wtime, btime = [float(n) for n in state[1].split(",")]
+                    wtime, btime = [seconds(float(n)) for n in state[1].split(",")]
                     if len(moves) <= len(self.moves_sent) and not event:
                         time.sleep(0.001)
                         continue
@@ -79,8 +80,8 @@ class GameStream:
             time.sleep(0.1)
             new_game_state = {"type": "gameState",
                               "moves": moves,
-                              "wtime": int(wtime * 1000),
-                              "btime": int(wtime * 1000),
+                              "wtime": int(wtime / msec(1)),
+                              "btime": int(btime / msec(1)),
                               "winc": 100,
                               "binc": 100}
             if event == "end":

--- a/test_bot/lichess.py
+++ b/test_bot/lichess.py
@@ -68,7 +68,7 @@ class GameStream:
                     board = chess.Board()
                     for move in moves.split():
                         board.push_uci(move)
-                    wtime, btime = state[1].split(",")
+                    wtime, btime = [float(n) for n in state[1].split(",")]
                     if len(moves) <= len(self.moves_sent) and not event:
                         time.sleep(0.001)
                         continue
@@ -76,12 +76,11 @@ class GameStream:
                     break
                 except (IndexError, ValueError):
                     pass
-            wtime_int, wtime_int = float(wtime), float(btime)
             time.sleep(0.1)
             new_game_state = {"type": "gameState",
                               "moves": moves,
-                              "wtime": int(wtime_int * 1000),
-                              "btime": int(wtime_int * 1000),
+                              "wtime": int(wtime * 1000),
+                              "btime": int(wtime * 1000),
                               "winc": 100,
                               "binc": 100}
             if event == "end":

--- a/test_bot/test_bot.py
+++ b/test_bot/test_bot.py
@@ -3,7 +3,6 @@ import pytest
 import zipfile
 import requests
 import time
-import datetime
 import yaml
 import chess
 import chess.engine
@@ -14,7 +13,7 @@ import stat
 import shutil
 import importlib
 import config
-from timer import Timer, to_seconds
+from timer import Timer, to_seconds, seconds
 from typing import Any
 if __name__ == "__main__":
     sys.exit(f"The script {os.path.basename(__file__)} should only be run by pytest.")
@@ -87,8 +86,8 @@ def thread_for_test() -> None:
     open("./logs/states.txt", "w").close()
     open("./logs/result.txt", "w").close()
 
-    start_time = datetime.timedelta(seconds=10)
-    increment = datetime.timedelta(seconds=0.1)
+    start_time = seconds(10)
+    increment = seconds(0.1)
 
     board = chess.Board()
     wtime = start_time

--- a/test_bot/test_bot.py
+++ b/test_bot/test_bot.py
@@ -3,6 +3,7 @@ import pytest
 import zipfile
 import requests
 import time
+import datetime
 import yaml
 import chess
 import chess.engine
@@ -85,15 +86,15 @@ def thread_for_test() -> None:
     open("./logs/states.txt", "w").close()
     open("./logs/result.txt", "w").close()
 
-    start_time = 10.
-    increment = 0.1
+    start_time = datetime.timedelta(seconds=10)
+    increment = datetime.timedelta(seconds=0.1)
 
     board = chess.Board()
     wtime = start_time
     btime = start_time
 
     with open("./logs/states.txt", "w") as file:
-        file.write(f"\n{wtime},{btime}")
+        file.write(f"\n{wtime.total_seconds()},{btime.total_seconds()}")
 
     engine = chess.engine.SimpleEngine.popen_uci(stockfish_path)
     engine.configure({"Skill Level": 0, "Move Overhead": 1000, "Use NNUE": False})
@@ -105,13 +106,13 @@ def thread_for_test() -> None:
                                    chess.engine.Limit(time=1),
                                    ponder=False)
             else:
-                start_time = time.perf_counter_ns()
+                move_start_time = datetime.datetime.now()
                 move = engine.play(board,
-                                   chess.engine.Limit(white_clock=wtime - 2,
-                                                      white_inc=increment),
+                                   chess.engine.Limit(white_clock=wtime.total_seconds() - 2,
+                                                      white_inc=increment.total_seconds()),
                                    ponder=False)
-                end_time = time.perf_counter_ns()
-                wtime -= (end_time - start_time) / 1e9
+                move_end_time = datetime.datetime.now()
+                wtime -= (move_end_time - move_start_time)
                 wtime += increment
             engine_move = move.move
             if engine_move is None:
@@ -128,7 +129,7 @@ def thread_for_test() -> None:
                 file.write(state_str)
 
         else:  # lichess-bot move.
-            start_time = time.perf_counter_ns()
+            move_start_time = datetime.datetime.now()
             state2 = state_str
             moves_are_correct = False
             while state2 == state_str or not moves_are_correct:
@@ -145,9 +146,9 @@ def thread_for_test() -> None:
                         moves_are_correct = False
             with open("./logs/states.txt") as states:
                 state2 = states.read()
-            end_time = time.perf_counter_ns()
+            move_end_time = datetime.datetime.now()
             if len(board.move_stack) > 1:
-                btime -= (end_time - start_time) / 1e9
+                btime -= (move_end_time - move_start_time)
                 btime += increment
             move_str = state2.split("\n")[0].split(" ")[-1]
             board.push_uci(move_str)
@@ -156,7 +157,7 @@ def thread_for_test() -> None:
         with open("./logs/states.txt") as states:
             state_str = states.read()
         state = state_str.split("\n")
-        state[1] = f"{wtime},{btime}"
+        state[1] = f"{wtime.total_seconds()},{btime.total_seconds()}"
         state_str = "\n".join(state)
         with open("./logs/states.txt", "w") as file:
             file.write(state_str)

--- a/test_bot/test_bot.py
+++ b/test_bot/test_bot.py
@@ -95,7 +95,7 @@ def thread_for_test() -> None:
     btime = start_time
 
     with open("./logs/states.txt", "w") as file:
-        file.write(f"\n{wtime.total_seconds()},{btime.total_seconds()}")
+        file.write(f"\n{to_seconds(wtime)},{to_seconds(btime)}")
 
     engine = chess.engine.SimpleEngine.popen_uci(stockfish_path)
     engine.configure({"Skill Level": 0, "Move Overhead": 1000, "Use NNUE": False})

--- a/test_bot/test_bot.py
+++ b/test_bot/test_bot.py
@@ -14,7 +14,7 @@ import stat
 import shutil
 import importlib
 import config
-from timer import Timer
+from timer import Timer, to_seconds
 from typing import Any
 if __name__ == "__main__":
     sys.exit(f"The script {os.path.basename(__file__)} should only be run by pytest.")
@@ -109,8 +109,8 @@ def thread_for_test() -> None:
             else:
                 move_timer = Timer()
                 move = engine.play(board,
-                                   chess.engine.Limit(white_clock=wtime.total_seconds() - 2,
-                                                      white_inc=increment.total_seconds()),
+                                   chess.engine.Limit(white_clock=to_seconds(wtime) - 2,
+                                                      white_inc=to_seconds(increment)),
                                    ponder=False)
                 wtime -= move_timer.time_since_reset()
                 wtime += increment
@@ -156,7 +156,7 @@ def thread_for_test() -> None:
         with open("./logs/states.txt") as states:
             state_str = states.read()
         state = state_str.split("\n")
-        state[1] = f"{wtime.total_seconds()},{btime.total_seconds()}"
+        state[1] = f"{to_seconds(wtime)},{to_seconds(btime)}"
         state_str = "\n".join(state)
         with open("./logs/states.txt", "w") as file:
             file.write(state_str)

--- a/test_bot/test_bot.py
+++ b/test_bot/test_bot.py
@@ -14,6 +14,7 @@ import stat
 import shutil
 import importlib
 import config
+from timer import Timer
 from typing import Any
 if __name__ == "__main__":
     sys.exit(f"The script {os.path.basename(__file__)} should only be run by pytest.")
@@ -106,13 +107,12 @@ def thread_for_test() -> None:
                                    chess.engine.Limit(time=1),
                                    ponder=False)
             else:
-                move_start_time = datetime.datetime.now()
+                move_timer = Timer()
                 move = engine.play(board,
                                    chess.engine.Limit(white_clock=wtime.total_seconds() - 2,
                                                       white_inc=increment.total_seconds()),
                                    ponder=False)
-                move_end_time = datetime.datetime.now()
-                wtime -= (move_end_time - move_start_time)
+                wtime -= move_timer.time_since_reset()
                 wtime += increment
             engine_move = move.move
             if engine_move is None:
@@ -129,7 +129,7 @@ def thread_for_test() -> None:
                 file.write(state_str)
 
         else:  # lichess-bot move.
-            move_start_time = datetime.datetime.now()
+            move_timer = Timer()
             state2 = state_str
             moves_are_correct = False
             while state2 == state_str or not moves_are_correct:
@@ -146,9 +146,8 @@ def thread_for_test() -> None:
                         moves_are_correct = False
             with open("./logs/states.txt") as states:
                 state2 = states.read()
-            move_end_time = datetime.datetime.now()
             if len(board.move_stack) > 1:
-                btime -= (move_end_time - move_start_time)
+                btime -= move_timer.time_since_reset()
                 btime += increment
             move_str = state2.split("\n")[0].split(" ")[-1]
             board.push_uci(move_str)

--- a/timer.py
+++ b/timer.py
@@ -58,8 +58,8 @@ class Timer:
         """
         Start the timer.
 
-        :param duration: The duration of the timer. If duration is a float, then the unit is seconds.
-        :param backdated_timestamp: When the timer started. Used to keep the timers between sessions.
+        :param duration: The duration of time before Timer.is_expired() returns True.
+        :param backdated_timestamp: When the timer should have started. Used to keep the timers between sessions.
         """
         self.duration = duration
         self.reset()

--- a/timer.py
+++ b/timer.py
@@ -1,13 +1,38 @@
 """A timer for use in lichess-bot."""
 import time
 import datetime
-from typing import Optional, Union
+from typing import Optional
+
+
+def msec(time_in_msec: float) -> datetime.timedelta:
+    """Create a timedelta duration in milliseconds."""
+    return datetime.timedelta(milliseconds=time_in_msec)
+
+
+def seconds(time_in_sec: float) -> datetime.timedelta:
+    """Create a timedelta duration in seconds."""
+    return datetime.timedelta(seconds=time_in_sec)
+
+
+def minutes(time_in_minutes: float) -> datetime.timedelta:
+    """Create a timedelta duration in minutes."""
+    return datetime.timedelta(minutes=time_in_minutes)
+
+
+def hours(time_in_hours: float) -> datetime.timedelta:
+    """Create a timedelta duration in hours."""
+    return datetime.timedelta(minutes=time_in_hours)
+
+
+def days(time_in_days: float) -> datetime.timedelta:
+    """Create a timedelta duration in minutes."""
+    return datetime.timedelta(days=time_in_days)
 
 
 class Timer:
     """A timer for use in lichess-bot."""
 
-    def __init__(self, duration: Union[datetime.timedelta, float] = 0,
+    def __init__(self, duration: datetime.timedelta = seconds(0),
                  backdated_timestamp: Optional[float] = None) -> None:
         """
         Start the timer.
@@ -15,7 +40,7 @@ class Timer:
         :param duration: The duration of the timer. If duration is a float, then the unit is seconds.
         :param backdated_timestamp: When the timer started. Used to keep the timers between sessions.
         """
-        self.duration = duration if isinstance(duration, datetime.timedelta) else datetime.timedelta(seconds=duration)
+        self.duration = duration
         self.reset()
         if backdated_timestamp is not None:
             time_already_used = time.time() - backdated_timestamp
@@ -31,11 +56,11 @@ class Timer:
 
     def time_since_reset(self) -> datetime.timedelta:
         """How much time has passed."""
-        return datetime.timedelta(seconds=time.time() - self.starting_time)
+        return seconds(time.time() - self.starting_time)
 
     def time_until_expiration(self) -> datetime.timedelta:
         """How much time is left until it expires."""
-        return max(datetime.timedelta(), self.duration - self.time_since_reset())
+        return max(seconds(0), self.duration - self.time_since_reset())
 
     def starting_timestamp(self) -> float:
         """When the timer started."""

--- a/timer.py
+++ b/timer.py
@@ -48,7 +48,7 @@ class Timer:
     method time_until_expiration() gives the amount of time left until the timer
     expires.
 
-    Regardless of the initial duration (event if it's zero), a timer can be used
+    Regardless of the initial duration (even if it's zero), a timer can be used
     as a stopwatch by calling time_since_reset() to get the amount of time since
     the timer was created or since it was last reset.
     """

--- a/timer.py
+++ b/timer.py
@@ -54,7 +54,7 @@ class Timer:
     """
 
     def __init__(self, duration: datetime.timedelta = seconds(0),
-                 backdated_timestamp: Optional[float] = None) -> None:
+                 backdated_timestamp: Optional[datetime.datetime] = None) -> None:
         """
         Start the timer.
 
@@ -73,11 +73,11 @@ class Timer:
 
     def reset(self) -> None:
         """Reset the timer."""
-        self.starting_time = time.time()
+        self.starting_time = time.monotonic()
 
     def time_since_reset(self) -> datetime.timedelta:
         """How much time has passed."""
-        return seconds(time.time() - self.starting_time)
+        return seconds(time.monotonic() - self.starting_time)
 
     def time_until_expiration(self) -> datetime.timedelta:
         """How much time is left until it expires."""

--- a/timer.py
+++ b/timer.py
@@ -1,4 +1,5 @@
 """A timer for use in lichess-bot."""
+import time
 import datetime
 from typing import Optional, Union
 
@@ -7,17 +8,17 @@ class Timer:
     """A timer for use in lichess-bot."""
 
     def __init__(self, duration: Union[datetime.timedelta, float] = 0,
-                 backdated_start: Optional[datetime.datetime] = None) -> None:
+                 backdated_timestamp: Optional[float] = None) -> None:
         """
         Start the timer.
 
         :param duration: The duration of the timer. If duration is a float, then the unit is seconds.
-        :param backdated_start: When the timer started. Used to keep the timers between sessions.
+        :param backdated_timestamp: When the timer started. Used to keep the timers between sessions.
         """
         self.duration = duration if isinstance(duration, datetime.timedelta) else datetime.timedelta(seconds=duration)
         self.reset()
-        if backdated_start:
-            time_already_used = datetime.datetime.now() - backdated_start
+        if backdated_timestamp is not None:
+            time_already_used = time.time() - backdated_timestamp
             self.starting_time -= time_already_used
 
     def is_expired(self) -> bool:
@@ -26,16 +27,16 @@ class Timer:
 
     def reset(self) -> None:
         """Reset the timer."""
-        self.starting_time = datetime.datetime.now()
+        self.starting_time = time.time()
 
     def time_since_reset(self) -> datetime.timedelta:
         """How much time has passed."""
-        return datetime.datetime.now() - self.starting_time
+        return datetime.timedelta(seconds=time.time() - self.starting_time)
 
     def time_until_expiration(self) -> datetime.timedelta:
         """How much time is left until it expires."""
         return max(datetime.timedelta(), self.duration - self.time_since_reset())
 
-    def starting_timestamp(self) -> datetime.datetime:
+    def starting_timestamp(self) -> float:
         """When the timer started."""
-        return datetime.datetime.now() - self.time_since_reset()
+        return time.time() - self.time_since_reset().total_seconds()

--- a/timer.py
+++ b/timer.py
@@ -40,7 +40,18 @@ def days(time_in_days: float) -> datetime.timedelta:
 
 
 class Timer:
-    """A timer for use in lichess-bot."""
+    """
+    A timer for use in lichess-bot. An instance of timer can be used both as a countdown timer and a stopwatch.
+
+    If the duration argument in the __init__() method is greater than zero, then
+    the method is_expired() indicates when the intial duration has passed. The
+    method time_until_expiration() gives the amount of time left until the timer
+    expires.
+
+    Regardless of the initial duration (event if it's zero), a timer can be used
+    as a stopwatch by calling time_since_reset() to get the amount of time since
+    the timer was created or since it was last reset.
+    """
 
     def __init__(self, duration: datetime.timedelta = seconds(0),
                  backdated_timestamp: Optional[float] = None) -> None:

--- a/timer.py
+++ b/timer.py
@@ -83,6 +83,6 @@ class Timer:
         """How much time is left until it expires."""
         return max(seconds(0), self.duration - self.time_since_reset())
 
-    def starting_timestamp(self) -> float:
+    def starting_timestamp(self, format: str) -> str:
         """When the timer started."""
-        return time.time() - self.time_since_reset().total_seconds()
+        return (datetime.datetime.now() - self.time_since_reset()).strftime(format)

--- a/timer.py
+++ b/timer.py
@@ -9,9 +9,14 @@ def msec(time_in_msec: float) -> datetime.timedelta:
     return datetime.timedelta(milliseconds=time_in_msec)
 
 
+def to_msec(duration: datetime.timedelta) -> float:
+    """Return a bare number representing the length of the duration in milliseconds."""
+    return duration / msec(1)
+
+
 def msec_str(duration: datetime.timedelta) -> str:
     """Return a string with the duration value in whole number milliseconds."""
-    return f"{round(duration/msec(1))}"
+    return f"{round(to_msec(duration))}"
 
 
 def seconds(time_in_sec: float) -> datetime.timedelta:
@@ -19,9 +24,14 @@ def seconds(time_in_sec: float) -> datetime.timedelta:
     return datetime.timedelta(seconds=time_in_sec)
 
 
+def to_seconds(duration: datetime.timedelta) -> float:
+    """Return a bare number representing the length of the duration in seconds."""
+    return duration.total_seconds()
+
+
 def sec_str(duration: datetime.timedelta) -> str:
     """Return a string with the duration value in whole number seconds."""
-    return f"{round(duration.total_seconds())}"
+    return f"{round(to_seconds(duration))}"
 
 
 def minutes(time_in_minutes: float) -> datetime.timedelta:
@@ -37,6 +47,11 @@ def hours(time_in_hours: float) -> datetime.timedelta:
 def days(time_in_days: float) -> datetime.timedelta:
     """Create a timedelta duration in minutes."""
     return datetime.timedelta(days=time_in_days)
+
+
+def years(time_in_years: float) -> datetime.timedelta:
+    """Create a timedelta duration in median years--i.e., 365 days."""
+    return days(365 * time_in_years)
 
 
 class Timer:
@@ -65,7 +80,7 @@ class Timer:
         self.reset()
         if backdated_timestamp is not None:
             time_already_used = datetime.datetime.now() - backdated_timestamp
-            self.starting_time -= time_already_used.total_seconds()
+            self.starting_time -= to_seconds(time_already_used)
 
     def is_expired(self) -> bool:
         """Check if a timer is expired."""

--- a/timer.py
+++ b/timer.py
@@ -64,8 +64,8 @@ class Timer:
         self.duration = duration
         self.reset()
         if backdated_timestamp is not None:
-            time_already_used = time.time() - backdated_timestamp
-            self.starting_time -= time_already_used
+            time_already_used = datetime.datetime.now() - backdated_timestamp
+            self.starting_time -= time_already_used.total_seconds()
 
     def is_expired(self) -> bool:
         """Check if a timer is expired."""
@@ -73,11 +73,11 @@ class Timer:
 
     def reset(self) -> None:
         """Reset the timer."""
-        self.starting_time = time.monotonic()
+        self.starting_time = time.perf_counter()
 
     def time_since_reset(self) -> datetime.timedelta:
         """How much time has passed."""
-        return seconds(time.monotonic() - self.starting_time)
+        return seconds(time.perf_counter() - self.starting_time)
 
     def time_until_expiration(self) -> datetime.timedelta:
         """How much time is left until it expires."""

--- a/timer.py
+++ b/timer.py
@@ -1,24 +1,24 @@
 """A timer for use in lichess-bot."""
-import time
 import datetime
-from typing import Optional
+from typing import Optional, Union
 
 
 class Timer:
     """A timer for use in lichess-bot."""
 
-    def __init__(self, duration: float = 0, backdated_start: Optional[datetime.datetime] = None) -> None:
+    def __init__(self, duration: Union[datetime.timedelta, float] = 0,
+                 backdated_start: Optional[datetime.datetime] = None) -> None:
         """
         Start the timer.
 
-        :param duration: The duration of the timer.
+        :param duration: The duration of the timer. If duration is a float, then the unit is seconds.
         :param backdated_start: When the timer started. Used to keep the timers between sessions.
         """
-        self.duration = duration
+        self.duration = duration if isinstance(duration, datetime.timedelta) else datetime.timedelta(seconds=duration)
         self.reset()
         if backdated_start:
             time_already_used = datetime.datetime.now() - backdated_start
-            self.starting_time -= time_already_used.total_seconds()
+            self.starting_time -= time_already_used
 
     def is_expired(self) -> bool:
         """Check if a timer is expired."""
@@ -26,16 +26,16 @@ class Timer:
 
     def reset(self) -> None:
         """Reset the timer."""
-        self.starting_time = time.time()
+        self.starting_time = datetime.datetime.now()
 
-    def time_since_reset(self) -> float:
+    def time_since_reset(self) -> datetime.timedelta:
         """How much time has passed."""
-        return time.time() - self.starting_time
+        return datetime.datetime.now() - self.starting_time
 
-    def time_until_expiration(self) -> float:
+    def time_until_expiration(self) -> datetime.timedelta:
         """How much time is left until it expires."""
-        return max(0., self.duration - self.time_since_reset())
+        return max(datetime.timedelta(), self.duration - self.time_since_reset())
 
     def starting_timestamp(self) -> datetime.datetime:
         """When the timer started."""
-        return datetime.datetime.now() - datetime.timedelta(seconds=self.time_since_reset())
+        return datetime.datetime.now() - self.time_since_reset()

--- a/timer.py
+++ b/timer.py
@@ -9,9 +9,19 @@ def msec(time_in_msec: float) -> datetime.timedelta:
     return datetime.timedelta(milliseconds=time_in_msec)
 
 
+def msec_str(duration: datetime.timedelta) -> str:
+    """Return a string with the duration value in whole number milliseconds."""
+    return f"{round(duration/msec(1))}"
+
+
 def seconds(time_in_sec: float) -> datetime.timedelta:
     """Create a timedelta duration in seconds."""
     return datetime.timedelta(seconds=time_in_sec)
+
+
+def sec_str(duration: datetime.timedelta) -> str:
+    """Return a string with the duration value in whole number seconds."""
+    return f"{round(duration.total_seconds())}"
 
 
 def minutes(time_in_minutes: float) -> datetime.timedelta:


### PR DESCRIPTION
This PR replaces all `int` and `float` data that represent time with proper types.
- Duration: bare `int` and `float` replaced by `datetime.timedelta`
- Stopwatch: two calls to `time.perf_counter()` replaced with `Timer` and calls to `time_since_reset()`
- `Timer` internals: replace `time.time()` (which can be altered by system clock changes like daylight saving time) with the monotonic `time.perf_counter()`
- Variables tagged with `_ms`, `_sec`, etc.: explicit conversions to `timedelta` with functions named `msec()`, `seconds()`, etc.

The main benefit of these changes is that there is no need to keep track of what units a given `int` or `float` variable is using to store its time. There is no more need for `* 1000` or `/ 1e9` or `* 60` operations to get numbers into common units. Everything is handled by the `timedelta` type. The result of `seconds(5) + msec(50)` is correctly computed without manually coded conversions.

Other bugs fixed:
- test_bot/lichess.py line 84: `wtime` used instead of `btime`

Note:
The only time variables that were not converted to `datetime.timedelta` are the time control variables in the functions that create a new challenge (`create_challenge()` and `choose_opponent()`). Since these functions select values from lists in the user's config file and then immediately send them to `Lichess.challenge()`, the round trip from `int` to `timedelta` and back to `int` seemed pointless.