### PR TITLE
Convert number from config file to timedelta

### DIFF
--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -531,12 +531,10 @@ def handle_challenge(event: EVENT_TYPE, li: lichess.Lichess, challenge_queue: MU
     is_supported, decline_reason = chlng.is_supported(challenge_config, recent_bot_challenges)
     if is_supported:
         challenge_queue.append(chlng)
-        if challenge_config.recent_bot_challenge_age is not None:
-            recent_bot_challenges[chlng.challenger.name].append(Timer(challenge_config.recent_bot_challenge_age))
         sort_challenges(challenge_queue, challenge_config)
         time_window = challenge_config.recent_bot_challenge_age
         if time_window is not None:
-            recent_bot_challenges[chlng.challenger.name].append(Timer(time_window))
+            recent_bot_challenges[chlng.challenger.name].append(Timer(seconds(time_window)))
     elif chlng.id != matchmaker.challenge_id:
         li.decline_challenge(chlng.id, reason=decline_reason)
 


### PR DESCRIPTION
This number from the configuration file was not converted to a datetime.timedelta in seconds before being used to create a Timer.

Also, deleted duplicate lines.

Closes #808