### PR TITLE
Try to load engine on startup

### DIFF
--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -968,7 +968,13 @@ def start_lichess_bot() -> None:
         auto_log_filename = "./lichess_bot_auto_logs/recent.log"
     logging_configurer(logging_level, args.logfile, auto_log_filename, True)
     logger.info(intro(), extra={"highlighter": None})
+
     CONFIG = load_config(args.config or "./config.yml")
+    logger.info("Checking engine configuration ...")
+    with engine_wrapper.create_engine(CONFIG):
+        pass
+    logger.info("Engine configuration OK")
+
     max_retries = CONFIG.engine.online_moves.max_retries
     check_python_version()
     li = lichess.Lichess(CONFIG.token, CONFIG.url, __version__, logging_level, max_retries)


### PR DESCRIPTION
Instead of waiting for a game to begin to first try to start the chess engine, make an attempt to start it when lichess-bot starts. This way, if there is something wrong with the user's engine or configuration, they will find out immediately.