### PR TITLE
Allow for toggle-type engine options

### DIFF
--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -48,7 +48,7 @@ def create_engine(engine_config: config.Configuration) -> Generator[EngineWrappe
     commands = [engine_path]
     if cfg.engine_options:
         for k, v in cfg.engine_options.items():
-            commands.append(f"--{k}={v}")
+            commands.append(f"--{k}={v}" if v is not None else f"--{k}")
 
     stderr = None if cfg.silence_stderr else subprocess.DEVNULL
 


### PR DESCRIPTION
An engine may have a command line option that doesn't take a value--i.e., one that toggles some option on or off. This will be indicated in the user's config file by leaving the value of an option empty or nil. This change will translate the engine_options section of their config file from this

    engine:
      name: engine_name
      engine_options:
        settings: settings.txt
        logging:

into the command line instruction

    engine_name --settings=settings.txt --logging