### PR TITLE
Implement matchmaking overrides

### DIFF
--- a/config.py
+++ b/config.py
@@ -6,7 +6,7 @@ import logging
 import math
 from abc import ABCMeta
 from enum import Enum
-from typing import Any
+from typing import Any, Union
 CONFIG_DICT_TYPE = dict[str, Any]
 
 logger = logging.getLogger(__name__)
@@ -55,6 +55,15 @@ class Configuration:
     def items(self) -> Any:
         """:return: All the key-value pairs in this config."""
         return self.config.items()
+
+    def keys(self) -> list[str]:
+        """:return: All of the keys in this config."""
+        return list(self.config.keys())
+
+    def __or__(self, other: Union["Configuration", CONFIG_DICT_TYPE]) -> "Configuration":
+        """Create a copy of this configuration that is updated with values from the parameter."""
+        other_dict = other.config if isinstance(other, Configuration) else other
+        return Configuration(self.config | other_dict)
 
     def __bool__(self) -> bool:
         """Whether `self.config` is empty."""
@@ -221,6 +230,7 @@ def insert_default_values(CONFIG: CONFIG_DICT_TYPE) -> None:
     set_config_default(CONFIG, "matchmaking", key="opponent_allow_tos_violation", default=True)
     set_config_default(CONFIG, "matchmaking", key="challenge_variant", default="random")
     set_config_default(CONFIG, "matchmaking", key="challenge_mode", default="random")
+    set_config_default(CONFIG, "matchmaking", key="overrides", default={}, force_empty_values=True)
 
     for section in ["engine", "correspondence"]:
         for ponder in ["ponder", "uci_ponder"]:

--- a/config.py
+++ b/config.py
@@ -231,6 +231,11 @@ def insert_default_values(CONFIG: CONFIG_DICT_TYPE) -> None:
     set_config_default(CONFIG, "matchmaking", key="challenge_variant", default="random")
     set_config_default(CONFIG, "matchmaking", key="challenge_mode", default="random")
     set_config_default(CONFIG, "matchmaking", key="overrides", default={}, force_empty_values=True)
+    for override_config in CONFIG["matchmaking"]["overrides"].values():
+        for parameter in ["challenge_initial_time", "challenge_increment", "challenge_days"]:
+            if parameter in override_config:
+                set_config_default(override_config, key=parameter, default=[None], force_empty_values=True)
+                change_value_to_list(override_config, key=parameter)    
 
     for section in ["engine", "correspondence"]:
         for ponder in ["ponder", "uci_ponder"]:

--- a/config.py
+++ b/config.py
@@ -1,4 +1,5 @@
 """Code related to the config that lichess-bot uses."""
+from __future__ import annotations
 import yaml
 import os
 import os.path
@@ -60,7 +61,7 @@ class Configuration:
         """:return: All of the keys in this config."""
         return list(self.config.keys())
 
-    def __or__(self, other: Union["Configuration", CONFIG_DICT_TYPE]) -> "Configuration":
+    def __or__(self, other: Union[Configuration, CONFIG_DICT_TYPE]) -> Configuration:
         """Create a copy of this configuration that is updated with values from the parameter."""
         other_dict = other.config if isinstance(other, Configuration) else other
         return Configuration(self.config | other_dict)

--- a/config.py
+++ b/config.py
@@ -236,7 +236,7 @@ def insert_default_values(CONFIG: CONFIG_DICT_TYPE) -> None:
         for parameter in ["challenge_initial_time", "challenge_increment", "challenge_days"]:
             if parameter in override_config:
                 set_config_default(override_config, key=parameter, default=[None], force_empty_values=True)
-                change_value_to_list(override_config, key=parameter)    
+                change_value_to_list(override_config, key=parameter)
 
     for section in ["engine", "correspondence"]:
         for ponder in ["ponder", "uci_ponder"]:

--- a/config.yml.default
+++ b/config.yml.default
@@ -198,3 +198,27 @@ matchmaking:
 #   - user1
 #   - user2
 
+# overrides:                       # These section provide overrides for the matchmaking specifications above. When a challenge is created,
+#   bullet_only_horde:             # either the default specification above or one of the overrides will be randomly chosen. If one of the
+#     challenge_variant: "horde"   # overrides is chosen, the configurations in that override will replace the ones in the default; all others
+#     challenge_initial_time:      # are unchanged. The names of the overrides ("bullet_only_horde" and "easy_chess960" in these examples) are
+#       - 1                        # arbitrary strings and are only for labeling the override sections. The only requirement is that different
+#       - 2                        # overrides have different names.
+#     challenge_increment:         #
+#       - 0                        # The following configurations cannot be overridden: allow_matchmaking, challenge_timeout, challenge_filter,
+#       - 1                        # and block_list.
+#
+#   easy_chess960:
+#     challenge_variant: "chess960"
+#     opponent_min_rating: 400
+#     opponent_max_rating: 1200
+#     opponent_rating_difference:
+#     challenge_mode: casual
+#
+#   no_pressure_correspondence:
+#     challenge_initial_time:
+#     challenge_increment:
+#     challenge_days:
+#       - 2
+#       - 3
+#     challenge_mode: casual

--- a/config.yml.default
+++ b/config.yml.default
@@ -198,7 +198,7 @@ matchmaking:
 #   - user1
 #   - user2
 
-# overrides:                       # These section provide overrides for the matchmaking specifications above. When a challenge is created,
+# overrides:                       # These sections provide overrides for the matchmaking specifications above. When a challenge is created,
 #   bullet_only_horde:             # either the default specification above or one of the overrides will be randomly chosen. If one of the
 #     challenge_variant: "horde"   # overrides is chosen, the configurations in that override will replace the ones in the default; all others
 #     challenge_initial_time:      # are unchanged. The names of the overrides ("bullet_only_horde" and "easy_chess960" in these examples) are

--- a/config.yml.default
+++ b/config.yml.default
@@ -206,7 +206,7 @@ matchmaking:
 #       - 2                        # overrides have different names.
 #     challenge_increment:         #
 #       - 0                        # The following configurations cannot be overridden: allow_matchmaking, challenge_timeout, challenge_filter,
-#       - 1                        # and block_list.
+#       - 1                        # challenge_filter, and block_list.
 #
 #   easy_chess960:
 #     challenge_variant: "chess960"


### PR DESCRIPTION
A new subsection of the matchmaking configutation section is added to allow the user to create custom matches that differ from the main configuration. For example, a user may want to specify different time controls for variant games.

Closes #787