### PR TITLE
PGN file organization

### DIFF
--- a/config.py
+++ b/config.py
@@ -154,6 +154,7 @@ def insert_default_values(CONFIG: CONFIG_DICT_TYPE) -> None:
     set_config_default(CONFIG, key="abort_time", default=20)
     set_config_default(CONFIG, key="move_overhead", default=1000)
     set_config_default(CONFIG, key="rate_limiting_delay", default=0)
+    set_config_default(CONFIG, key="pgn_file_grouping", default="game", force_empty_values=True)
     set_config_default(CONFIG, "engine", key="working_dir", default=os.getcwd(), force_empty_values=True)
     set_config_default(CONFIG, "engine", key="silence_stderr", default=False)
     set_config_default(CONFIG, "engine", "draw_or_resign", key="offer_draw_enabled", default=False)
@@ -288,6 +289,12 @@ def validate_config(CONFIG: CONFIG_DICT_TYPE) -> None:
             online_section = (CONFIG["engine"].get(section) or {}).get(subsection) or {}
             config_assert(online_section.get("move_quality") != "suggest" or not online_section.get("enabled"),
                           f"XBoard engines can't be used with `move_quality` set to `suggest` in {subsection}.")
+
+    valid_pgn_grouping_options = ["game", "opponent", "all"]
+    config_pgn_choice = CONFIG["pgn_file_grouping"]
+    config_assert(config_pgn_choice in valid_pgn_grouping_options,
+                  f"The `pgn_file_grouping` choice of `{config_pgn_choice}` is not valid. "
+                  f"Please choose from {valid_pgn_grouping_options}.")
 
     for section, subsection in (("online_moves", "online_egtb"),
                                 ("lichess_bot_tbs", "syzygy"),

--- a/config.yml.default
+++ b/config.yml.default
@@ -174,6 +174,10 @@ greeting:
   goodbye_spectators: "Thanks for watching!" # Message to send to spectator chat at the end of a game
 
 # pgn_directory: "game_records"    # A directory where PGN-format records of the bot's games are kept
+# pgn_file_grouping: "game"        # How to group games into files. Options are "game", "opponent", and "all"
+                                   # "game" (default) - every game is written to a different file named "{White name} vs. {Black name} - {lichess game ID}.pgn"
+                                   # "opponent" - every game with a given opponent is written to a file named "lichess {Bot name} games vs. {Opponent name}.pgn"
+                                   # "all" - every game is written to a single file named "lichess {Bot name} games.pgn"
 
 matchmaking:
   allow_matchmaking: false         # Set it to 'true' to challenge other bots.

--- a/config.yml.default
+++ b/config.yml.default
@@ -176,8 +176,8 @@ greeting:
 # pgn_directory: "game_records"    # A directory where PGN-format records of the bot's games are kept
 # pgn_file_grouping: "game"        # How to group games into files. Options are "game", "opponent", and "all"
                                    # "game" (default) - every game is written to a different file named "{White name} vs. {Black name} - {lichess game ID}.pgn"
-                                   # "opponent" - every game with a given opponent is written to a file named "lichess {Bot name} games vs. {Opponent name}.pgn"
-                                   # "all" - every game is written to a single file named "lichess {Bot name} games.pgn"
+                                   # "opponent" - every game with a given opponent is written to a file named "{Bot name} games vs. {Opponent name}.pgn"
+                                   # "all" - every game is written to a single file named "{Bot name} games.pgn"
 
 matchmaking:
   allow_matchmaking: false         # Set it to 'true' to challenge other bots.

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -840,7 +840,7 @@ def try_get_pgn_game_record(li: lichess.Lichess, config: Configuration, game: mo
 def pgn_game_record(li: lichess.Lichess, config: Configuration, game: model.Game, board: chess.Board,
                     engine: engine_wrapper.EngineWrapper) -> str:
     """
-    Write the game to a PGN file.
+    Return the text of the game's PGN.
 
     :param li: Provides communication with lichess.org.
     :param config: The config that the bot will use.

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -889,7 +889,7 @@ def pgn_game_record(li: lichess.Lichess, config: Configuration, game: model.Game
 
 def get_game_file_path(config: Configuration, game: model.Game, force_single: bool = False) -> str:
     """Return the path of the file where the game record will be written."""
-    if config.pgn_file_grouping == "game" or game.result() == model.GameEnding.INCOMPLETE or force_single:
+    if config.pgn_file_grouping == "game" or not is_game_over(game) or force_single:
         game_file_name = f"{game.white.name} vs {game.black.name} - {game.id}.pgn"
     elif config.pgn_file_grouping == "opponent":
         game_file_name = f"{game.me.name} games vs. {game.opponent.name}.pgn"

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -328,9 +328,9 @@ def lichess_bot_main(li: lichess.Lichess,
                 control_queue.task_done()
                 break
             elif event["type"] in ["local_game_done", "gameFinish"]:
-                id = event["game"]["id"]
-                if id in active_games:
-                    active_games.discard(id)
+                game_id = event["game"]["id"]
+                if game_id in active_games:
+                    active_games.discard(game_id)
                     matchmaker.game_done()
                     log_proc_count("Freed", active_games)
                 one_game_completed = True

--- a/model.py
+++ b/model.py
@@ -141,15 +141,6 @@ class Termination(str, Enum):
     DRAW = "draw"
 
 
-class GameEnding(str, Enum):
-    """Whether a game is completed and the winner, if any."""
-
-    WHITE_WINS = "1-0"
-    BLACK_WINS = "0-1"
-    DRAW = "1/2-1/2"
-    INCOMPLETE = "*"
-
-
 class Game:
     """Store information about a game."""
 
@@ -239,6 +230,12 @@ class Game:
 
     def result(self) -> str:
         """Get the result of the game."""
+        class GameEnding(str, Enum):
+            WHITE_WINS = "1-0"
+            BLACK_WINS = "0-1"
+            DRAW = "1/2-1/2"
+            INCOMPLETE = "*"
+
         winner = self.state.get("winner")
         termination = self.state.get("status")
 

--- a/model.py
+++ b/model.py
@@ -141,6 +141,15 @@ class Termination(str, Enum):
     DRAW = "draw"
 
 
+class GameEnding(str, Enum):
+    """Whether a game is completed and the winner, if any."""
+
+    WHITE_WINS = "1-0"
+    BLACK_WINS = "0-1"
+    DRAW = "1/2-1/2"
+    INCOMPLETE = "*"
+
+
 class Game:
     """Store information about a game."""
 
@@ -230,12 +239,6 @@ class Game:
 
     def result(self) -> str:
         """Get the result of the game."""
-        class GameEnding(str, Enum):
-            WHITE_WINS = "1-0"
-            BLACK_WINS = "0-1"
-            DRAW = "1/2-1/2"
-            INCOMPLETE = "*"
-
         winner = self.state.get("winner")
         termination = self.state.get("status")
 

--- a/wiki/Configure-lichess-bot.md
+++ b/wiki/Configure-lichess-bot.md
@@ -210,9 +210,14 @@ will precede the `go` command to start thinking with `sd 5`. The other `go_comma
 - `fake_think_time`: Artificially slow down the engine to simulate a person thinking about a move. The amount of thinking time decreases as the game goes on.
 - `rate_limiting_delay`: For extremely fast games, the lichess.org servers may respond with an error if too many moves are played too quickly. This option avoids this problem by pausing for a specified number of milliseconds after submitting a move before making the next move.
 - `move_overhead`: To prevent losing on time due to network lag, subtract this many milliseconds from the time to think on each move.
-- `pgn_directory`: Write a record of every game played in PGN format to files in this directory. Each bot move will be annotated with the bot's calculated score and principal variation. The score is written with a tag of the form `[%eval s,d]`, where `s` is the score in pawns (positive means white has the advantage), and `d` is the depth of the search. Each game will be written to a uniquely named file.
+- `pgn_directory`: Write a record of every game played in PGN format to files in this directory. Each bot move will be annotated with the bot's calculated score and principal variation. The score is written with a tag of the form `[%eval s,d]`, where `s` is the score in pawns (positive means white has the advantage), and `d` is the depth of the search.
+- `pgn_file_grouping`: Determine how games are written to files. There are three options:
+    - `game`: Every game record is written to a different file in the `pgn_directory`. The file name is `{White name} vs. {Black name} - {lichess game ID}.pgn`.
+    - `opponent`: Game records are written to files named according to the bot's opponent. The file name is `{Bot name} games vs. {Opponent name}.pgn`.
+    - `all`: All games are written to the same file. The file name is `{Bot name} games.pgn`.
 ```yml
   pgn_directory: "game_records"
+  pgn_file_grouping: "all"
 ```
 
 ## Challenging other bots


### PR DESCRIPTION
Give the user a choice of how to organize the PGN records of a bot's games:

- record each game to a separate file (the current behavior and the default),
- sort games into files by opponent, and
- put all games into one file.

To prevent multiple threads from writing to one file, the PGN writing process has changed:

1. When a `play_game()` thread ends, write the PGN record to a string and add it to the `local_game_done` event.
2. In the `lichess_bot_main()` function, call `save_pgn_record()` to write the string to a file.
3. If the game is not complete, the PGN record is written to a single-game format file so it can be read when the game restarts.