### PR TITLE
UTF-8 Fixes

### DIFF
--- a/conversation.py
+++ b/conversation.py
@@ -39,7 +39,7 @@ class Conversation:
 
         :param line: Information about the message.
         """
-        logger.info(f'*** {self.game.url()} [{line.room}] {line.username}: {line.text.encode("utf-8")!r}')
+        logger.info(f'*** {self.game.url()} [{line.room}] {line.username}: {line.text}')
         if line.text[0] == self.command_prefix:
             self.command(line, line.text[1:].lower())
 

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -142,7 +142,7 @@ def logging_configurer(level: int, filename: Optional[str], auto_log_filename: O
     all_handlers: list[logging.Handler] = [console_handler]
 
     if filename:
-        file_handler = logging.FileHandler(filename, delay=True)
+        file_handler = logging.FileHandler(filename, delay=True, encoding="utf-8")
         FORMAT = "%(asctime)s %(name)s (%(filename)s:%(lineno)d) %(levelname)s %(message)s"
         file_formatter = logging.Formatter(FORMAT)
         file_handler.setFormatter(file_formatter)
@@ -157,7 +157,7 @@ def logging_configurer(level: int, filename: Optional[str], auto_log_filename: O
             handle_old_logs(auto_log_filename)
 
         # Set up automatic logging.
-        auto_file_handler = logging.FileHandler(auto_log_filename, delay=True)
+        auto_file_handler = logging.FileHandler(auto_log_filename, delay=True, encoding="utf-8")
         auto_file_handler.setLevel(logging.DEBUG)
 
         FORMAT = "%(asctime)s %(name)s (%(filename)s:%(lineno)d) %(levelname)s %(message)s"


### PR DESCRIPTION
- Correct display of chat that contains UTF-8 characters.
- Prevent errors when logging UTF-8 characters from chat to files.

Discovered after typing `!eval` into the spectator chat when my bot was playing against [simplexitor](https://lichess.org/@/simplexitor).