### PR TITLE
Math simplification

### DIFF
--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -1126,7 +1126,7 @@ def dtz_scorer(tablebase: chess.syzygy.Tablebase, board: chess.Board) -> Union[i
 
 def dtz_to_wdl(dtz: Union[int, float]) -> int:
     """Convert DTZ scores to syzygy WDL scores."""
-    return piecewise_function([(-100, 'i', -1), (0, 'e', -2), (0, 'i', 0), (100, 'i', 2)], 1, dtz)
+    return piecewise_function([(-100, 'i', -1), (0, 'e', -2), (0, 'i', 0), (100, 'e', 2)], 1, dtz)
 
 
 def get_gaviota(board: chess.Board, game: model.Game,

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -1126,9 +1126,10 @@ def dtz_scorer(tablebase: chess.syzygy.Tablebase, board: chess.Board) -> Union[i
 
 def dtz_to_wdl(dtz: Union[int, float]) -> int:
     """Convert DTZ scores to syzygy WDL scores.
-    
+
     A DTZ of +/-100 returns a draw score of +/-1 instead of a win/loss score of +/-2 because
-    a 50-move draw can be forced before checkmate can be forced."""
+    a 50-move draw can be forced before checkmate can be forced.
+    """
     return piecewise_function([(-100, 'i', -1), (0, 'e', -2), (0, 'i', 0), (100, 'e', 2)], 1, dtz)
 
 

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -11,6 +11,7 @@ import logging
 import datetime
 import time
 import random
+import math
 from collections import Counter
 from collections.abc import Generator, Callable
 from contextlib import contextmanager
@@ -1119,8 +1120,8 @@ def dtz_scorer(tablebase: chess.syzygy.Tablebase, board: chess.Board) -> Union[i
     For a zeroing move (capture or pawn move), a DTZ of +/-0.5 is returned.
     """
     dtz: Union[int, float] = -tablebase.probe_dtz(board)
-    dtz = dtz if board.halfmove_clock else .5 * (1 if dtz > 0 else -1)
-    return dtz + (1 if dtz > 0 else -1) * board.halfmove_clock * (0 if dtz == 0 else 1)
+    dtz = dtz if board.halfmove_clock else math.copysign(.5, dtz)
+    return dtz + (math.copysign(board.halfmove_clock, dtz) if dtz else 0)
 
 
 def dtz_to_wdl(dtz: Union[int, float]) -> int:
@@ -1182,7 +1183,7 @@ def get_gaviota(board: chess.Board, game: model.Game,
 def dtm_scorer(tablebase: Union[chess.gaviota.NativeTablebase, chess.gaviota.PythonTablebase], board: chess.Board) -> int:
     """Score a position based on a gaviota DTM egtb."""
     dtm = -tablebase.probe_dtm(board)
-    return dtm + (1 if dtm > 0 else -1) * board.halfmove_clock * (0 if dtm == 0 else 1)
+    return dtm + int(math.copysign(board.halfmove_clock, dtm) if dtm else 0)
 
 
 def dtm_to_gaviota_wdl(dtm: int) -> int:

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -1125,7 +1125,10 @@ def dtz_scorer(tablebase: chess.syzygy.Tablebase, board: chess.Board) -> Union[i
 
 
 def dtz_to_wdl(dtz: Union[int, float]) -> int:
-    """Convert DTZ scores to syzygy WDL scores."""
+    """Convert DTZ scores to syzygy WDL scores.
+    
+    A DTZ of +/-100 returns a draw score of +/-1 instead of a win/loss score of +/-2 because
+    a 50-move draw can be forced before checkmate can be forced."""
     return piecewise_function([(-100, 'i', -1), (0, 'e', -2), (0, 'i', 0), (100, 'e', 2)], 1, dtz)
 
 


### PR DESCRIPTION
Two changes that should not affect calculation results:
1. Use `math.copysign()` to simplify expressions that get the sign of a number--like `dtz` or `dtm`.
2. In `piecewise_function()` specify whether each range border is inclusive (`<=`) or exclusive (`<`). This way, exclusive borders can be specified exactly without needing to use off-by-one values.