### PR TITLE
Limit depth of opening book search

### DIFF
--- a/config.py
+++ b/config.py
@@ -168,6 +168,7 @@ def insert_default_values(CONFIG: CONFIG_DICT_TYPE) -> None:
     set_config_default(CONFIG, "engine", "draw_or_resign", key="offer_draw_pieces", default=10)
     set_config_default(CONFIG, "engine", "online_moves", key="max_out_of_book_moves", default=10)
     set_config_default(CONFIG, "engine", "online_moves", key="max_retries", default=2, force_empty_values=True)
+    set_config_default(CONFIG, "engine", "online_moves", key="max_depth", default=math.inf, force_empty_values=True)
     set_config_default(CONFIG, "engine", "online_moves", "online_egtb", key="enabled", default=False)
     set_config_default(CONFIG, "engine", "online_moves", "online_egtb", key="source", default="lichess")
     set_config_default(CONFIG, "engine", "online_moves", "online_egtb", key="min_time", default=20)

--- a/config.yml.default
+++ b/config.yml.default
@@ -38,6 +38,7 @@ engine:                            # Engine settings.
   online_moves:
     max_out_of_book_moves: 10      # Stop using online opening books after they don't have a move for 'max_out_of_book_moves' positions. Doesn't apply to the online endgame tablebases.
     max_retries: 2                 # The maximum amount of retries when getting an online move.
+    # max_depth: 10                # How many moves from the start to take from online books. Default is no limit.
     chessdb_book:
       enabled: false               # Whether or not to use chessdb book.
       min_time: 20                 # Minimum time (in seconds) to use chessdb book.

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -699,36 +699,18 @@ def get_online_move(li: lichess.Lichess, board: chess.Board, game: model.Game, o
     If `move_quality` is `suggest`, then it will return a list of moves for the engine to choose from.
     """
     online_egtb_cfg = online_moves_cfg.online_egtb
-    chessdb_cfg = online_moves_cfg.chessdb_book
-    lichess_cloud_cfg = online_moves_cfg.lichess_cloud_analysis
-    opening_explorer_cfg = online_moves_cfg.lichess_opening_explorer
-    max_out_of_book_moves = online_moves_cfg.max_out_of_book_moves
-    offer_draw = False
-    resign = False
     best_move, wdl, comment = get_online_egtb_move(li, board, game, online_egtb_cfg)
     if best_move is not None and comment is not None:  # `and comment is not None` is there only for mypy.
         can_offer_draw = draw_or_resign_cfg.offer_draw_enabled
         offer_draw_for_zero = draw_or_resign_cfg.offer_draw_for_egtb_zero
-        if can_offer_draw and offer_draw_for_zero and wdl == 0:
-            offer_draw = True
+        offer_draw = can_offer_draw and offer_draw_for_zero and wdl == 0
 
         can_resign = draw_or_resign_cfg.resign_enabled
         resign_on_egtb_loss = draw_or_resign_cfg.resign_for_egtb_minus_two
-        if can_resign and resign_on_egtb_loss and wdl == -2:
-            resign = True
+        resign = can_resign and resign_on_egtb_loss and wdl == -2
 
         wdl_to_score = {2: 9900, 1: 500, 0: 0, -1: -500, -2: -9900}
         comment["score"] = chess.engine.PovScore(chess.engine.Cp(wdl_to_score[wdl]), board.turn)
-    elif out_of_online_opening_book_moves[game.id] < max_out_of_book_moves:
-        best_move, comment = get_chessdb_move(li, board, game, chessdb_cfg)
-
-    if best_move is None and out_of_online_opening_book_moves[game.id] < max_out_of_book_moves:
-        best_move, comment = get_lichess_cloud_move(li, board, game, lichess_cloud_cfg)
-
-    if best_move is None and out_of_online_opening_book_moves[game.id] < max_out_of_book_moves:
-        best_move, comment = get_opening_explorer_move(li, board, game, opening_explorer_cfg)
-
-    if best_move:
         if isinstance(best_move, str):
             return chess.engine.PlayResult(chess.Move.from_uci(best_move),
                                            None,
@@ -736,6 +718,24 @@ def get_online_move(li: lichess.Lichess, board: chess.Board, game: model.Game, o
                                            draw_offered=offer_draw,
                                            resigned=resign)
         return [chess.Move.from_uci(move) for move in best_move]
+
+    max_out_of_book_moves = online_moves_cfg.max_out_of_book_moves
+    max_opening_moves = online_moves_cfg.max_depth * 2 - 1
+    game_moves = len(board.move_stack)
+    if game_moves > max_opening_moves or out_of_online_opening_book_moves[game.id] >= max_out_of_book_moves:
+        return chess.engine.PlayResult(None, None)
+
+    chessdb_cfg = online_moves_cfg.chessdb_book
+    lichess_cloud_cfg = online_moves_cfg.lichess_cloud_analysis
+    opening_explorer_cfg = online_moves_cfg.lichess_opening_explorer
+
+    for online_source, cfg in ((get_chessdb_move, chessdb_cfg),
+                               (get_lichess_cloud_move, lichess_cloud_cfg),
+                               (get_opening_explorer_move, opening_explorer_cfg)):
+        best_move, comment = online_source(li, board, game, cfg)
+        if best_move:
+            return chess.engine.PlayResult(chess.Move.from_uci(best_move), None, comment)
+
     out_of_online_opening_book_moves[game.id] += 1
     used_opening_books = chessdb_cfg.enabled or lichess_cloud_cfg.enabled or opening_explorer_cfg.enabled
     if out_of_online_opening_book_moves[game.id] == max_out_of_book_moves and used_opening_books:

--- a/wiki/Configure-lichess-bot.md
+++ b/wiki/Configure-lichess-bot.md
@@ -96,6 +96,7 @@ will precede the `go` command to start thinking with `sd 5`. The other `go_comma
     4. `online_egtb`: Consults either the online Syzygy 7-piece endgame tablebase [hosted by Lichess](https://lichess.org/blog/W3WeMyQAACQAdfAL/7-piece-syzygy-tablebases-are-complete) or the chessdb listed above.
     - `max_out_of_book_moves`: Stop using online opening books after they don't have a move for `max_out_of_book_moves` positions. Doesn't apply to the online endgame tablebases.
     - `max_retries`: The maximum amount of retries when getting an online move.
+    - `max_depth`: The maximum number of moves a bot can make in the opening before it stops consulting the online opening books. If `max_depth` is 5, then the bot will stop consulting the online books after its fifth move.
     - Configurations common to all:
         - `enabled`: Whether to use the database at all.
         - `min_time`: The minimum time in seconds on the game clock necessary to allow the online database to be consulted.


### PR DESCRIPTION
Add a configuration that limits how many opening moves for which a bot will use an online opening book. The extra check made the function get_online_move() too complex, so some editing was done to simplify it.

Fixes #829