### PR TITLE
Only use local_game_done events to signal games are over

### DIFF
--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -835,9 +835,6 @@ def try_get_pgn_game_record(li: lichess.Lichess, config: Configuration, game: mo
     :param board: The board. Contains the moves.
     :param engine: The engine. Contains information about the moves (e.g. eval, PV, depth).
     """
-    if board is None:
-        return
-
     try:
         return pgn_game_record(li, config, game, board, engine)
     except Exception:

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -854,7 +854,7 @@ def pgn_game_record(li: lichess.Lichess, config: Configuration, game: model.Game
     lichess_game_record = chess.pgn.read_game(io.StringIO(li.get_game_pgn(game.id))) or chess.pgn.Game()
     try:
         # Recall previously written PGN file to retain engine evaluations.
-        previous_game_path = get_game_file_path(config, game, True)
+        previous_game_path = get_game_file_path(config, game, force_single=True)
         with open(previous_game_path) as game_data:
             game_record = chess.pgn.read_game(game_data) or lichess_game_record
         game_record.headers.update(lichess_game_record.headers)
@@ -887,16 +887,27 @@ def pgn_game_record(li: lichess.Lichess, config: Configuration, game: model.Game
     return game_record.accept(pgn_writer)
 
 
-def get_game_file_path(config: Configuration, game: model.Game, force_single: bool = False) -> str:
+def get_game_file_path(config: Configuration, game: Optional[model.Game], *, pgn: str = "", force_single: bool = False) -> str:
     """Return the path of the file where the game record will be written."""
-    if config.pgn_file_grouping == "game" or not is_game_over(game) or force_single:
-        game_file_name = f"{game.white.name} vs {game.black.name} - {game.id}.pgn"
+    def create_valid_path(s: str) -> str:
+        illegal = '<>:"/\\|?*'
+        return os.path.join(config.pgn_directory, "".join(c for c in s if c not in illegal))
+
+    if game is None:
+        # Game process exited due to an error, so write to single-game file.
+        game_from_pgn = chess.pgn.read_game(io.StringIO(pgn))
+        assert game_from_pgn is not None
+        white = game_from_pgn.headers["White"]
+        black = game_from_pgn.headers["Black"]
+        game_id = game_from_pgn.headers["Site"].split("/")[-1]
+        return create_valid_path(f"{white} vs {black} - {game_id}.pgn")
+
+    if config.pgn_file_grouping == "game" or game is None or not is_game_over(game) or force_single:
+        return create_valid_path(f"{game.white.name} vs {game.black.name} - {game.id}.pgn")
     elif config.pgn_file_grouping == "opponent":
-        game_file_name = f"{game.me.name} games vs. {game.opponent.name}.pgn"
+        return create_valid_path(f"{game.me.name} games vs. {game.opponent.name}.pgn")
     else:  # config.pgn_file_grouping == "all"
-        game_file_name = f"{game.me.name} games.pgn"
-    game_file_name = "".join(c for c in game_file_name if c not in '<>:"/\\|?*')
-    return os.path.join(config.pgn_directory, game_file_name)
+        return create_valid_path(f"{game.me.name} games.pgn")
 
 
 def fill_missing_pgn_headers(game_record: chess.pgn.Game, game: model.Game) -> None:
@@ -954,14 +965,15 @@ def save_pgn_record(event: EVENT_TYPE, config: Configuration) -> None:
     if not config.pgn_directory or not event["game"]["pgn"]:
         return
 
+    pgn: str = event["game"]["pgn"]
     os.makedirs(config.pgn_directory, exist_ok=True)
-    game = event["game"]["state"]
-    game_path = get_game_file_path(config, game)
-    single_game_path = get_game_file_path(config, game, True)
+    game: Optional[model.Game] = event["game"].get("state")
+    game_path = get_game_file_path(config, game, pgn=pgn)
+    single_game_path = get_game_file_path(config, game, pgn=pgn, force_single=True)
     write_mode = "w" if game_path == single_game_path else "a"
     logger.debug(f"Writing PGN game record to: {game_path}")
     with open(game_path, write_mode) as game_file:
-        game_file.write(event["game"]["pgn"] + "\n\n")
+        game_file.write(pgn + "\n\n")
 
     if os.path.exists(single_game_path) and game_path != single_game_path:
         os.remove(single_game_path)

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -961,7 +961,12 @@ def get_headers(game: model.Game) -> dict[str, Union[str, int]]:
 
 
 def save_pgn_record(event: EVENT_TYPE, config: Configuration) -> None:
-    """Write the game PGN record to a file."""
+    """
+    Write the game PGN record to a file.
+
+    :param event: A local_game_done event from the control queue.
+    :param config: The user's bot configuration.
+    """
     if not config.pgn_directory or not event["game"]["pgn"]:
         return
 

--- a/test_bot/lichess.py
+++ b/test_bot/lichess.py
@@ -194,8 +194,8 @@ class Lichess:
 [Site "pytest"]
 [Date "2022.03.11"]
 [Round "1"]
-[White "Engine"]
-[Black "Engine"]
+[White "bo"]
+[Black "b"]
 [Result "0-1"]
 
 *

--- a/versioning.yml
+++ b/versioning.yml
@@ -1,4 +1,4 @@
-lichess_bot_version: 2023.9.22.2
+lichess_bot_version: 2023.9.22.3
 minimum_python_version: '3.9'
 deprecated_python_version: '3.8'
 deprecation_date: 2023-05-01


### PR DESCRIPTION
Since `local_game_done` events are only put in the `control_queue` when the game thread ends, this change will prevent `gameFinish` events from prematurely removing games from the `active_games`, allowing for more simultaneous game threads than the user's configuration specifies (as mentioned [here](https://github.com/lichess-bot-devs/lichess-bot/pull/699#issuecomment-1660490533)). To make sure that game threads that exit due to errors do not leave behind zombie game IDs in `active_games` the error handler for game threads was changed to put `local_game_done` events in the queue. This change provided an opportunity to attempt saving the game PGN since a game-ending error would skip that step.