### PR TITLE
Local FEN header update

### DIFF
--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -953,8 +953,11 @@ def get_headers(game: model.Game) -> dict[str, Union[str, int]]:
 
     headers["UTCDate"] = headers["Date"]
     headers["UTCTime"] = game.game_start.strftime("%H:%M:%S")
-    if game.variant_name not in ["Standard", "From Position"]:
-        headers["Variant"] = game.variant_name
+    headers["Variant"] = game.variant_name
+
+    if game.initial_fen and game.initial_fen != "startpos":
+        headers["Setup"] = 1
+        headers["FEN"] = game.initial_fen
 
     if game.white.rating:
         headers["WhiteElo"] = game.white.rating


### PR DESCRIPTION
Always add variant to headers. Add FEN field when it is different from the standard chess starting position. These fields are only added if they are not retrieved from lichess.org (usually if the connection to the site is down).