### PR TITLE
Restart engine when bot exceeds per-move time limit

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Automatically convert EOL characters as needed
+* text=auto

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -23,7 +23,6 @@ from lib.config import load_config, Configuration
 from lib.conversation import Conversation, ChatLine
 from lib.timer import Timer, seconds, msec, hours, to_seconds
 from requests.exceptions import ChunkedEncodingError, ConnectionError, HTTPError, ReadTimeout
-from asyncio.exceptions import TimeoutError as MoveTimeout
 from rich.logging import RichHandler
 from collections import defaultdict
 from collections.abc import Iterator, MutableSequence
@@ -640,13 +639,7 @@ def play_game(li: lichess.Lichess,
                     prior_game = copy.deepcopy(game)
                 elif u_type == "ping" and should_exit_game(board, game, prior_game, li, is_correspondence):
                     break
-            except (HTTPError,
-                    ReadTimeout,
-                    RemoteDisconnected,
-                    ChunkedEncodingError,
-                    ConnectionError,
-                    StopIteration,
-                    MoveTimeout) as e:
+            except (HTTPError, ReadTimeout, RemoteDisconnected, ChunkedEncodingError, ConnectionError, StopIteration) as e:
                 stopped = isinstance(e, StopIteration)
                 if stopped or (not move_attempted and not game_is_active(li, game.id)):
                     break

--- a/test_bot/buggy_engine
+++ b/test_bot/buggy_engine
@@ -1,0 +1,3 @@
+#!/usr/bin/sh
+
+python3 test_bot/buggy_engine.py

--- a/test_bot/buggy_engine.bat
+++ b/test_bot/buggy_engine.bat
@@ -1,0 +1,2 @@
+@echo off
+python test_bot\buggy_engine.py

--- a/test_bot/buggy_engine.py
+++ b/test_bot/buggy_engine.py
@@ -5,7 +5,7 @@ import time
 
 assert input() == "uci"
 
-print("id name Delay tactic")
+print("id name Procrastinator")
 print("id author MZH")
 print("uciok")
 

--- a/test_bot/buggy_engine.py
+++ b/test_bot/buggy_engine.py
@@ -5,8 +5,11 @@ import time
 
 assert input() == "uci"
 
+
 def send_command(command: str) -> None:
+    """Send UCI commands to lichess-bot without output buffering."""
     print(command, flush=True)
+
 
 send_command("id name Procrastinator")
 send_command("id author MZH")

--- a/test_bot/buggy_engine.py
+++ b/test_bot/buggy_engine.py
@@ -5,9 +5,12 @@ import time
 
 assert input() == "uci"
 
-print("id name Procrastinator")
-print("id author MZH")
-print("uciok")
+def send_command(command: str) -> None:
+    print(command, flush=True)
+
+send_command("id name Procrastinator")
+send_command("id author MZH")
+send_command("uciok")
 
 delay_performed = False
 just_started = True
@@ -18,7 +21,7 @@ while True:
     if command == "quit":
         break
     elif command == "isready":
-        print("readyok")
+        send_command("readyok")
     elif command == "position":
         spec_type, *remaining = remaining
         assert spec_type == "startpos"
@@ -33,9 +36,9 @@ while True:
     elif command == "go":
         move_count = len(board.move_stack)
         if move_count == 2 and not delay_performed:
-            print("info string delaying move")
+            send_command("info string delaying move")
             delay_performed = True
             time.sleep(11)
         move = scholars_mate[move_count]
-        print(f"bestmove {move}")
+        send_command(f"bestmove {move}")
         just_started = False

--- a/test_bot/buggy_engine.py
+++ b/test_bot/buggy_engine.py
@@ -31,11 +31,11 @@ while True:
             assert moves_label == "moves"
             for move in move_list:
                 board.push_uci(move)
-        if just_started and len(board.move_stack) > 0:
+        if just_started and len(board.move_stack) > 1:
             delay_performed = True
     elif command == "go":
         move_count = len(board.move_stack)
-        if move_count == 2 and not delay_performed:
+        if move_count == 3 and not delay_performed:
             send_command("info string delaying move")
             delay_performed = True
             time.sleep(11)

--- a/test_bot/buggy_engine.py
+++ b/test_bot/buggy_engine.py
@@ -1,0 +1,41 @@
+"""An engine that takes too much time to make a move during tests."""
+
+import chess
+import time
+
+assert input() == "uci"
+
+print("id name Delay tactic")
+print("id author MZH")
+print("uciok")
+
+delay_performed = False
+just_started = True
+scholars_mate = ["a2a3", "e7e5", "a3a4", "f8c5", "a4a5", "d8h4", "a5a6", "h4f2"]
+
+while True:
+    command, *remaining = input().split()
+    if command == "quit":
+        break
+    elif command == "isready":
+        print("readyok")
+    elif command == "position":
+        spec_type, *remaining = remaining
+        assert spec_type == "startpos"
+        board = chess.Board()
+        if remaining:
+            moves_label, *move_list = remaining
+            assert moves_label == "moves"
+            for move in move_list:
+                board.push_uci(move)
+        if just_started and len(board.move_stack) > 0:
+            delay_performed = True
+    elif command == "go":
+        move_count = len(board.move_stack)
+        if move_count == 2 and not delay_performed:
+            print("info string delaying move")
+            delay_performed = True
+            time.sleep(11)
+        move = scholars_mate[move_count]
+        print(f"bestmove {move}")
+        just_started = False

--- a/test_bot/test_bot.py
+++ b/test_bot/test_bot.py
@@ -323,7 +323,7 @@ class Stockfish(ExampleEngine):
 
 @pytest.mark.timeout(30, method="thread")
 def test_buggy_engine() -> None:
-    """Test lichess-bot with Stockfish (UCI)."""
+    """Test lichess-bot with an engine that causes a timeout error within python-chess."""
     if os.path.exists("logs"):
         shutil.rmtree("logs")
     os.mkdir("logs")

--- a/test_bot/test_bot.py
+++ b/test_bot/test_bot.py
@@ -90,7 +90,7 @@ lichess_bot.logging_configurer(logging_level, testing_log_file_name, None, False
 lichess_bot.logger.info("Downloaded engines")
 
 
-def thread_for_test(opponent_path) -> None:
+def thread_for_test(opponent_path: str) -> None:
     """Play the moves for the opponent of lichess-bot."""
     open("./logs/events.txt", "w").close()
     open("./logs/states.txt", "w").close()
@@ -332,8 +332,10 @@ def test_buggy_engine() -> None:
     CONFIG["token"] = ""
     CONFIG["engine"]["dir"] = "test_bot"
 
-    def engine_path(CONFIG):
-        return os.path.join(CONFIG["engine"]["dir"], CONFIG["engine"]["name"])
+    def engine_path(CONFIG: dict[str, Any]) -> str:
+        dir: str = CONFIG["engine"]["dir"]
+        name: str = CONFIG["engine"]["name"]
+        return os.path.join(dir, name)
 
     if platform == "win32":
         CONFIG["engine"]["name"] = "buggy_engine.bat"

--- a/test_bot/test_bot.py
+++ b/test_bot/test_bot.py
@@ -343,7 +343,7 @@ def test_buggy_engine() -> None:
         CONFIG["engine"]["name"] = "buggy_engine"
         st = os.stat(engine_path(CONFIG))
         os.chmod(engine_path(CONFIG), st.st_mode | stat.S_IEXEC)
-    CONFIG["engine"]["uci_options"] = {"go_commands": {"movetime": 1}}
+    CONFIG["engine"]["uci_options"] = {"go_commands": {"movetime": 100}}
     CONFIG["pgn_directory"] = "TEMP/bug_game_record"
 
     win = run_bot(CONFIG, logging_level, engine_path(CONFIG))


### PR DESCRIPTION
## Type of pull request:
- [X] Bug fix
- [ ] Feature
- [ ] Other

## Description:

If a user specifies a per-move time limit in their configuration file--e.g., `uci_options: go_commands: movetime: 1000` for 1000 milliseconds per move--and the engine exceeds this time limit by more than 10 seconds, the python-chess library will intervene and cancel the search while raising a `TimeoutError`. Previously, this error would be caught and main `play_game()` loop would carry on without sending a move to lichess.org.

Now, the `TimeoutError` is propagated until it hits the `backoff` decoration of `play_game()`. This shuts down the engine (correctly, now, due to changes in engine_wrapper.py) and restarts it when `backoff` restarts `play_game()`. Even if the engine keeps exhibiting the same buggy behavior, the errors will be displayed on the terminal and log, so the user will know that something is wrong. 

## Related Issues:

This PR closes #893 and should be a better solution to #623 than the previous PR #628.

## Checklist:

- [X] I have read and followed the [contribution guidelines](/CONTRIBUTING.md).
- [X] I have added necessary documentation (if applicable).
- [X] The changes pass all existing tests.