### PR TITLE
Prevent hangs due to timeout errors

### DIFF
--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -23,7 +23,6 @@ from lib.config import load_config, Configuration
 from lib.conversation import Conversation, ChatLine
 from lib.timer import Timer, seconds, msec, hours, to_seconds
 from requests.exceptions import ChunkedEncodingError, ConnectionError, HTTPError, ReadTimeout
-from asyncio.exceptions import TimeoutError as MoveTimeout
 from rich.logging import RichHandler
 from collections import defaultdict
 from collections.abc import Iterator, MutableSequence
@@ -640,13 +639,7 @@ def play_game(li: lichess.Lichess,
                     prior_game = copy.deepcopy(game)
                 elif u_type == "ping" and should_exit_game(board, game, prior_game, li, is_correspondence):
                     break
-            except (HTTPError,
-                    ReadTimeout,
-                    RemoteDisconnected,
-                    ChunkedEncodingError,
-                    ConnectionError,
-                    StopIteration,
-                    MoveTimeout) as e:
+            except (HTTPError, ReadTimeout, RemoteDisconnected, ChunkedEncodingError, ConnectionError, StopIteration) as e:
                 stopped = isinstance(e, StopIteration)
                 if stopped or (not move_attempted and not game_is_active(li, game.id)):
                     break

--- a/test_bot/buggy_engine
+++ b/test_bot/buggy_engine
@@ -1,0 +1,3 @@
+#!/usr/bin/sh
+
+python3 test_bot/buggy_engine.py

--- a/test_bot/buggy_engine.bat
+++ b/test_bot/buggy_engine.bat
@@ -1,0 +1,2 @@
+@echo off
+python test_bot\buggy_engine.py

--- a/test_bot/buggy_engine.py
+++ b/test_bot/buggy_engine.py
@@ -1,0 +1,47 @@
+"""An engine that takes too much time to make a move during tests."""
+
+import chess
+import time
+
+assert input() == "uci"
+
+
+def send_command(command: str) -> None:
+    """Send UCI commands to lichess-bot without output buffering."""
+    print(command, flush=True)
+
+
+send_command("id name Procrastinator")
+send_command("id author MZH")
+send_command("uciok")
+
+delay_performed = False
+just_started = True
+scholars_mate = ["a2a3", "e7e5", "a3a4", "f8c5", "a4a5", "d8h4", "a5a6", "h4f2"]
+
+while True:
+    command, *remaining = input().split()
+    if command == "quit":
+        break
+    elif command == "isready":
+        send_command("readyok")
+    elif command == "position":
+        spec_type, *remaining = remaining
+        assert spec_type == "startpos"
+        board = chess.Board()
+        if remaining:
+            moves_label, *move_list = remaining
+            assert moves_label == "moves"
+            for move in move_list:
+                board.push_uci(move)
+        if just_started and len(board.move_stack) > 1:
+            delay_performed = True
+    elif command == "go":
+        move_count = len(board.move_stack)
+        if move_count == 3 and not delay_performed:
+            send_command("info string delaying move")
+            delay_performed = True
+            time.sleep(11)
+        move = scholars_mate[move_count]
+        send_command(f"bestmove {move}")
+        just_started = False

--- a/test_bot/test_bot.py
+++ b/test_bot/test_bot.py
@@ -85,11 +85,12 @@ if platform == "win32":
     download_lc0()
     download_sjeng()
 logging_level = lichess_bot.logging.DEBUG
-lichess_bot.logging_configurer(logging_level, None, None, False)
+testing_log_file_name = None
+lichess_bot.logging_configurer(logging_level, testing_log_file_name, None, False)
 lichess_bot.logger.info("Downloaded engines")
 
 
-def thread_for_test() -> None:
+def thread_for_test(opponent_path: str) -> None:
     """Play the moves for the opponent of lichess-bot."""
     open("./logs/events.txt", "w").close()
     open("./logs/states.txt", "w").close()
@@ -105,8 +106,9 @@ def thread_for_test() -> None:
     with open("./logs/states.txt", "w") as file:
         file.write(f"\n{to_seconds(wtime)},{to_seconds(btime)}")
 
-    engine = chess.engine.SimpleEngine.popen_uci(stockfish_path)
-    engine.configure({"Skill Level": 0, "Move Overhead": 1000, "Use NNUE": False})
+    engine = chess.engine.SimpleEngine.popen_uci(opponent_path)
+    engine.configure({"Skill Level": 0, "Move Overhead": 1000, "Use NNUE": False}
+                     if opponent_path == stockfish_path else {})
 
     while not board.is_game_over():
         if len(board.move_stack) % 2 == 0:
@@ -178,7 +180,7 @@ def thread_for_test() -> None:
         file.write("1" if win else "0")
 
 
-def run_bot(raw_config: dict[str, Any], logging_level: int) -> str:
+def run_bot(raw_config: dict[str, Any], logging_level: int, opponent_path: str = stockfish_path) -> str:
     """Start lichess-bot."""
     config.insert_default_values(raw_config)
     CONFIG = config.Configuration(raw_config)
@@ -192,9 +194,9 @@ def run_bot(raw_config: dict[str, Any], logging_level: int) -> str:
     lichess_bot.logger.info(f"Welcome {username}!")
     lichess_bot.disable_restart()
 
-    thr = threading.Thread(target=thread_for_test)
+    thr = threading.Thread(target=thread_for_test, args=[opponent_path])
     thr.start()
-    lichess_bot.start(li, user_profile, CONFIG, logging_level, None, None, one_game=True)
+    lichess_bot.start(li, user_profile, CONFIG, logging_level, testing_log_file_name, None, one_game=True)
     thr.join()
 
     with open("./logs/result.txt") as file:
@@ -314,6 +316,39 @@ class Stockfish(ExampleEngine):
     with open(strategies_py, "w") as file:
         file.write(original_strategies)
     lichess_bot.logger.info("Finished Testing Homemade")
+    assert win == "1"
+    assert os.path.isfile(os.path.join(CONFIG["pgn_directory"],
+                                       "bo vs b - zzzzzzzz.pgn"))
+
+
+@pytest.mark.timeout(30, method="thread")
+def test_buggy_engine() -> None:
+    """Test lichess-bot with an engine that causes a timeout error within python-chess."""
+    if os.path.exists("logs"):
+        shutil.rmtree("logs")
+    os.mkdir("logs")
+    with open("./config.yml.default") as file:
+        CONFIG = yaml.safe_load(file)
+    CONFIG["token"] = ""
+    CONFIG["engine"]["dir"] = "test_bot"
+
+    def engine_path(CONFIG: dict[str, Any]) -> str:
+        dir: str = CONFIG["engine"]["dir"]
+        name: str = CONFIG["engine"]["name"]
+        return os.path.join(dir, name)
+
+    if platform == "win32":
+        CONFIG["engine"]["name"] = "buggy_engine.bat"
+    else:
+        CONFIG["engine"]["name"] = "buggy_engine"
+        st = os.stat(engine_path(CONFIG))
+        os.chmod(engine_path(CONFIG), st.st_mode | stat.S_IEXEC)
+    CONFIG["engine"]["uci_options"] = {"go_commands": {"movetime": 100}}
+    CONFIG["pgn_directory"] = "TEMP/bug_game_record"
+
+    win = run_bot(CONFIG, logging_level, engine_path(CONFIG))
+    shutil.rmtree("logs")
+    lichess_bot.logger.info("Finished Testing buggy engine")
     assert win == "1"
     assert os.path.isfile(os.path.join(CONFIG["pgn_directory"],
                                        "bo vs b - zzzzzzzz.pgn"))


### PR DESCRIPTION
## Type of pull request:
- [X] Bug fix
- [ ] Feature
- [ ] Other

## Description:

If a user sets a finite value for movetime in their config file (e.g., engine: uci_options: go_commands: movetime) and the engine takes significantly longer to pick a move (10 seconds longer by default), then the python-chess framework will cancel the search for a move and raise a TimeoutError.

Before this PR, this would cause lichess-bot to hang and stop listening to the engine. Now, the error propagates to the backoff decorator so that the engine can be restarted.

## Related Issues:

This PR closes #893 and should be a better solution to #623 than the previous PR #628.

## Checklist:

- [x] I have read and followed the [contribution guidelines](/CONTRIBUTING.md).
- [x] I have added necessary documentation (if applicable).
- [x] The changes pass all existing tests.
