### PR TITLE
Matchmaking pull back

### DIFF
--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -329,7 +329,6 @@ def lichess_bot_main(li: lichess.Lichess,
                            pool,
                            play_game_args,
                            config,
-                           matchmaker,
                            startup_correspondence_games,
                            correspondence_queue,
                            active_games,
@@ -481,7 +480,6 @@ def start_game(event: EVENT_TYPE,
                pool: POOL_TYPE,
                play_game_args: PLAY_GAME_ARGS_TYPE,
                config: Configuration,
-               matchmaker: matchmaking.Matchmaking,
                startup_correspondence_games: list[str],
                correspondence_queue: CORRESPONDENCE_QUEUE_TYPE,
                active_games: set[str],
@@ -493,15 +491,12 @@ def start_game(event: EVENT_TYPE,
     :param pool: The thread pool that the game is added to, so they can be run asynchronously.
     :param play_game_args: The args passed to `play_game`.
     :param config: The config the bot will use.
-    :param matchmaker: The matchmaker that challenges other bots.
     :param startup_correspondence_games: A list of correspondence games that have to be started.
     :param correspondence_queue: The queue that correspondence games are added to, to be started.
     :param active_games: A set of all the games that aren't correspondence games.
     :param low_time_games: A list of games, in which we don't have much time remaining.
     """
     game_id = event["game"]["id"]
-    if matchmaker.challenge_id == game_id:
-        matchmaker.challenge_id = ""
     if game_id in startup_correspondence_games:
         if enough_time_to_queue(event, config):
             logger.info(f'--- Enqueue {config.url + game_id}')


### PR DESCRIPTION
## Type of pull request:
- [ ] Bug fix
- [ ] Feature
- [x] Other

## Description:

Simplify how the `Matchmaking` class handles the `challenge_id` string and remove the need to pass instances outside of `lichess_bot_main()`.

1. In `handle_challenge()`, use `Challenge.from_self` instead of `chlng.id != matchmaker.challenge_id` to prevent declining challenges originating from the user's bot. The `Matchmaker` instance is no longer needed as an argument.
2. Before calling `play_game()`, `matchmaker.challegne_id` is already cleared in `matchmaker.accepted_challenge()`. There's no need to do so in `play_game()`, so there's no need for `matchmaker` to be a parameter.
3. Create a method for clearing the `Matchmaker.challenge_id` in order to consolidate repeated code. Should we ever want to allow for multiple matchmaking challenges at once, this should make that simpler to implement.

## Related Issues:

Inspired by discussion #883

## Checklist:

- [x] I have read and followed the [contribution guidelines](/CONTRIBUTING.md).
- [x] I have added necessary documentation (if applicable).
- [x] The changes pass all existing tests.

## Screenshots/logs (if applicable):

N/A