### PR TITLE
Quit lichess-bot after all games finish

### DIFF
--- a/config.yml.default
+++ b/config.yml.default
@@ -115,6 +115,7 @@ abort_time: 30                     # Time to abort a game in seconds when there 
 fake_think_time: false             # Artificially slow down the bot to pretend like it's thinking.
 rate_limiting_delay: 0             # Time (in ms) to delay after sending a move to prevent "Too Many Requests" errors.
 move_overhead: 2000                # Increase if your bot flags games too often.
+quit_after_all_games_finish: false # If set to true, then pressing Ctrl-C to quit will only stop lichess-bot after all current games have finished.
 
 correspondence:
   move_time: 60                    # Time in seconds to search in correspondence games.

--- a/lib/config.py
+++ b/lib/config.py
@@ -153,6 +153,7 @@ def insert_default_values(CONFIG: CONFIG_DICT_TYPE) -> None:
     """
     set_config_default(CONFIG, key="abort_time", default=20)
     set_config_default(CONFIG, key="move_overhead", default=1000)
+    set_config_default(CONFIG, key="quit_after_all_games_finish", default=False)
     set_config_default(CONFIG, key="rate_limiting_delay", default=0)
     set_config_default(CONFIG, key="pgn_file_grouping", default="game", force_empty_values=True)
     set_config_default(CONFIG, "engine", key="working_dir", default=os.getcwd(), force_empty_values=True)

--- a/lib/matchmaking.py
+++ b/lib/matchmaking.py
@@ -239,7 +239,7 @@ class Matchmaking:
         value: str = config.lookup(parameter)
         return value if value != "random" else random.choice(choices)
 
-    def challenge(self, active_games: set[str], challenge_queue: MULTIPROCESSING_LIST_TYPE) -> None:
+    def challenge(self, active_games: dict[Any, Any], challenge_queue: MULTIPROCESSING_LIST_TYPE) -> None:
         """
         Challenge an opponent.
 

--- a/lib/matchmaking.py
+++ b/lib/matchmaking.py
@@ -239,7 +239,7 @@ class Matchmaking:
         value: str = config.lookup(parameter)
         return value if value != "random" else random.choice(choices)
 
-    def challenge(self, active_games: dict[Any, Any], challenge_queue: MULTIPROCESSING_LIST_TYPE) -> None:
+    def challenge(self, active_games: set[str], challenge_queue: MULTIPROCESSING_LIST_TYPE) -> None:
         """
         Challenge an opponent.
 

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -175,7 +175,7 @@ def logging_listener_proc(queue: LOGGING_QUEUE_TYPE, level: int, log_filename: O
     while True:
         task: Optional[logging.LogRecord] = None
         try:
-            task = queue.get(10)
+            task = queue.get(timeout=10)
         except Empty:
             pass
         except InterruptedError:

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -174,9 +174,9 @@ def logging_listener_proc(queue: LOGGING_QUEUE_TYPE, level: int, log_filename: O
     while True:
         task: Optional[logging.LogRecord] = None
         try:
-            task = queue.get(timeout=10)
+            task = queue.get(block=False)
         except Empty:
-            pass
+            time.sleep(0.1)
         except InterruptedError:
             pass
         except Exception:

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -377,6 +377,8 @@ def next_event(control_queue: CONTROL_QUEUE_TYPE) -> EVENT_TYPE:
     """Get the next event from the control queue."""
     try:
         event: EVENT_TYPE = control_queue.get()
+        if event is None:
+            return {}
     except InterruptedError:
         return {}
 

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -415,9 +415,7 @@ def check_in_on_correspondence_games(pool: POOL_TYPE,
         start_game_thread(active_games, game_id, play_game_args, pool)
 
 
-def start_low_time_games(low_time_games: list[EVENT_GETATTR_GAME_TYPE],
-                         active_games: set[str],
-                         max_games: int,
+def start_low_time_games(low_time_games: list[EVENT_GETATTR_GAME_TYPE], active_games: set[str], max_games: int,
                          pool: POOL_TYPE, play_game_args: PLAY_GAME_ARGS_TYPE) -> None:
     """Start the games based on how much time we have left."""
     low_time_games.sort(key=lambda g: g.get("secondsLeft", math.inf))
@@ -426,9 +424,7 @@ def start_low_time_games(low_time_games: list[EVENT_GETATTR_GAME_TYPE],
         start_game_thread(active_games, game_id, play_game_args, pool)
 
 
-def accept_challenges(li: lichess.Lichess,
-                      challenge_queue: MULTIPROCESSING_LIST_TYPE,
-                      active_games: set[str],
+def accept_challenges(li: lichess.Lichess, challenge_queue: MULTIPROCESSING_LIST_TYPE, active_games: set[str],
                       max_games: int) -> None:
     """Accept a challenge."""
     while len(active_games) < max_games and challenge_queue:
@@ -478,8 +474,7 @@ def game_is_active(li: lichess.Lichess, game_id: str) -> bool:
     return game_id in (ongoing_game["gameId"] for ongoing_game in li.get_ongoing_games())
 
 
-def start_game_thread(active_games: set[str], game_id: str,
-                      play_game_args: PLAY_GAME_ARGS_TYPE, pool: POOL_TYPE) -> None:
+def start_game_thread(active_games: set[str], game_id: str, play_game_args: PLAY_GAME_ARGS_TYPE, pool: POOL_TYPE) -> None:
     """Start a game thread."""
     active_games.add(game_id)
     log_proc_count("Used", active_games)

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -365,8 +365,6 @@ def lichess_bot_main(li: lichess.Lichess,
             pool.close()
             pool.join()
 
-    logger.info("Terminated")
-
 
 def next_event(control_queue: CONTROL_QUEUE_TYPE) -> EVENT_TYPE:
     """Get the next event from the control queue."""

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -190,7 +190,7 @@ def logging_listener_proc(queue: LOGGING_QUEUE_TYPE, level: int, log_filename: O
         queue.task_done()
 
 
-def thread_logging_configurer(queue: Union[CONTROL_QUEUE_TYPE, LOGGING_QUEUE_TYPE]) -> None:
+def thread_logging_configurer(queue: LOGGING_QUEUE_TYPE) -> None:
     """Configure the game logger."""
     h = logging.handlers.QueueHandler(queue)
     root = logging.getLogger()

--- a/wiki/Configure-lichess-bot.md
+++ b/wiki/Configure-lichess-bot.md
@@ -210,6 +210,7 @@ will precede the `go` command to start thinking with `sd 5`. The other `go_comma
 - `fake_think_time`: Artificially slow down the engine to simulate a person thinking about a move. The amount of thinking time decreases as the game goes on.
 - `rate_limiting_delay`: For extremely fast games, the lichess.org servers may respond with an error if too many moves are played too quickly. This option avoids this problem by pausing for a specified number of milliseconds after submitting a move before making the next move.
 - `move_overhead`: To prevent losing on time due to network lag, subtract this many milliseconds from the time to think on each move.
+- `quit_after_all_games_finish`: If this is set to `true`, then pressing Ctrl-c to quit will cause lichess-bot to terminate after all in-progress games are finished. No new challenges will be sent or accepted, nor will any correspondence games be checked on. If `false` (the default), lichess-bot will terminate immediately and not wait to finish games in progress.
 - `pgn_directory`: Write a record of every game played in PGN format to files in this directory. Each bot move will be annotated with the bot's calculated score and principal variation. The score is written with a tag of the form `[%eval s,d]`, where `s` is the score in pawns (positive means white has the advantage), and `d` is the depth of the search.
 - `pgn_file_grouping`: Determine how games are written to files. There are three options:
     - `game`: Every game record is written to a different file in the `pgn_directory`. The file name is `{White name} vs. {Black name} - {lichess game ID}.pgn`.
@@ -258,13 +259,13 @@ matchmaking:
   allow_matchmaking: false
   challenge_variant: "random"
   challenge_timeout: 30
-  challenge_initial_time: 
+  challenge_initial_time:
     - 60
     - 120
-  challenge_increment: 
+  challenge_increment:
     - 1
     - 2
-  challenge_days: 
+  challenge_days:
      - 1
      - 2
 # opponent_min_rating: 600


### PR DESCRIPTION
## Type of pull request:
- [ ] Bug fix
- [x] Feature
- [ ] Other

## Description:

If a user wants to quit lichess-bot without interrupting in-progress games, they can add `quit_after_all_games_finish: true` to their configuration file. Then, pressing Ctrl-C will stop new game from being started--whether from matchmaking, challenges, or correspondence check-ins--and wait for all game processes to exit before quitting. The user no longer needs to forfeit games or wait around for current games to end in order to quit lichess-bot.

## Related Issues:

N/A

## Checklist:

- [x] I have read and followed the [contribution guidelines](/CONTRIBUTING.md).
- [x] I have added necessary documentation (if applicable).
- [x] The changes pass all existing tests.

## Screenshots/logs (if applicable):

N/A