### PR TITLE
Pytest

### DIFF
--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -3,7 +3,7 @@ import argparse
 import chess
 import chess.pgn
 from chess.variant import find_variant
-from lib import engine_wrapper, model, lichess, matchmaking
+from lib import engine_wrapper, model, matchmaking
 import json
 import logging
 import logging.handlers
@@ -30,6 +30,10 @@ from http.client import RemoteDisconnected
 from queue import Queue
 from multiprocessing.pool import Pool
 from typing import Any, Optional, Union
+if __name__ == "main":
+    from lib import lichess
+else:
+    from test_bot import lichess
 USER_PROFILE_TYPE = dict[str, Any]
 EVENT_TYPE = dict[str, Any]
 PLAY_GAME_ARGS_TYPE = dict[str, Any]

--- a/test_bot/conftest.py
+++ b/test_bot/conftest.py
@@ -6,8 +6,6 @@ from typing import Any
 
 def pytest_sessionfinish(session: Any, exitstatus: Any) -> None:
     """Remove files created when testing lichess-bot."""
-    shutil.copyfile("lib/correct_lichess.py", "lib/lichess.py")
-    os.remove("lib/correct_lichess.py")
     if os.path.exists("TEMP") and not os.getenv("GITHUB_ACTIONS"):
         shutil.rmtree("TEMP")
     if os.path.exists("logs"):

--- a/test_bot/lichess.py
+++ b/test_bot/lichess.py
@@ -125,7 +125,7 @@ class EventStream:
 class Lichess:
     """Imitate communication with lichess.org."""
 
-    def __init__(self, token: str, url: str, version: str) -> None:
+    def __init__(self, token: str, url: str, version: str, logging_level: int, max_retries: int) -> None:
         """Has the same parameters as `lichess.Lichess` to be able to be used in its placed without any modification."""
         self.baseUrl = url
         self.game_accepted = False

--- a/test_bot/test_bot.py
+++ b/test_bot/test_bot.py
@@ -1,4 +1,6 @@
 """Test lichess-bot."""
+import logging
+
 import pytest
 import zipfile
 import requests
@@ -18,8 +20,6 @@ from lib.timer import Timer, to_seconds, seconds
 from typing import Any
 if __name__ == "__main__":
     sys.exit(f"The script {os.path.basename(__file__)} should only be run by pytest.")
-shutil.copyfile("lib/lichess.py", "lib/correct_lichess.py")
-shutil.copyfile("test_bot/lichess.py", "lib/lichess.py")
 lichess_bot = importlib.import_module("lichess-bot")
 
 platform = sys.platform
@@ -185,7 +185,7 @@ def run_bot(raw_config: dict[str, Any], logging_level: int, opponent_path: str =
     config.insert_default_values(raw_config)
     CONFIG = config.Configuration(raw_config)
     lichess_bot.logger.info(lichess_bot.intro())
-    li = lichess_bot.lichess.Lichess(CONFIG.token, CONFIG.url, lichess_bot.__version__)
+    li = lichess_bot.lichess.Lichess(CONFIG.token, CONFIG.url, lichess_bot.__version__, logging_level, 1)
 
     user_profile = li.get_profile()
     username = user_profile["username"]

--- a/test_bot/test_bot.py
+++ b/test_bot/test_bot.py
@@ -1,6 +1,4 @@
 """Test lichess-bot."""
-import logging
-
 import pytest
 import zipfile
 import requests


### PR DESCRIPTION
## Type of pull request:
- [ ] Bug fix
- [ ] Feature
- [x] Other

## Description:

Doesn't copy `test_bot\lichess.py` to `lichess.py` and the back. In the past, when the tests timed out the wrong `lichess.py` file would be in `lib/` so that the user would have to copy it back manually.

## Related Issues:

None

## Checklist:

- [x] I have read and followed the [contribution guidelines](/CONTRIBUTING.md).
- [x] I have added necessary documentation (if applicable).
- [x] The changes pass all existing tests.

## Screenshots/logs (if applicable):
