### PR TITLE
Replace file reading/writing with interprocess queues for tests

### DIFF
--- a/test_bot/conftest.py
+++ b/test_bot/conftest.py
@@ -8,5 +8,3 @@ def pytest_sessionfinish(session: Any, exitstatus: Any) -> None:
     """Remove files created when testing lichess-bot."""
     if os.path.exists("TEMP") and not os.getenv("GITHUB_ACTIONS"):
         shutil.rmtree("TEMP")
-    if os.path.exists("logs"):
-        shutil.rmtree("logs")

--- a/test_bot/lichess.py
+++ b/test_bot/lichess.py
@@ -34,7 +34,13 @@ class GameStream:
     def __init__(self,
                  board_queue: Queue[chess.Board],
                  clock_queue: Queue[tuple[datetime.timedelta, datetime.timedelta, datetime.timedelta]]) -> None:
-        """Initialize `self.moves_sent` to an empty string. It stores the moves that we have already sent."""
+        """
+        Capture the interprocess queues that will feed the gameStream with game information.
+
+        :param board_queue: Updated board positions from the lichess_org_simulator() function.
+        :param clock_queue: Updated game clock timings (white time, black time, and increment) from the
+        lichess_org_simulator() function.
+        """
         self.board_queue = board_queue
         self.clock_queue = clock_queue
 
@@ -88,6 +94,7 @@ class GameStream:
                 new_game_state["winner"] = "black"
                 yield json.dumps(new_game_state).encode("utf-8")
                 break
+
             if board.move_stack:
                 new_game_state["status"] = "started"
                 yield json.dumps(new_game_state).encode("utf-8")
@@ -97,7 +104,11 @@ class EventStream:
     """Imitate lichess.org's EventStream. Used in tests."""
 
     def __init__(self, sent_game: bool = False) -> None:
-        """:param sent_game: If we have already sent the `gameStart` event, so we don't send it again."""
+        """
+        Start the event stream for the lichess_bot_main() loop.
+
+        :param sent_game: If we have already sent the `gameStart` event, so we don't send it again.
+        """
         self.sent_game = sent_game
 
     def iter_lines(self) -> Generator[bytes, None, None]:
@@ -122,7 +133,13 @@ class Lichess:
                  move_queue: Queue[Optional[chess.Move]],
                  board_queue: Queue[chess.Board],
                  clock_queue: Queue[tuple[datetime.timedelta, datetime.timedelta, datetime.timedelta]]) -> None:
-        """Has the same parameters as `lichess.Lichess` to be able to be used in its placed without any modification."""
+        """
+        Capture the interprocess queues to distribute them to the eventStream and gameStream instances.
+
+        :param move_queue: An interprocess queue to send moves chosen by the bot under test to the mock lichess function.
+        :param board_queue: An interprocess queue to send board positions to the mock game stream.
+        :param clock_queue: An interprocess queue to send game clock information to the mock game stream.
+        """
         self.baseUrl = "testing"
         self.move_queue = move_queue
         self.board_queue = board_queue

--- a/test_bot/test_bot.py
+++ b/test_bot/test_bot.py
@@ -97,7 +97,15 @@ def lichess_org_simulator(opponent_path: str,
                           board_queue: Queue[chess.Board],
                           clock_queue: Queue[tuple[datetime.timedelta, datetime.timedelta, datetime.timedelta]],
                           results: Queue[bool]) -> None:
-    """Play the moves for the opponent of lichess-bot."""
+    """
+    Run a mocked version of the lichess.org server to provide an opponent for a test. This opponent always plays white.
+
+    :param opponent_path: The path to the executable of the opponent. Usually Stockfish.
+    :param move_queue: An interprocess queue that supplies the moves chosen by the bot being tested.
+    :param board_queue: An interprocess queue where this function sends the updated board after choosing a move.
+    :param clock_queue: An interprocess queue where this function sends the updated game clock after choosing a move.
+    :param results: An interprocess queue where this function sends the result of the game to the testing function.
+    """
     start_time = seconds(10)
     increment = seconds(0.1)
 
@@ -151,7 +159,13 @@ def lichess_org_simulator(opponent_path: str,
 
 
 def run_bot(raw_config: dict[str, Any], logging_level: int, opponent_path: str = stockfish_path) -> bool:
-    """Start lichess-bot."""
+    """
+    Start lichess-bot test with a mocked version of the lichess.org site.
+
+    :param raw_config: A dictionary of values to specify the engine to test. This engine will play as white.
+    :param logging_level: The level of logging to use during the test. Usually logging.DEBUG.
+    :param opponent_path: The path to the executable that will play the opponent. The opponent plays as black.
+    """
     config.insert_default_values(raw_config)
     CONFIG = config.Configuration(raw_config)
     lichess_bot.logger.info(lichess_bot.intro())

--- a/test_bot/test_bot.py
+++ b/test_bot/test_bot.py
@@ -80,8 +80,7 @@ def download_sjeng() -> None:
     shutil.copyfile("./TEMP/Release/Sjeng112.exe", "./TEMP/sjeng.exe")
 
 
-if not os.path.exists("TEMP"):
-    os.mkdir("TEMP")
+os.makedirs("TEMP", exist_ok=True)
 download_sf()
 if platform == "win32":
     download_lc0()

--- a/test_bot/test_bot.py
+++ b/test_bot/test_bot.py
@@ -2,7 +2,6 @@
 import pytest
 import zipfile
 import requests
-import time
 import yaml
 import chess
 import chess.engine
@@ -13,10 +12,13 @@ import stat
 import shutil
 import importlib
 import tarfile
+import datetime
+from multiprocessing import Manager
+from queue import Queue
 import test_bot.lichess
 from lib import config
 from lib.timer import Timer, to_seconds, seconds
-from typing import Any
+from typing import Any, Optional
 from lib.engine_wrapper import test_suffix
 if "pytest" not in sys.modules:
     sys.exit(f"The script {os.path.basename(__file__)} should only be run by pytest.")
@@ -90,12 +92,12 @@ lichess_bot.logging_configurer(logging_level, testing_log_file_name, None, False
 lichess_bot.logger.info("Downloaded engines")
 
 
-def thread_for_test(opponent_path: str) -> None:
+def lichess_org_simulator(opponent_path: str,
+                          move_queue: Queue[Optional[chess.Move]],
+                          board_queue: Queue[chess.Board],
+                          clock_queue: Queue[tuple[datetime.timedelta, datetime.timedelta, datetime.timedelta]],
+                          results: Queue[bool]) -> None:
     """Play the moves for the opponent of lichess-bot."""
-    open("./logs/events.txt", "w").close()
-    open("./logs/states.txt", "w").close()
-    open("./logs/result.txt", "w").close()
-
     start_time = seconds(10)
     increment = seconds(0.1)
 
@@ -103,15 +105,12 @@ def thread_for_test(opponent_path: str) -> None:
     wtime = start_time
     btime = start_time
 
-    with open("./logs/states.txt", "w") as file:
-        file.write(f"\n{to_seconds(wtime)},{to_seconds(btime)}")
-
     engine = chess.engine.SimpleEngine.popen_uci(opponent_path)
     engine.configure({"Skill Level": 0, "Move Overhead": 1000, "Use NNUE": False}
                      if opponent_path == stockfish_path else {})
 
     while not board.is_game_over():
-        if len(board.move_stack) % 2 == 0:
+        if board.turn == chess.WHITE:
             if not board.move_stack:
                 move = engine.play(board,
                                    chess.engine.Limit(time=1),
@@ -119,8 +118,10 @@ def thread_for_test(opponent_path: str) -> None:
             else:
                 move_timer = Timer()
                 move = engine.play(board,
-                                   chess.engine.Limit(white_clock=to_seconds(wtime) - 2,
-                                                      white_inc=to_seconds(increment)),
+                                   chess.engine.Limit(white_clock=to_seconds(wtime - seconds(2.0)),
+                                                      white_inc=to_seconds(increment),
+                                                      black_clock=to_seconds(btime),
+                                                      black_inc=to_seconds(increment)),
                                    ponder=False)
                 wtime -= move_timer.time_since_reset()
                 wtime += increment
@@ -128,80 +129,61 @@ def thread_for_test(opponent_path: str) -> None:
             if engine_move is None:
                 raise RuntimeError("Engine attempted to make null move.")
             board.push(engine_move)
-
-            uci_move = engine_move.uci()
-            with open("./logs/states.txt") as states:
-                state_str = states.read()
-            state = state_str.split("\n")
-            state[0] += f" {uci_move}"
-            state_str = "\n".join(state)
-            with open("./logs/states.txt", "w") as file:
-                file.write(state_str)
-
-        else:  # lichess-bot move.
+            board_queue.put(board)
+            clock_queue.put((wtime, btime, increment))
+        else:
             move_timer = Timer()
-            state2 = state_str
-            moves_are_correct = False
-            while state2 == state_str or not moves_are_correct:
-                with open("./logs/states.txt") as states:
-                    state2 = states.read()
-                time.sleep(0.001)
-                moves = state2.split("\n")[0]
-                temp_board = chess.Board()
-                moves_are_correct = True
-                for move_str in moves.split():
-                    try:
-                        temp_board.push_uci(move_str)
-                    except ValueError:
-                        moves_are_correct = False
-            with open("./logs/states.txt") as states:
-                state2 = states.read()
-            if len(board.move_stack) > 1:
+            while (bot_move := move_queue.get()) is None:
+                board_queue.put(board)
+                clock_queue.put((wtime, btime, increment))
+                move_queue.task_done()
+            board.push(bot_move)
+            move_queue.task_done()
+            if len(board.move_stack) > 2:
                 btime -= move_timer.time_since_reset()
                 btime += increment
-            move_str = state2.split("\n")[0].split(" ")[-1]
-            board.push_uci(move_str)
 
-        time.sleep(0.001)
-        with open("./logs/states.txt") as states:
-            state_str = states.read()
-        state = state_str.split("\n")
-        state[1] = f"{to_seconds(wtime)},{to_seconds(btime)}"
-        state_str = "\n".join(state)
-        with open("./logs/states.txt", "w") as file:
-            file.write(state_str)
-
-    with open("./logs/events.txt", "w") as file:
-        file.write("end")
+    board_queue.put(board)
+    clock_queue.put((wtime, btime, increment))
     engine.quit()
     outcome = board.outcome()
-    win = outcome.winner == chess.BLACK if outcome else False
-    with open("./logs/result.txt", "w") as file:
-        file.write("1" if win else "0")
+    results.put(outcome is not None and outcome.winner == chess.BLACK)
 
 
-def run_bot(raw_config: dict[str, Any], logging_level: int, opponent_path: str = stockfish_path) -> str:
+def run_bot(raw_config: dict[str, Any], logging_level: int, opponent_path: str = stockfish_path) -> bool:
     """Start lichess-bot."""
     config.insert_default_values(raw_config)
     CONFIG = config.Configuration(raw_config)
     lichess_bot.logger.info(lichess_bot.intro())
-    li = test_bot.lichess.Lichess(CONFIG.token, CONFIG.url, lichess_bot.__version__, logging_level, 1)
+    manager = Manager()
+    board_queue: Queue[chess.Board] = manager.Queue()
+    clock_queue: Queue[tuple[datetime.timedelta, datetime.timedelta, datetime.timedelta]] = manager.Queue()
+    move_queue: Queue[Optional[chess.Move]] = manager.Queue()
+    li = test_bot.lichess.Lichess(move_queue, board_queue, clock_queue)
 
     user_profile = li.get_profile()
     username = user_profile["username"]
     if user_profile.get("title") != "BOT":
-        return "0"
+        return False
     lichess_bot.logger.info(f"Welcome {username}!")
     lichess_bot.disable_restart()
 
-    thr = threading.Thread(target=thread_for_test, args=[opponent_path])
+    results: Queue[bool] = manager.Queue()
+    thr = threading.Thread(target=lichess_org_simulator, args=[opponent_path, move_queue, board_queue, clock_queue, results])
     thr.start()
     lichess_bot.start(li, user_profile, CONFIG, logging_level, testing_log_file_name, None, one_game=True)
+
+    result = results.get()
+    results.task_done()
+
+    results.join()
+    board_queue.join()
+    clock_queue.join()
+    move_queue.join()
+
     thr.join()
 
-    with open("./logs/result.txt") as file:
-        data = file.read()
-    return data
+    return result
 
 
 @pytest.mark.timeout(150, method="thread")
@@ -210,9 +192,6 @@ def test_sf() -> None:
     if platform != "linux" and platform != "win32":
         assert True
         return
-    if os.path.exists("logs"):
-        shutil.rmtree("logs")
-    os.mkdir("logs")
     with open("./config.yml.default") as file:
         CONFIG = yaml.safe_load(file)
     CONFIG["token"] = ""
@@ -221,9 +200,8 @@ def test_sf() -> None:
     CONFIG["engine"]["uci_options"]["Threads"] = 1
     CONFIG["pgn_directory"] = "TEMP/sf_game_record"
     win = run_bot(CONFIG, logging_level)
-    shutil.rmtree("logs")
     lichess_bot.logger.info("Finished Testing SF")
-    assert win == "1"
+    assert win
     assert os.path.isfile(os.path.join(CONFIG["pgn_directory"],
                                        "bo vs b - zzzzzzzz.pgn"))
 
@@ -234,9 +212,6 @@ def test_lc0() -> None:
     if platform != "win32":
         assert True
         return
-    if os.path.exists("logs"):
-        shutil.rmtree("logs")
-    os.mkdir("logs")
     with open("./config.yml.default") as file:
         CONFIG = yaml.safe_load(file)
     CONFIG["token"] = ""
@@ -248,9 +223,8 @@ def test_lc0() -> None:
     CONFIG["engine"]["uci_options"].pop("Move Overhead", None)
     CONFIG["pgn_directory"] = "TEMP/lc0_game_record"
     win = run_bot(CONFIG, logging_level)
-    shutil.rmtree("logs")
     lichess_bot.logger.info("Finished Testing LC0")
-    assert win == "1"
+    assert win
     assert os.path.isfile(os.path.join(CONFIG["pgn_directory"],
                                        "bo vs b - zzzzzzzz.pgn"))
 
@@ -261,9 +235,6 @@ def test_sjeng() -> None:
     if platform != "win32":
         assert True
         return
-    if os.path.exists("logs"):
-        shutil.rmtree("logs")
-    os.mkdir("logs")
     with open("./config.yml.default") as file:
         CONFIG = yaml.safe_load(file)
     CONFIG["token"] = ""
@@ -274,9 +245,8 @@ def test_sjeng() -> None:
     CONFIG["engine"]["ponder"] = False
     CONFIG["pgn_directory"] = "TEMP/sjeng_game_record"
     win = run_bot(CONFIG, logging_level)
-    shutil.rmtree("logs")
     lichess_bot.logger.info("Finished Testing Sjeng")
-    assert win == "1"
+    assert win
     assert os.path.isfile(os.path.join(CONFIG["pgn_directory"],
                                        "bo vs b - zzzzzzzz.pgn"))
 
@@ -287,9 +257,6 @@ def test_homemade() -> None:
     if platform != "linux" and platform != "win32":
         assert True
         return
-    if os.path.exists("logs"):
-        shutil.rmtree("logs")
-    os.mkdir("logs")
     with open("./config.yml.default") as file:
         CONFIG = yaml.safe_load(file)
     CONFIG["token"] = ""
@@ -297,9 +264,8 @@ def test_homemade() -> None:
     CONFIG["engine"]["protocol"] = "homemade"
     CONFIG["pgn_directory"] = "TEMP/homemade_game_record"
     win = run_bot(CONFIG, logging_level)
-    shutil.rmtree("logs")
     lichess_bot.logger.info("Finished Testing Homemade")
-    assert win == "1"
+    assert win
     assert os.path.isfile(os.path.join(CONFIG["pgn_directory"],
                                        "bo vs b - zzzzzzzz.pgn"))
 
@@ -307,9 +273,6 @@ def test_homemade() -> None:
 @pytest.mark.timeout(30, method="thread")
 def test_buggy_engine() -> None:
     """Test lichess-bot with an engine that causes a timeout error within python-chess."""
-    if os.path.exists("logs"):
-        shutil.rmtree("logs")
-    os.mkdir("logs")
     with open("./config.yml.default") as file:
         CONFIG = yaml.safe_load(file)
     CONFIG["token"] = ""
@@ -330,8 +293,7 @@ def test_buggy_engine() -> None:
     CONFIG["pgn_directory"] = "TEMP/bug_game_record"
 
     win = run_bot(CONFIG, logging_level, engine_path(CONFIG))
-    shutil.rmtree("logs")
     lichess_bot.logger.info("Finished Testing buggy engine")
-    assert win == "1"
+    assert win
     assert os.path.isfile(os.path.join(CONFIG["pgn_directory"],
                                        "bo vs b - zzzzzzzz.pgn"))


### PR DESCRIPTION
## Type of pull request:
- [ ] Bug fix
- [ ] Feature
- [x] Other

## Description:

Instead of reading and writing files to communicate between the various processes during testing, use multiprocessing managed queues to send chess objects. This is much simpler than serializing and deserializing text. There is no chance for any test to overwrite communication from a different test.

## Related Issues:

N/A

## Checklist:

- [x] I have read and followed the [contribution guidelines](/docs/CONTRIBUTING.md).
- [x] I have added necessary documentation (if applicable).
- [x] The changes pass all existing tests.

## Screenshots/logs (if applicable):

N/A