### PR TITLE
Allow matchmaking during games

### DIFF
--- a/config.yml.default
+++ b/config.yml.default
@@ -183,6 +183,7 @@ greeting:
 
 matchmaking:
   allow_matchmaking: false         # Set it to 'true' to challenge other bots.
+  allow_during_games: false        # Set it to 'true' to create challenges during long games.
   challenge_variant: "random"      # If set to 'random', the bot will choose one variant from the variants enabled in 'challenge.variants'.
   challenge_timeout: 30            # Create a challenge after being idle for 'challenge_timeout' minutes. The minimum is 1 minute.
   challenge_initial_time:          # Initial time in seconds of the challenge (to be chosen at random).

--- a/lib/matchmaking.py
+++ b/lib/matchmaking.py
@@ -2,10 +2,9 @@
 import random
 import logging
 import datetime
-import math
 import test_bot.lichess
 from lib import model
-from lib.timer import Timer, seconds, minutes, days
+from lib.timer import Timer, seconds, minutes, days, years
 from collections import defaultdict
 from collections.abc import Sequence
 from lib import lichess
@@ -58,7 +57,7 @@ class Matchmaking:
         self.min_wait_time = seconds(60)  # Wait before new challenge to avoid api rate limits.
 
         # Maximum time between challenges, even if there are active games
-        self.max_wait_time = minutes(10) if self.matchmaking_cfg.allow_during_games else seconds(math.inf)
+        self.max_wait_time = minutes(10) if self.matchmaking_cfg.allow_during_games else years(10)
         self.challenge_id: str = ""
         self.daily_challenges: DAILY_TIMERS_TYPE = read_daily_challenges()
 

--- a/lib/matchmaking.py
+++ b/lib/matchmaking.py
@@ -241,14 +241,17 @@ class Matchmaking:
         value: str = config.lookup(parameter)
         return value if value != "random" else random.choice(choices)
 
-    def challenge(self, active_games: set[str], challenge_queue: MULTIPROCESSING_LIST_TYPE) -> None:
+    def challenge(self, active_games: set[str], challenge_queue: MULTIPROCESSING_LIST_TYPE, max_games: int) -> None:
         """
         Challenge an opponent.
 
         :param active_games: The games that the bot is playing.
         :param challenge_queue: The queue containing the challenges.
+        :param max_games: The maximum allowed number of simultaneous games.
         """
-        if active_games or challenge_queue or not self.should_create_challenge():
+        max_games_for_matchmaking = max_games if self.matchmaking_cfg.allow_during_games else 0
+        game_count = len(active_games) + len(challenge_queue)
+        if game_count >= max_games_for_matchmaking or not self.should_create_challenge():
             return
 
         logger.info("Challenging a random bot")

--- a/lib/matchmaking.py
+++ b/lib/matchmaking.py
@@ -252,7 +252,7 @@ class Matchmaking:
         :param challenge_queue: The queue containing the challenges.
         :param max_games: The maximum allowed number of simultaneous games.
         """
-        max_games_for_matchmaking = max_games if self.matchmaking_cfg.allow_during_games else 0
+        max_games_for_matchmaking = max_games if self.matchmaking_cfg.allow_during_games else 1
         game_count = len(active_games) + len(challenge_queue)
         if (game_count >= max_games_for_matchmaking
                 or (game_count > 0 and self.last_challenge_created_delay.time_since_reset() < self.max_wait_time)

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -368,7 +368,7 @@ def lichess_bot_main(li: LICHESS_TYPE,
                                              active_games,
                                              max_games)
             accept_challenges(li, challenge_queue, active_games, max_games)
-            matchmaker.challenge(active_games, challenge_queue)
+            matchmaker.challenge(active_games, challenge_queue, max_games)
             check_online_status(li, user_profile, last_check_online_time)
 
             control_queue.task_done()

--- a/wiki/Configure-lichess-bot.md
+++ b/wiki/Configure-lichess-bot.md
@@ -224,7 +224,7 @@ will precede the `go` command to start thinking with `sd 5`. The other `go_comma
 ## Challenging other bots
 - `matchmaking`: Challenge a random bot.
   - `allow_matchmaking`: Whether to challenge other bots.
-  - `allow_during_games`: Whether to issue new challenges while the bot is already playing games.
+  - `allow_during_games`: Whether to issue new challenges while the bot is already playing games. If true, no more than 10 minutes will pass between matchmaking challenges.
   - `challenge_variant`: The variant for the challenges. If set to `random` a variant from the ones enabled in `challenge.variants` will be chosen at random.
   - `challenge_timeout`: The time (in minutes) the bot has to be idle before it creates a challenge.
   - `challenge_initial_time`: A list of initial times (in seconds and to be chosen at random) for the challenges.

--- a/wiki/Configure-lichess-bot.md
+++ b/wiki/Configure-lichess-bot.md
@@ -224,6 +224,7 @@ will precede the `go` command to start thinking with `sd 5`. The other `go_comma
 ## Challenging other bots
 - `matchmaking`: Challenge a random bot.
   - `allow_matchmaking`: Whether to challenge other bots.
+  - `allow_during_games`: Whether to issue new challenges while the bot is already playing games.
   - `challenge_variant`: The variant for the challenges. If set to `random` a variant from the ones enabled in `challenge.variants` will be chosen at random.
   - `challenge_timeout`: The time (in minutes) the bot has to be idle before it creates a challenge.
   - `challenge_initial_time`: A list of initial times (in seconds and to be chosen at random) for the challenges.


### PR DESCRIPTION
## Type of pull request:
- [ ] Bug fix
- [x] Feature
- [ ] Other

## Description:

Provides a new option so that, if a bot has been playing a game for more than 10 minutes and it has room for another game, it can issue another matchmaking challenge.

## Related Issues:

Inspired by discussion #883.

## Checklist:

- [x] I have read and followed the [contribution guidelines](/docs/CONTRIBUTING.md).
- [x] I have added necessary documentation (if applicable).
- [x] The changes pass all existing tests.

## Screenshots/logs (if applicable):

N/A