### PR TITLE
Add note that ultraBullet isn't allowed

### DIFF
--- a/config.yml.default
+++ b/config.yml.default
@@ -146,7 +146,7 @@ challenge:                         # Incoming challenges.
 #   - kingOfTheHill
 #   - racingKings
 #   - threeCheck
-  time_controls:                   # Time controls to accept (bots are not allowed to play ultraBullet)
+  time_controls:                   # Time controls to accept (bots are not allowed to play ultraBullet).
     - bullet
     - blitz
     - rapid

--- a/config.yml.default
+++ b/config.yml.default
@@ -146,7 +146,7 @@ challenge:                         # Incoming challenges.
 #   - kingOfTheHill
 #   - racingKings
 #   - threeCheck
-  time_controls:                   # Time controls to accept.
+  time_controls:                   # Time controls to accept (bots are not allowed to play ultraBullet)
     - bullet
     - blitz
     - rapid

--- a/wiki/Configure-lichess-bot.md
+++ b/wiki/Configure-lichess-bot.md
@@ -171,7 +171,7 @@ will precede the `go` command to start thinking with `sd 5`. The other `go_comma
     - antichess
     # etc.
 ```
-  - `time_controls`: An indented list of acceptable time control types from `bullet` to `correspondence`.
+  - `time_controls`: An indented list of acceptable time control types from `bullet` to `correspondence` (bots are not allowed to play `ultraBullet`).
 ```yml
   time_controls:
     - bullet


### PR DESCRIPTION
## Type of pull request:
- [ ] Bug fix
- [ ] Feature
- [x] Other

## Description:

I was wondering why my bot rejected 0.25+0 games, then I tried adding `ultraBullet` to my config, then I found [an old issue](https://github.com/lichess-bot-devs/lichess-bot/issues/556) saying it's disallowed. Save the next person some time by noting this fact directly in the sample config.

## Checklist:

- [x] I have read and followed the [contribution guidelines](/docs/CONTRIBUTING.md).
- [x] I have added necessary documentation (if applicable).
- [x] The changes pass all existing tests.