### PR TITLE
Type some Lichess API methods as returning None

### DIFF
--- a/lib/lichess.py
+++ b/lib/lichess.py
@@ -357,7 +357,6 @@ class Lichess:
         """Cancel a challenge."""
         self.api_post("cancel", challenge_id, raise_for_status=False)
 
-    # TOOD: Replace with a more specific type
     def online_book_get(self, path: str, params: Optional[dict[str, Any]] = None, stream: bool = False) -> JSON_REPLY_TYPE:
         """Get an external move from online sources (chessdb or lichess.org)."""
         @backoff.on_exception(backoff.constant,

--- a/lib/lichess.py
+++ b/lib/lichess.py
@@ -41,6 +41,7 @@ logger = logging.getLogger(__name__)
 
 MAX_CHAT_MESSAGE_LEN = 140  # The maximum characters in a chat message.
 
+
 class OKResponse(TypedDict):
     """Often given by the API on POSTs or endpoints needing no further action."""
     ok: bool
@@ -268,8 +269,10 @@ class Lichess:
         :param game_id: The id of the game.
         :param move: The move to make.
         """
-        return cast(OKResponse, self.api_post("move", game_id, move.move,
-                             params={"offeringDraw": str(move.draw_offered).lower()}))
+        return cast(OKResponse, self.api_post(
+            "move", game_id, move.move,
+            params={"offeringDraw": str(move.draw_offered).lower()}
+        ))
 
     def chat(self, game_id: str, room: str, text: str) -> OKResponse:
         """
@@ -309,11 +312,12 @@ class Lichess:
     def decline_challenge(self, challenge_id: str, reason: str = "generic") -> OKResponse:
         """Decline a challenge."""
         try:
-            return cast(OKResponse, self.api_post("decline", challenge_id,
-                                 data=f"reason={reason}",
-                                 headers={"Content-Type":
-                                          "application/x-www-form-urlencoded"},
-                                 raise_for_status=False))
+            return cast(OKResponse, self.api_post(
+                "decline", challenge_id,
+                data=f"reason={reason}",
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+                raise_for_status=False
+            ))
         except Exception:
             return {"ok": False}
 

--- a/lib/lichess.py
+++ b/lib/lichess.py
@@ -309,14 +309,12 @@ class Lichess:
         except Exception:
             pass
 
-    # TODO: Replace with a more specific type
     def get_profile(self) -> JSON_REPLY_TYPE:
         """Get the bot's profile (e.g. username)."""
         profile = self.api_get_json("profile")
         self.set_user_agent(profile["username"])
         return profile
 
-    # TODO: Replace with a more specific type
     def get_ongoing_games(self) -> list[dict[str, Any]]:
         """Get the bot's ongoing games."""
         ongoing_games: list[dict[str, Any]] = []
@@ -342,7 +340,6 @@ class Lichess:
         except Exception:
             return ""
 
-    # TODO: Replace with a more specific type
     def get_online_bots(self) -> list[dict[str, Any]]:
         """Get a list of bots that are online."""
         try:
@@ -352,7 +349,6 @@ class Lichess:
         except Exception:
             return []
 
-    # TODO: Replace with a more specific type
     def challenge(self, username: str, payload: REQUESTS_PAYLOAD_TYPE) -> JSON_REPLY_TYPE:
         """Create a challenge."""
         return self.api_post("challenge", username, payload=payload, raise_for_status=False)
@@ -383,7 +379,6 @@ class Lichess:
         user = self.api_get_list("status", params={"ids": user_id})
         return bool(user and user[0].get("online"))
 
-    # TODO: Replace with a more specific type
     def get_public_data(self, user_name: str) -> JSON_REPLY_TYPE:
         """Get the public data of a bot."""
         return self.api_get_json("public_data", user_name)

--- a/lib/lichess.py
+++ b/lib/lichess.py
@@ -296,12 +296,10 @@ class Lichess:
         """Aborts a game."""
         return cast(OKResponse, self.api_post("abort", game_id))
 
-    # TODO: Align types with test_bot/lichess.py
     def get_event_stream(self) -> requests.models.Response:
         """Get a stream of the events (e.g. challenge, gameStart)."""
         return self.api_get("stream_event", stream=True, timeout=15)
 
-    # TODO: Align types with test_bot/lichess.py
     def get_game_stream(self, game_id: str) -> requests.models.Response:
         """Get  stream of the in-game events (e.g. moves by the opponent)."""
         return self.api_get("stream", game_id, stream=True, timeout=15)

--- a/lib/lichess.py
+++ b/lib/lichess.py
@@ -264,10 +264,8 @@ class Lichess:
         :param game_id: The id of the game.
         :param move: The move to make.
         """
-        self.api_post(
-            "move", game_id, move.move,
-            params={"offeringDraw": str(move.draw_offered).lower()}
-        )
+        self.api_post("move", game_id, move.move,
+                      params={"offeringDraw": str(move.draw_offered).lower()})
 
     def chat(self, game_id: str, room: str, text: str) -> None:
         """
@@ -304,12 +302,10 @@ class Lichess:
     def decline_challenge(self, challenge_id: str, reason: str = "generic") -> None:
         """Decline a challenge."""
         try:
-            self.api_post(
-                "decline", challenge_id,
-                data=f"reason={reason}",
-                headers={"Content-Type": "application/x-www-form-urlencoded"},
-                raise_for_status=False
-            )
+            self.api_post("decline", challenge_id,
+                          data=f"reason={reason}",
+                          headers={"Content-Type": "application/x-www-form-urlencoded"},
+                          raise_for_status=False)
         except Exception:
             pass
 

--- a/lib/lichess.py
+++ b/lib/lichess.py
@@ -44,6 +44,7 @@ MAX_CHAT_MESSAGE_LEN = 140  # The maximum characters in a chat message.
 
 class OKResponse(TypedDict):
     """Often given by the API on POSTs or endpoints needing no further action."""
+
     ok: bool
 
 

--- a/test_bot/lichess.py
+++ b/test_bot/lichess.py
@@ -9,8 +9,7 @@ import datetime
 from queue import Queue
 from typing import Union, Any, Optional, Generator
 from lib.timer import to_msec
-JSON_REPLY_TYPE = dict[str, Any]
-REQUESTS_PAYLOAD_TYPE = dict[str, Any]
+from lib.lichess import JSON_REPLY_TYPE, REQUESTS_PAYLOAD_TYPE, OKResponse
 
 logger = logging.getLogger(__name__)
 
@@ -147,22 +146,22 @@ class Lichess:
         self.sent_game = False
         self.started_game_stream = False
 
-    def upgrade_to_bot_account(self) -> JSON_REPLY_TYPE:
+    def upgrade_to_bot_account(self) -> OKResponse:
         """Isn't used in tests."""
-        return {}
+        return {"ok": True}
 
-    def make_move(self, game_id: str, move: chess.engine.PlayResult) -> JSON_REPLY_TYPE:
+    def make_move(self, game_id: str, move: chess.engine.PlayResult) -> OKResponse:
         """Send a move to the opponent engine thread."""
         self.move_queue.put(move.move)
-        return {}
+        return {"ok": True}
 
-    def chat(self, game_id: str, room: str, text: str) -> JSON_REPLY_TYPE:
+    def chat(self, game_id: str, room: str, text: str) -> OKResponse:
         """Isn't used in tests."""
-        return {}
+        return {"ok": True}
 
-    def abort(self, game_id: str) -> JSON_REPLY_TYPE:
+    def abort(self, game_id: str) -> OKResponse:
         """Isn't used in tests."""
-        return {}
+        return {"ok": True}
 
     def get_event_stream(self) -> EventStream:
         """Send the `EventStream`."""
@@ -177,13 +176,13 @@ class Lichess:
         self.started_game_stream = True
         return GameStream(self.board_queue, self.clock_queue)
 
-    def accept_challenge(self, challenge_id: str) -> JSON_REPLY_TYPE:
+    def accept_challenge(self, challenge_id: str) -> OKResponse:
         """Isn't used in tests."""
-        return {}
+        return {"ok": True}
 
-    def decline_challenge(self, challenge_id: str, reason: str = "generic") -> JSON_REPLY_TYPE:
+    def decline_challenge(self, challenge_id: str, reason: str = "generic") -> OKResponse:
         """Isn't used in tests."""
-        return {}
+        return {"ok": True}
 
     def get_profile(self) -> dict[str, Union[str, bool, dict[str, str]]]:
         """Return a simple profile for the bot that lichess-bot uses when testing."""
@@ -202,9 +201,9 @@ class Lichess:
         """Return that the bot isn't playing a game."""
         return []
 
-    def resign(self, game_id: str) -> None:
+    def resign(self, game_id: str) -> OKResponse:
         """Isn't used in tests."""
-        return
+        return {"ok": True}
 
     def get_game_pgn(self, game_id: str) -> str:
         """Return a simple PGN."""
@@ -228,9 +227,9 @@ class Lichess:
         """Isn't used in tests."""
         return {}
 
-    def cancel(self, challenge_id: str) -> JSON_REPLY_TYPE:
+    def cancel(self, challenge_id: str) -> OKResponse:
         """Isn't used in tests."""
-        return {}
+        return {"ok": True}
 
     def online_book_get(self, path: str, params: Optional[dict[str, Any]] = None, stream: bool = False) -> JSON_REPLY_TYPE:
         """Isn't used in tests."""

--- a/test_bot/lichess.py
+++ b/test_bot/lichess.py
@@ -9,7 +9,7 @@ import datetime
 from queue import Queue
 from typing import Union, Any, Optional, Generator
 from lib.timer import to_msec
-from lib.lichess import JSON_REPLY_TYPE, REQUESTS_PAYLOAD_TYPE, OKResponse
+from lib.lichess import JSON_REPLY_TYPE, REQUESTS_PAYLOAD_TYPE
 
 logger = logging.getLogger(__name__)
 
@@ -146,22 +146,21 @@ class Lichess:
         self.sent_game = False
         self.started_game_stream = False
 
-    def upgrade_to_bot_account(self) -> OKResponse:
+    def upgrade_to_bot_account(self) -> None:
         """Isn't used in tests."""
-        return {"ok": True}
+        pass
 
-    def make_move(self, game_id: str, move: chess.engine.PlayResult) -> OKResponse:
+    def make_move(self, game_id: str, move: chess.engine.PlayResult) -> None:
         """Send a move to the opponent engine thread."""
         self.move_queue.put(move.move)
-        return {"ok": True}
 
-    def chat(self, game_id: str, room: str, text: str) -> OKResponse:
+    def chat(self, game_id: str, room: str, text: str) -> None:
         """Isn't used in tests."""
-        return {"ok": True}
+        pass
 
-    def abort(self, game_id: str) -> OKResponse:
+    def abort(self, game_id: str) -> None:
         """Isn't used in tests."""
-        return {"ok": True}
+        pass
 
     def get_event_stream(self) -> EventStream:
         """Send the `EventStream`."""
@@ -176,13 +175,13 @@ class Lichess:
         self.started_game_stream = True
         return GameStream(self.board_queue, self.clock_queue)
 
-    def accept_challenge(self, challenge_id: str) -> OKResponse:
+    def accept_challenge(self, challenge_id: str) -> None:
         """Isn't used in tests."""
-        return {"ok": True}
+        pass
 
-    def decline_challenge(self, challenge_id: str, reason: str = "generic") -> OKResponse:
+    def decline_challenge(self, challenge_id: str, reason: str = "generic") -> None:
         """Isn't used in tests."""
-        return {"ok": True}
+        pass
 
     def get_profile(self) -> dict[str, Union[str, bool, dict[str, str]]]:
         """Return a simple profile for the bot that lichess-bot uses when testing."""
@@ -201,9 +200,9 @@ class Lichess:
         """Return that the bot isn't playing a game."""
         return []
 
-    def resign(self, game_id: str) -> OKResponse:
+    def resign(self, game_id: str) -> None:
         """Isn't used in tests."""
-        return {"ok": True}
+        pass
 
     def get_game_pgn(self, game_id: str) -> str:
         """Return a simple PGN."""
@@ -227,9 +226,9 @@ class Lichess:
         """Isn't used in tests."""
         return {}
 
-    def cancel(self, challenge_id: str) -> OKResponse:
+    def cancel(self, challenge_id: str) -> None:
         """Isn't used in tests."""
-        return {"ok": True}
+        pass
 
     def online_book_get(self, path: str, params: Optional[dict[str, Any]] = None, stream: bool = False) -> JSON_REPLY_TYPE:
         """Isn't used in tests."""


### PR DESCRIPTION
## Type of pull request:
- [ ] Bug fix
- [ ] Feature
- [x] Other

## Description:

For endpoints that the [Lichess docs](https://lichess.org/api#tag/Bot/operation/botGameAbort) say just return `{"ok": boolean}`, type it as such.

We could keep extending similar to what I was doing in a different branch: https://github.com/lichess-bot-devs/lichess-bot/compare/master...greg-finley:lichess-bot:types

I'd suggest each TODO is a separate PR probably. Maybe it's even worth making separate issues for all of them (I can do it if you want).

## Related Issues:

Makes progress on https://github.com/lichess-bot-devs/lichess-bot/issues/921

## Checklist:

- [x] I have read and followed the [contribution guidelines](/docs/CONTRIBUTING.md).
- [x] I have added necessary documentation (if applicable).
- [x] The changes pass all existing tests.

## Screenshots/logs (if applicable):
