### PR TITLE
Fix `get_opening_explorer_move` when having the black pieces

### DIFF
--- a/lib/engine_wrapper.py
+++ b/lib/engine_wrapper.py
@@ -952,6 +952,8 @@ def get_opening_explorer_move(li: LICHESS_TYPE, board: chess.Board, game: model.
         for possible_move in response["moves"]:
             games_played = possible_move["white"] + possible_move["black"] + possible_move["draws"]
             winrate = (possible_move["white"] + possible_move["draws"] * .5) / games_played
+            if wb == "b":
+                winrate = 1 - winrate
             if games_played >= opening_explorer_cfg.min_games:
                 # We add both winrate and games_played to the tuple, so that if 2 moves are tied on the first metric,
                 # the second one will be used.


### PR DESCRIPTION
## Type of pull request:
- [x] Bug fix
- [ ] Feature
- [ ] Other

## Description:

The winrate calculation in `get_opening_explorer_move` was always from whites perspective, so when playing black, it would choose the worst move available.

## Related Issues:

fixes #954 

## Checklist:

- [x] I have read and followed the [contribution guidelines](/docs/CONTRIBUTING.md).
- [x] I have added necessary documentation (if applicable).
- [x] The changes pass all existing tests.

## Screenshots/logs (if applicable):
