### PR TITLE
Docker: Fixes annoying message at restart, makes the image easier to use in non root mode + Cleanup useless files

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,8 +12,6 @@ COPY . .
 
 RUN python3 -m pip install --no-cache-dir -r requirements.txt
 
-ARG CONF_FOLDER=$LICHESS_DIR/config
-
-RUN chmod +x docker/copy_files.sh
+RUN chmod +x docker/copy_files.sh && ln -s $LICHESS_DIR/config/config.yml config.yml
 
 CMD docker/copy_files.sh && python3 lichess-bot.py ${OPTIONS} --disable_auto_logging

--- a/docker/Dockerfile.dockerignore
+++ b/docker/Dockerfile.dockerignore
@@ -1,3 +1,5 @@
+docker/*
+!docker/copy_files.sh
 docs/
 wiki/
 .git*

--- a/docker/copy_files.sh
+++ b/docker/copy_files.sh
@@ -1,7 +1,5 @@
 #!/bin/sh
 
-ln -s /lichess-bot/config/config.yml /lichess-bot/
-
 if [ -e /lichess-bot/config/homemade.py ]; then
     ln -sf /lichess-bot/config/homemade.py /lichess-bot/
 fi


### PR DESCRIPTION
Some enhancements of the Docker image:
- Makes `config.yml` link during image build, not at runtime.
- Removes useless ARG in Docker file.
- Removes useless files in the image (everything but `copy_files.sh` in docker directory)

## Type of pull request:
- [ ] Bug fix
- [ ] Feature
- [x] Other

## Description:
The main change is to make the `config.yml` link during the build.  
The advantages are:
- No more annoying `ln: /lichess-bot/config.yml: File exists` message in log when a container is restarted.
- More importantly: for those, like me, who don't need custom `extra_game_handlers.py` or `extra_game_handlers.py`, this allows again (as in version `2024.5.1.2`) to run a container based on this image as a non-root user without digging into the source code to guess what permissions are required to prevent the launch from failing with a permission error.
Since the link is created during construction, no permissions are needed to use it at runtime.
PS: Running a container as root on a production environment is a well-known worst practice. Copying `extra_game_handlers.py` or `extra_game_handlers.py` into the container file system still requires *guessed* permissions.

## Checklist:

- [x] I have read and followed the [contribution guidelines](/docs/CONTRIBUTING.md).
- [x] I have added necessary documentation (if applicable).
- [x] The changes pass all existing tests.
