### PR TITLE
Allow all commands that start with `!eval` to overcome spam rules

### DIFF
--- a/lib/conversation.py
+++ b/lib/conversation.py
@@ -67,6 +67,7 @@ class Conversation:
         :param cmd: The command to react to.
         """
         from_self = line.username == self.game.username
+        is_eval = cmd.startswith("eval")
         if cmd == "commands" or cmd == "help":
             self.send_reply(line, "Supported commands: !wait (wait a minute for my first move), !name, !howto, !eval, !queue")
         elif cmd == "wait" and self.game.is_abortable():
@@ -77,10 +78,10 @@ class Conversation:
             self.send_reply(line, f"{name} running {self.engine.name()} (lichess-bot v{self.version})")
         elif cmd == "howto":
             self.send_reply(line, "How to run: Check out 'Lichess Bot API'")
-        elif cmd == "eval" and (from_self or line.room == "spectator"):
+        elif is_eval and (from_self or line.room == "spectator"):
             stats = self.engine.get_stats(for_chat=True)
             self.send_reply(line, ", ".join(stats))
-        elif cmd == "eval":
+        elif is_eval:
             self.send_reply(line, "I don't tell that to my opponent, sorry.")
         elif cmd == "queue":
             if self.challengers:

--- a/lib/conversation.py
+++ b/lib/conversation.py
@@ -69,7 +69,7 @@ class Conversation:
         from_self = line.username == self.game.username
         is_eval = cmd.startswith("eval")
         if cmd == "commands" or cmd == "help":
-            self.send_reply(line, "Supported commands: !wait (wait a minute for my first move), !name, !howto, !eval, !queue")
+            self.send_reply(line, "Supported commands: !wait (wait a minute for my first move), !name, !howto, !eval (or any text starting with !eval), !queue")
         elif cmd == "wait" and self.game.is_abortable():
             self.game.ping(seconds(60), seconds(120), seconds(120))
             self.send_reply(line, "Waiting 60 seconds...")

--- a/lib/conversation.py
+++ b/lib/conversation.py
@@ -69,7 +69,9 @@ class Conversation:
         from_self = line.username == self.game.username
         is_eval = cmd.startswith("eval")
         if cmd == "commands" or cmd == "help":
-            self.send_reply(line, "Supported commands: !wait (wait a minute for my first move), !name, !howto, !eval (or any text starting with !eval), !queue")
+            self.send_reply(line, (
+                "Supported commands: !wait (wait a minute for my first move), !name, !howto, "
+                "!eval (or any text starting with !eval), !queue"))
         elif cmd == "wait" and self.game.is_abortable():
             self.game.ping(seconds(60), seconds(120), seconds(120))
             self.send_reply(line, "Waiting 60 seconds...")


### PR DESCRIPTION
## Type of pull request:
- [ ] Bug fix
- [x] Feature
- [ ] Other

## Description:

### Context

When watching bot games, chat spam become very strict when trying to send the same command multiple times, which usually happens for `!eval` command.
[This seems to be the piece of code](https://github.com/tsoj/lila/blob/b1f33443d61aba16dd0d66a678ea6fec77b52f3d/modules/security/src/main/Flood.scala#L19C7-L19C19) responsible of detecting a message as spam. It basically detects duplicated messages (thanks [@tsoj](https://github.com/tsoj)!)

There was an attempt to improve this on lichess side [Relaxing spam rules for when being a normal user alone with just BOT accounts in chat](https://github.com/lichess-org/lila/pull/12554), but it didn't make it.

### Proposal

We can improve spectator experience on our side by allowing multiple commands to return our bot's eval.
The easiest way I could think of is doing so for every command that starts with (`!eval`), i.e. `!eval1234`, `!evalplease`, `!eval with spaces`.

This change has been applied to [my bot](https://lichess.org/@/Lynx_BOT) and can be verified right now by watching any of his games and entering those commands one after each other.

## Related Issues:

## Checklist:

- [x] I have read and followed the [contribution guidelines](/docs/CONTRIBUTING.md).
- [ ] I have added necessary documentation (if applicable).
- [ ] The changes pass all existing tests.

## Screenshots/logs (if applicable):
![image](https://github.com/lichess-bot-devs/lichess-bot/assets/11148519/b3f62d90-80ed-4086-934a-9f41f5089e7f)

