### PR TITLE
Append block list from challenge to matchmaking

### DIFF
--- a/config.yml.default
+++ b/config.yml.default
@@ -206,6 +206,7 @@ matchmaking:
 # block_list:                      # The list of bots that will not be challenged
 #   - user1
 #   - user2
+  include_challenge_block_list: false  # Do not challenge bots in the challenge: block_list in addition to the matchmaking block list.
 
 # overrides:                       # List of overrides for the matchmaking specifications above. When a challenge is created, either the default specification above or one of the overrides will be randomly chosen.
 #   bullet_only_horde:             # Name of the override. Can be anything as long as each override has a unique name ("bullet_only_horde" and "easy_chess960" in these examples).

--- a/lib/config.py
+++ b/lib/config.py
@@ -242,6 +242,9 @@ def insert_default_values(CONFIG: CONFIG_DICT_TYPE) -> None:
         for target in ["", "_spectators"]:
             set_config_default(CONFIG, "greeting", key=type + target, default="", force_empty_values=True)
 
+    if CONFIG["matchmaking"]["include_challenge_block_list"]:
+        CONFIG["matchmaking"]["block_list"].extend(CONFIG["challenge"]["block_list"])
+
 
 def log_config(CONFIG: CONFIG_DICT_TYPE) -> None:
     """

--- a/lib/config.py
+++ b/lib/config.py
@@ -212,6 +212,7 @@ def insert_default_values(CONFIG: CONFIG_DICT_TYPE) -> None:
     set_config_default(CONFIG, "matchmaking", key="challenge_timeout", default=30, force_empty_values=True)
     CONFIG["matchmaking"]["challenge_timeout"] = max(CONFIG["matchmaking"]["challenge_timeout"], 1)
     set_config_default(CONFIG, "matchmaking", key="block_list", default=[], force_empty_values=True)
+    set_config_default(CONFIG, "matchmaking", key="include_challenge_block_list", default=False, force_empty_values=True)
     default_filter = (CONFIG.get("matchmaking") or {}).get("delay_after_decline") or FilterType.NONE.value
     set_config_default(CONFIG, "matchmaking", key="challenge_filter", default=default_filter, force_empty_values=True)
     set_config_default(CONFIG, "matchmaking", key="allow_matchmaking", default=False)

--- a/wiki/Configure-lichess-bot.md
+++ b/wiki/Configure-lichess-bot.md
@@ -249,6 +249,7 @@ will precede the `go` command to start thinking with `sd 5`. The other `go_comma
 
     The `challenge_filter` option can be useful if your matchmaking settings result in a lot of declined challenges. The bots that accept challenges will be challenged more often than those that have declined. The filter will remain until lichess-bot quits or the connection with lichess.org is reset.
   - `block_list`: An indented list of usernames of bots that will not be challenged. If this option is not present, then the list is considered empty.
+  - `include_challenge_block_list`: If `true`, do not send challenges to the bots listed in the `challenge: block_list`. Default is `false`.
   - `overrides`: Create variations on the matchmaking settings above for more specific circumstances. If there are any subsections under `overrides`, the settings below that will override the settings in the matchmaking section. Any settings that do not appear will be taken from the settings above. <br/> <br/>
   The overrides section must have the following:
     - Name: A unique name must be given for each override. In the example configuration below, `easy_chess960` and `no_pressure_correspondence` are arbitrary strings to name the subsections and they are unique.


### PR DESCRIPTION
## Type of pull request:
- [ ] Bug fix
- [x] Feature
- [ ] Other

## Description:

Adds an option to the configuration file to add the entries in the `challenge: block_list` to the `matchmaking: block_list`. This avoids having to copy one block list into the other.

## Related Issues:

Closes #975

## Checklist:

- [x] I have read and followed the [contribution guidelines](/docs/CONTRIBUTING.md).
- [x] I have added necessary documentation (if applicable).
- [x] The changes pass all existing tests.

## Screenshots/logs (if applicable):

N/A