### PR TITLE
Allow the bot to prioritize playing against humans or bots

### DIFF
--- a/config.yml.default
+++ b/config.yml.default
@@ -127,6 +127,7 @@ correspondence:
 challenge:                         # Incoming challenges.
   concurrency: 1                   # Number of games to play simultaneously.
   sort_by: "best"                  # Possible values: "best" and "first".
+  preference: "none"               # Possible values: "none", "human", "bot".
   accept_bot: true                 # Accepts challenges coming from other bots.
   only_bot: false                  # Accept challenges by bots only.
   max_increment: 20                # Maximum amount of increment to accept a challenge in seconds. The max is 180. Set to 0 for no increment.

--- a/lib/config.py
+++ b/lib/config.py
@@ -286,6 +286,10 @@ def validate_config(CONFIG: CONFIG_DICT_TYPE) -> None:
             config_assert(online_section.get("move_quality") != "suggest" or not online_section.get("enabled"),
                           f"XBoard engines can't be used with `move_quality` set to `suggest` in {subsection}.")
 
+    config_assert(CONFIG["challenge"]["sort_by"] in ["best", "first"], "challenge.sort_by can be either `first` or `best`.")
+    config_assert(CONFIG["challenge"]["preference"] in ["none", "human", "bot"],
+                  "challenge.preference should be `none`, `human`, or `bot`.")
+
     pgn_directory = CONFIG["pgn_directory"]
     in_docker = os.environ.get("LICHESS_BOT_DOCKER")
     config_warn(not pgn_directory or not in_docker, "Games will be saved to '{}', please ensure this folder is in a mounted "

--- a/lib/config.py
+++ b/lib/config.py
@@ -196,6 +196,7 @@ def insert_default_values(CONFIG: CONFIG_DICT_TYPE) -> None:
     set_config_default(CONFIG, "engine", "polyglot", key="min_weight", default=1)
     set_config_default(CONFIG, "challenge", key="concurrency", default=1)
     set_config_default(CONFIG, "challenge", key="sort_by", default="best")
+    set_config_default(CONFIG, "challenge", key="preference", default="none")
     set_config_default(CONFIG, "challenge", key="accept_bot", default=False)
     set_config_default(CONFIG, "challenge", key="only_bot", default=False)
     set_config_default(CONFIG, "challenge", key="max_increment", default=180)

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -491,10 +491,18 @@ def sort_challenges(challenge_queue: MULTIPROCESSING_LIST_TYPE, challenge_config
     They can be sorted either by rating (the best challenger is accepted first),
     or by time (the first challenger is accepted first).
     """
-    if challenge_config.sort_by == "best":
-        list_c = list(challenge_queue)
-        list_c.sort(key=lambda c: -c.score())
-        challenge_queue[:] = list_c
+    if challenge_config.preference != "none":
+        list_challengers = list(challenge_queue)
+        humans = [challenger for challenger in list_challengers if not challenger.challenger.is_bot]
+        bots = [challenger for challenger in list_challengers if challenger.challenger.is_bot]
+        if challenge_config.sort_by == "best":
+            humans.sort(key=lambda challenger: challenger.score(), reverse=True)
+            bots.sort(key=lambda challenger: challenger.score(), reverse=True)
+        challenge_queue[:] = (humans + bots) if challenge_config.preference == "human" else (bots + humans)
+    elif challenge_config.sort_by == "best":
+        list_challengers = list(challenge_queue)
+        list_challengers.sort(key=lambda challenger: challenger.score(), reverse=True)
+        challenge_queue[:] = list_challengers
 
 
 def game_is_active(li: LICHESS_TYPE, game_id: str) -> bool:

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -489,20 +489,15 @@ def sort_challenges(challenge_queue: MULTIPROCESSING_LIST_TYPE, challenge_config
     Sort the challenges.
 
     They can be sorted either by rating (the best challenger is accepted first),
-    or by time (the first challenger is accepted first).
+    or by time (the first challenger is accepted first). The bot can also
+    prioritize playing against humans or bots.
     """
+    challenge_list = list(challenge_queue)
+    if challenge_config.sort_by == "best":
+        challenge_list.sort(key=lambda challenger: challenger.score(), reverse=True)
     if challenge_config.preference != "none":
-        list_challengers = list(challenge_queue)
-        humans = [challenger for challenger in list_challengers if not challenger.challenger.is_bot]
-        bots = [challenger for challenger in list_challengers if challenger.challenger.is_bot]
-        if challenge_config.sort_by == "best":
-            humans.sort(key=lambda challenger: challenger.score(), reverse=True)
-            bots.sort(key=lambda challenger: challenger.score(), reverse=True)
-        challenge_queue[:] = (humans + bots) if challenge_config.preference == "human" else (bots + humans)
-    elif challenge_config.sort_by == "best":
-        list_challengers = list(challenge_queue)
-        list_challengers.sort(key=lambda challenger: challenger.score(), reverse=True)
-        challenge_queue[:] = list_challengers
+        challenge_list.sort(key=lambda challenger: challenger.is_bot, reverse=challenge_config.preference == "bot")
+    challenge_queue[:] = challenge_list
 
 
 def game_is_active(li: LICHESS_TYPE, game_id: str) -> bool:

--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -496,7 +496,7 @@ def sort_challenges(challenge_queue: MULTIPROCESSING_LIST_TYPE, challenge_config
     if challenge_config.sort_by == "best":
         challenge_list.sort(key=lambda challenger: challenger.score(), reverse=True)
     if challenge_config.preference != "none":
-        challenge_list.sort(key=lambda challenger: challenger.is_bot, reverse=challenge_config.preference == "bot")
+        challenge_list.sort(key=lambda challenger: challenger.challenger.is_bot, reverse=challenge_config.preference == "bot")
     challenge_queue[:] = challenge_list
 
 

--- a/wiki/Configure-lichess-bot.md
+++ b/wiki/Configure-lichess-bot.md
@@ -154,6 +154,7 @@ will precede the `go` command to start thinking with `sd 5`. The other `go_comma
 - `challenge`: Control what kind of games for which the bot should accept challenges. All of the following options must be satisfied by a challenge to be accepted.
   - `concurrency`: The maximum number of games to play simultaneously.
   - `sort_by`: Whether to start games by the best rated/titled opponent `"best"` or by first-come-first-serve `"first"`.
+  - `preference`: Whether to prioritize human opponents, bot opponents, or treat them equally.
   - `accept_bot`: Whether to accept challenges from other bots.
   - `only_bot`: Whether to only accept challenges from other bots.
   - `max_increment`: The maximum value of time increment.


### PR DESCRIPTION
## Type of pull request:
- [ ] Bug fix
- [x] Feature
- [ ] Other

## Description:

Allow the bot to prioritize playing against humans or bots. For example, if someone changes `preference` to `human` and has `sort_by` set to `best`, then the bot will prefer to play with a human even if they are rated lower than a bot. The order of opponents will be:
```
HUMAN A (2100)
HUMAN B (1800)
HUMAN C (1500)
BOT A (3000)
BOT B (2500)
```

## Related Issues:

None

## Checklist:

- [x] I have read and followed the [contribution guidelines](/docs/CONTRIBUTING.md).
- [x] I have added necessary documentation (if applicable).
- [x] The changes pass all existing tests.

## Screenshots/logs (if applicable):
