### PR TITLE
Add wiki note about game length limit

### DIFF
--- a/wiki/Configure-lichess-bot.md
+++ b/wiki/Configure-lichess-bot.md
@@ -142,6 +142,8 @@ will precede the `go` command to start thinking with `sd 5`. The other `go_comma
     - `offer_draw_for_egtb_zero`: If true the bot will offer/accept draw in positions where the online_egtb returns a wdl of 0.
     - `offer_draw_moves`: The absolute value of the evaluation has to be less than or equal to `offer_draw_score` for `offer_draw_moves` amount of moves for the bot to offer/accept draw.
     - `offer_draw_pieces`: The bot only offers/accepts draws if the position has less than or equal to `offer_draw_pieces` pieces.
+  
+  Note: if a games reaches 300 moves it is adjudicated as a draw and shows up in the logs as _draw by agreement_ (see [this discussion](https://lichess.org/forum/general-chess-discussion/lichess-300-move-rule-forced-draw) and [this commit](https://github.com/lichess-org/lila/commit/f8921999115878a98431cd722b267281793b7f6f)).
 
 ## Options for correspondence games
 - `correspondence` These options control how the engine behaves during correspondence games.

--- a/wiki/Configure-lichess-bot.md
+++ b/wiki/Configure-lichess-bot.md
@@ -142,8 +142,8 @@ will precede the `go` command to start thinking with `sd 5`. The other `go_comma
     - `offer_draw_for_egtb_zero`: If true the bot will offer/accept draw in positions where the online_egtb returns a wdl of 0.
     - `offer_draw_moves`: The absolute value of the evaluation has to be less than or equal to `offer_draw_score` for `offer_draw_moves` amount of moves for the bot to offer/accept draw.
     - `offer_draw_pieces`: The bot only offers/accepts draws if the position has less than or equal to `offer_draw_pieces` pieces.
-  
-  Note: if a games reaches 300 moves it is adjudicated as a draw and shows up in the logs as _draw by agreement_ (see [this discussion](https://lichess.org/forum/general-chess-discussion/lichess-300-move-rule-forced-draw) and [this commit](https://github.com/lichess-org/lila/commit/f8921999115878a98431cd722b267281793b7f6f)).
+
+  Note: if a games reaches 300 moves and no checkmate is delivered on move 300, it is adjudicated as a draw and shows up in the logs as _draw by agreement_ (see [this discussion](https://lichess.org/forum/general-chess-discussion/lichess-300-move-rule-forced-draw) and [this commit](https://github.com/lichess-org/lila/commit/f8921999115878a98431cd722b267281793b7f6f)).
 
 ## Options for correspondence games
 - `correspondence` These options control how the engine behaves during correspondence games.

--- a/wiki/Configure-lichess-bot.md
+++ b/wiki/Configure-lichess-bot.md
@@ -143,7 +143,7 @@ will precede the `go` command to start thinking with `sd 5`. The other `go_comma
     - `offer_draw_moves`: The absolute value of the evaluation has to be less than or equal to `offer_draw_score` for `offer_draw_moves` amount of moves for the bot to offer/accept draw.
     - `offer_draw_pieces`: The bot only offers/accepts draws if the position has less than or equal to `offer_draw_pieces` pieces.
 
-  Note: if a games reaches 300 moves and no checkmate is delivered on move 300, it is adjudicated as a draw and shows up in the logs as _draw by agreement_ (see [this discussion](https://lichess.org/forum/general-chess-discussion/lichess-300-move-rule-forced-draw) and [this commit](https://github.com/lichess-org/lila/commit/f8921999115878a98431cd722b267281793b7f6f)). That's a lichess-specific behavior which doesn't depend on lichess-bot version or configuration.
+  Note: If a game reaches 300 moves and no checkmate is delivered on move 300, it is adjudicated as a draw and shows up in the logs as _draw by agreement_ (see [this discussion](https://lichess.org/forum/general-chess-discussion/lichess-300-move-rule-forced-draw) and [this commit](https://github.com/lichess-org/lila/commit/f8921999115878a98431cd722b267281793b7f6f)). That's a lichess-specific behavior which doesn't depend on lichess-bot version or configuration.
 
 ## Options for correspondence games
 - `correspondence` These options control how the engine behaves during correspondence games.

--- a/wiki/Configure-lichess-bot.md
+++ b/wiki/Configure-lichess-bot.md
@@ -143,7 +143,7 @@ will precede the `go` command to start thinking with `sd 5`. The other `go_comma
     - `offer_draw_moves`: The absolute value of the evaluation has to be less than or equal to `offer_draw_score` for `offer_draw_moves` amount of moves for the bot to offer/accept draw.
     - `offer_draw_pieces`: The bot only offers/accepts draws if the position has less than or equal to `offer_draw_pieces` pieces.
 
-  Note: if a games reaches 300 moves and no checkmate is delivered on move 300, it is adjudicated as a draw and shows up in the logs as _draw by agreement_ (see [this discussion](https://lichess.org/forum/general-chess-discussion/lichess-300-move-rule-forced-draw) and [this commit](https://github.com/lichess-org/lila/commit/f8921999115878a98431cd722b267281793b7f6f)).
+  Note: if a games reaches 300 moves and no checkmate is delivered on move 300, it is adjudicated as a draw and shows up in the logs as _draw by agreement_ (see [this discussion](https://lichess.org/forum/general-chess-discussion/lichess-300-move-rule-forced-draw) and [this commit](https://github.com/lichess-org/lila/commit/f8921999115878a98431cd722b267281793b7f6f)). That's a lichess-specific behavior which doesn't depend on lichess-bot version or configuration.
 
 ## Options for correspondence games
 - `correspondence` These options control how the engine behaves during correspondence games.


### PR DESCRIPTION
## Type of pull request:
- [ ] Bug fix
- [ ] Feature
- [x] Other

## Description:

As suggested in #983, this adds a note to the Wiki about the max. game length limit and how reaching it without deliverying checkmate forces a draw

## Related Issues:


## Checklist:

- [x] I have read and followed the [contribution guidelines](/docs/CONTRIBUTING.md).
- [x] I have added necessary documentation (if applicable).
- [ ] The changes pass all existing tests.

## Screenshots/logs (if applicable):

![image](https://github.com/lichess-bot-devs/lichess-bot/assets/11148519/da0b99c2-2170-4b05-8ea7-e8bfd848d513)

