### PR TITLE
ChallengeSentType no longer needed

### DIFF
--- a/lib/lichess.py
+++ b/lib/lichess.py
@@ -13,7 +13,7 @@ from lib.timer import Timer, seconds, sec_str
 from typing import Optional, Union, cast
 import chess.engine
 from lib.types import (UserProfileType, REQUESTS_PAYLOAD_TYPE, GameType, PublicDataType, OnlineType,
-                       ChallengeSentType, TOKEN_TESTS_TYPE, BackoffDetails)
+                       ChallengeType, TOKEN_TESTS_TYPE, BackoffDetails)
 
 
 ENDPOINTS = {
@@ -199,7 +199,7 @@ class Lichess:
                  headers: Optional[dict[str, str]] = None,
                  params: Optional[dict[str, str]] = None,
                  payload: Optional[REQUESTS_PAYLOAD_TYPE] = None,
-                 raise_for_status: bool = True) -> Union[ChallengeSentType, Optional[TOKEN_TESTS_TYPE]]:
+                 raise_for_status: bool = True) -> Union[ChallengeType, Optional[TOKEN_TESTS_TYPE]]:
         """
         Send a POST to lichess.org.
 
@@ -223,7 +223,7 @@ class Lichess:
         if raise_for_status:
             response.raise_for_status()
 
-        json_response: Union[ChallengeSentType, Optional[TOKEN_TESTS_TYPE]] = response.json()
+        json_response: Union[ChallengeType, Optional[TOKEN_TESTS_TYPE]] = response.json()
         return json_response
 
     def get_path_template(self, endpoint_name: str) -> str:
@@ -366,9 +366,9 @@ class Lichess:
         except Exception:
             return []
 
-    def challenge(self, username: str, payload: REQUESTS_PAYLOAD_TYPE) -> ChallengeSentType:
+    def challenge(self, username: str, payload: REQUESTS_PAYLOAD_TYPE) -> ChallengeType:
         """Create a challenge."""
-        return cast(ChallengeSentType,
+        return cast(ChallengeType,
                     self.api_post("challenge", username, payload=payload, raise_for_status=False))
 
     def cancel(self, challenge_id: str) -> None:

--- a/lib/matchmaking.py
+++ b/lib/matchmaking.py
@@ -104,7 +104,7 @@ class Matchmaking:
             self.update_daily_challenge_record()
             self.last_challenge_created_delay.reset()
             response = self.li.challenge(username, params)
-            challenge_id: str = response.get("challenge", {}).get("id", "")
+            challenge_id: str = response.get("id", "")
             if not challenge_id:
                 logger.error(response)
                 self.add_to_block_list(username)

--- a/lib/types.py
+++ b/lib/types.py
@@ -190,12 +190,6 @@ class ChallengeType(TypedDict, total=False):
     initialFen: str
 
 
-class ChallengeSentType(TypedDict, total=False):
-    """Type hint for challenge sent."""
-
-    challenge: ChallengeType
-
-
 class EventType(TypedDict, total=False):
     """Type hint for event."""
 

--- a/test_bot/lichess.py
+++ b/test_bot/lichess.py
@@ -9,7 +9,7 @@ import datetime
 from queue import Queue
 from typing import Union, Optional, Generator
 from lib.timer import to_msec
-from lib.types import (UserProfileType, ChallengeSentType, REQUESTS_PAYLOAD_TYPE, GameType, OnlineType, PublicDataType,
+from lib.types import (UserProfileType, ChallengeType, REQUESTS_PAYLOAD_TYPE, GameType, OnlineType, PublicDataType,
                        BackoffDetails)
 
 
@@ -228,7 +228,7 @@ class Lichess:
         """Return that the only bot online is us."""
         return [{"username": "b", "online": True}]
 
-    def challenge(self, username: str, payload: REQUESTS_PAYLOAD_TYPE) -> ChallengeSentType:
+    def challenge(self, username: str, payload: REQUESTS_PAYLOAD_TYPE) -> ChallengeType:
         """Isn't used in tests."""
         return {}
 


### PR DESCRIPTION
## Type of pull request:
- [x] Bug fix
- [ ] Feature
- [ ] Other

## Description:

The Lichess API was updated so that the JSON response to creating a challenge is no longer nested under a single `challenge` heading. All information has been moved to the top level. This commit aligns lichess-bot with the API change.

## Related Issues:

Closes #991.

Related Lichess API issue: https://github.com/lichess-org/api/pull/363

## Checklist:

- [x] I have read and followed the [contribution guidelines](/docs/CONTRIBUTING.md).
- [x] I have added necessary documentation (if applicable).
- [x] The changes pass all existing tests.

## Screenshots/logs (if applicable):

N/A