### PR TITLE
Write final PGNs to files before quitting

### DIFF
--- a/lib/types.py
+++ b/lib/types.py
@@ -255,6 +255,7 @@ class GameEventType(TypedDict, total=False):
 
 
 CONTROL_QUEUE_TYPE = Queue[EventType]
+PGN_QUEUE_TYPE = Queue[EventType]
 
 
 class PublicDataType(TypedDict, total=False):


### PR DESCRIPTION
## Type of pull request:
- [x] Bug fix
- [ ] Feature
- [ ] Other

## Description:

Prior to this change, pressing Ctrl-C to quit lichess-bot would skip writing the PGN records of any active games, even if the config said to wait for active games to finish. PGN records are now sent by a separate queue than the control stream events to make sure they are saved before quitting.

## Related Issues:

N/A

## Checklist:

- [x] I have read and followed the [contribution guidelines](/docs/CONTRIBUTING.md).
- [x] I have added necessary documentation (if applicable).
- [x] The changes pass all existing tests.

## Screenshots/logs (if applicable):

N/A