### PR TITLE
Fix matchmaking bug with concurrency set to 0

### DIFF
--- a/lib/config.py
+++ b/lib/config.py
@@ -290,6 +290,9 @@ def validate_config(CONFIG: CONFIG_DICT_TYPE) -> None:
             config_assert(online_section.get("move_quality") != "suggest" or not online_section.get("enabled"),
                           f"XBoard engines can't be used with `move_quality` set to `suggest` in {subsection}.")
 
+    config_warn(CONFIG["challenge"]["concurrency"] > 0, "With challenge.concurrency set to 0, the bot won't accept or create "
+                                                        "any challenges.")
+
     config_assert(CONFIG["challenge"]["sort_by"] in ["best", "first"], "challenge.sort_by can be either `first` or `best`.")
     config_assert(CONFIG["challenge"]["preference"] in ["none", "human", "bot"],
                   "challenge.preference should be `none`, `human`, or `bot`.")

--- a/lib/matchmaking.py
+++ b/lib/matchmaking.py
@@ -253,7 +253,7 @@ class Matchmaking:
         :param challenge_queue: The queue containing the challenges.
         :param max_games: The maximum allowed number of simultaneous games.
         """
-        max_games_for_matchmaking = max_games if self.matchmaking_cfg.allow_during_games else 1
+        max_games_for_matchmaking = max_games if self.matchmaking_cfg.allow_during_games else min(1, max_games)
         game_count = len(active_games) + len(challenge_queue)
         if (game_count >= max_games_for_matchmaking
                 or (game_count > 0 and self.last_challenge_created_delay.time_since_reset() < self.max_wait_time)


### PR DESCRIPTION
## Type of pull request:
- [x] Bug fix
- [ ] Feature
- [ ] Other

## Description:

The matchmaker would challenge other bots even when concurrency was set to 0, leading to the problems described in #1003. This PR fixes this.

## Related Issues:

#1003 

## Checklist:

- [x] I have read and followed the [contribution guidelines](/docs/CONTRIBUTING.md).
- [x] I have added necessary documentation (if applicable).
- [x] The changes pass all existing tests.

## Screenshots/logs (if applicable):
