### PR TITLE
Catch exception from upgrade_to_bot_account()

### DIFF
--- a/lib/lichess_bot.py
+++ b/lib/lichess_bot.py
@@ -109,7 +109,10 @@ signal.signal(signal.SIGINT, signal_handler)
 
 def upgrade_account(li: LICHESS_TYPE) -> bool:
     """Upgrade the account to a BOT account."""
-    if li.upgrade_to_bot_account() is None:
+    try:
+        li.upgrade_to_bot_account()
+    except HTTPError:
+        logger.exception("Failed to upgrade to Bot Account.")
         return False
 
     logger.info("Successfully upgraded to Bot Account!")


### PR DESCRIPTION
## Type of pull request:
- [x] Bug fix
- [ ] Feature
- [ ] Other

## Description:

The call to Lichess.upgrade_to_bot_account() does not return a value. Failure is signaled by an exception. Fix the call to upgrade_account() in lib/lichess_bot.py to reflect this.

## Related Issues:

Fixes #1029

## Checklist:

- [x] I have read and followed the [contribution guidelines](/docs/CONTRIBUTING.md).
- [x] I have added necessary documentation (if applicable).
- [x] The changes pass all existing tests.

## Screenshots/logs (if applicable):

N/A