### PR TITLE
Pgn error catching

### DIFF
--- a/lib/lichess_bot.py
+++ b/lib/lichess_bot.py
@@ -153,14 +153,19 @@ def do_correspondence_ping(control_queue: CONTROL_QUEUE_TYPE, period: datetime.t
 def write_pgn_records(pgn_queue: PGN_QUEUE_TYPE, config: Configuration, username: str) -> None:
     """Write PGN records to files as games finish."""
     while True:
+        mark_task_done = False
         try:
             event = pgn_queue.get()
+            mark_task_done = True
             save_pgn_record(event, config, username)
             pgn_queue.task_done()
         except InterruptedError:
             pass
         except Exception:
             logger.exception("Could not write PGN to file")
+
+        if mark_task_done:
+            pgn_queue.task_done()
 
 
 def handle_old_logs(auto_log_filename: str) -> None:

--- a/lib/lichess_bot.py
+++ b/lib/lichess_bot.py
@@ -158,7 +158,6 @@ def write_pgn_records(pgn_queue: PGN_QUEUE_TYPE, config: Configuration, username
             event = pgn_queue.get()
             mark_task_done = True
             save_pgn_record(event, config, username)
-            pgn_queue.task_done()
         except InterruptedError:
             pass
         except Exception:

--- a/lib/lichess_bot.py
+++ b/lib/lichess_bot.py
@@ -159,6 +159,8 @@ def write_pgn_records(pgn_queue: PGN_QUEUE_TYPE, config: Configuration, username
             pgn_queue.task_done()
         except InterruptedError:
             pass
+        except Exception:
+            logger.exception("Could not write PGN to file")
 
 
 def handle_old_logs(auto_log_filename: str) -> None:


### PR DESCRIPTION
## Type of pull request:
- [x] Bug fix
- [ ] Feature
- [ ] Other

## Description:

An exception raised within the `write_pgn_record()` thread will stop any more PGN records from being written. This PR catches all exceptions and logs them so that future games will be saved to files.

In the case of an exception being raised from `pgn_queue.get()` (usually when Ctrl-C is pressed), the `InterruptedError` is caught and ignored. Some additional logic ensures that `task_done()` is called for every successful `get()` call.

## Related Issues:

N/A

## Checklist:

- [x] I have read and followed the [contribution guidelines](/docs/CONTRIBUTING.md).
- [x] I have added necessary documentation (if applicable).
- [x] The changes pass all existing tests.

## Screenshots/logs (if applicable):

N/A