### PR TITLE
Delay engine and book downloads until needed for a test

### DIFF
--- a/test_bot/test_bot.py
+++ b/test_bot/test_bot.py
@@ -205,8 +205,7 @@ def run_bot(raw_config: CONFIG_DICT_TYPE, logging_level: int, opponent_path: str
 def test_sf() -> None:
     """Test lichess-bot with Stockfish (UCI)."""
     if platform != "linux" and platform != "win32":
-        assert True
-        return
+        pytest.skip("Platform must be Linux or Windows.")
     with open("./config.yml.default") as file:
         CONFIG = yaml.safe_load(file)
     CONFIG["token"] = ""
@@ -231,8 +230,7 @@ def test_sf() -> None:
 def test_lc0() -> None:
     """Test lichess-bot with Leela Chess Zero (UCI)."""
     if platform != "win32":
-        assert True
-        return
+        pytest.skip("Platform must be Windows.")
     with open("./config.yml.default") as file:
         CONFIG = yaml.safe_load(file)
     CONFIG["token"] = ""
@@ -260,8 +258,7 @@ def test_lc0() -> None:
 def test_sjeng() -> None:
     """Test lichess-bot with Sjeng (XBoard)."""
     if platform != "win32":
-        assert True
-        return
+        pytest.skip("Platform must be Windows.")
     with open("./config.yml.default") as file:
         CONFIG = yaml.safe_load(file)
     CONFIG["token"] = ""
@@ -288,8 +285,8 @@ def test_sjeng() -> None:
 def test_homemade() -> None:
     """Test lichess-bot with a homemade engine running Stockfish (Homemade)."""
     if platform != "linux" and platform != "win32":
-        assert True
-        return
+        pytest.skip("Platform must be Linux or Windows.")
+
     with open("./config.yml.default") as file:
         CONFIG = yaml.safe_load(file)
     CONFIG["token"] = ""

--- a/test_bot/test_bot.py
+++ b/test_bot/test_bot.py
@@ -114,6 +114,13 @@ def lichess_org_simulator(opponent_path: str,
     wtime = start_time
     btime = start_time
 
+    if opponent_path == stockfish_path:
+        try:
+            download_sf()
+        except Exception:
+            logger.exception("Could not download the Stockfish chess engine")
+            pytest.skip("Could not download the Stockfish chess engine")
+
     engine = chess.engine.SimpleEngine.popen_uci(opponent_path)
     engine.configure({"Skill Level": 0, "Move Overhead": 1000, "Use NNUE": False}
                      if opponent_path == stockfish_path else {})

--- a/test_bot/test_bot.py
+++ b/test_bot/test_bot.py
@@ -41,6 +41,7 @@ def download_sf() -> None:
     archive_link = f"https://github.com/official-stockfish/Stockfish/releases/download/sf_16/{sf_base}.{archive_ext}"
 
     response = requests.get(archive_link, allow_redirects=True)
+    response.raise_for_status()
     archive_name = f"./TEMP/sf_zip.{archive_ext}"
     with open(archive_name, "wb") as file:
         file.write(response.content)
@@ -63,6 +64,7 @@ def download_lc0() -> None:
         return
     response = requests.get("https://github.com/LeelaChessZero/lc0/releases/download/v0.29.0/lc0-v0.29.0-windows-cpu-dnnl.zip",
                             allow_redirects=True)
+    response.raise_for_status()
     with open("./TEMP/lc0_zip.zip", "wb") as file:
         file.write(response.content)
     with zipfile.ZipFile("./TEMP/lc0_zip.zip", "r") as zip_ref:
@@ -211,8 +213,12 @@ def test_sf() -> None:
     CONFIG["engine"]["name"] = f"sf{file_extension}"
     CONFIG["engine"]["uci_options"]["Threads"] = 1
     CONFIG["pgn_directory"] = "TEMP/sf_game_record"
-    logger.info("Downloading stockfish")
-    download_sf()
+    logger.info("Downloading Stockfish")
+    try:
+        download_sf()
+    except Exception:
+        logger.exception("Could not download the Stockfish chess engine")
+        pytest.skip("Could not download the Stockfish chess engine")
     win = run_bot(CONFIG, logging_level)
     logger.info("Finished Testing SF")
     assert win
@@ -236,8 +242,12 @@ def test_lc0() -> None:
     CONFIG["engine"]["uci_options"].pop("Hash", None)
     CONFIG["engine"]["uci_options"].pop("Move Overhead", None)
     CONFIG["pgn_directory"] = "TEMP/lc0_game_record"
-    logger.info("Downloading lc0")
-    download_lc0()
+    logger.info("Downloading LC0")
+    try:
+        download_lc0()
+    except Exception:
+        logger.exception("Could not download the LC0 chess engine")
+        pytest.skip("Could not download the LC0 chess engine")
     win = run_bot(CONFIG, logging_level)
     logger.info("Finished Testing LC0")
     assert win

--- a/test_bot/test_bot.py
+++ b/test_bot/test_bot.py
@@ -69,22 +69,18 @@ def download_lc0() -> None:
         zip_ref.extractall("./TEMP/")
 
 
-def download_sjeng() -> bool:
+def download_sjeng() -> None:
     """Download Sjeng."""
     if os.path.exists("./TEMP/sjeng.exe"):
-        return True
-    try:
-        response = requests.get("https://sjeng.org/ftp/Sjeng112.zip", allow_redirects=True)
-        response.raise_for_status()
-    except requests.HTTPError:
-        return False
+        return
 
+    response = requests.get("https://sjeng.org/ftp/Sjeng112.zip", allow_redirects=True)
+    response.raise_for_status()
     with open("./TEMP/sjeng_zip.zip", "wb") as file:
         file.write(response.content)
     with zipfile.ZipFile("./TEMP/sjeng_zip.zip", "r") as zip_ref:
         zip_ref.extractall("./TEMP/")
     shutil.copyfile("./TEMP/Release/Sjeng112.exe", "./TEMP/sjeng.exe")
-    return True
 
 
 os.makedirs("TEMP", exist_ok=True)
@@ -265,8 +261,11 @@ def test_sjeng() -> None:
     CONFIG["engine"]["ponder"] = False
     CONFIG["pgn_directory"] = "TEMP/sjeng_game_record"
     logger.info("Downloading Sjeng")
-    if not download_sjeng():
-        pytest.skip("Could not download Sjeng chess engine.")
+    try:
+        download_sjeng()
+    except Exception:
+        logger.exception("Could not download the Sjeng chess engine")
+        pytest.skip("Could not download the Sjeng chess engine")
     win = run_bot(CONFIG, logging_level)
     logger.info("Finished Testing Sjeng")
     assert win

--- a/test_bot/test_bot.py
+++ b/test_bot/test_bot.py
@@ -201,7 +201,7 @@ def run_bot(raw_config: CONFIG_DICT_TYPE, logging_level: int, opponent_path: str
     return result
 
 
-@pytest.mark.timeout(150, method="thread")
+@pytest.mark.timeout(180, method="thread")
 def test_sf() -> None:
     """Test lichess-bot with Stockfish (UCI)."""
     if platform != "linux" and platform != "win32":
@@ -226,7 +226,7 @@ def test_sf() -> None:
                                        "bo vs b - zzzzzzzz.pgn"))
 
 
-@pytest.mark.timeout(150, method="thread")
+@pytest.mark.timeout(180, method="thread")
 def test_lc0() -> None:
     """Test lichess-bot with Leela Chess Zero (UCI)."""
     if platform != "win32":
@@ -254,7 +254,7 @@ def test_lc0() -> None:
                                        "bo vs b - zzzzzzzz.pgn"))
 
 
-@pytest.mark.timeout(150, method="thread")
+@pytest.mark.timeout(180, method="thread")
 def test_sjeng() -> None:
     """Test lichess-bot with Sjeng (XBoard)."""
     if platform != "win32":
@@ -281,7 +281,7 @@ def test_sjeng() -> None:
                                        "bo vs b - zzzzzzzz.pgn"))
 
 
-@pytest.mark.timeout(150, method="thread")
+@pytest.mark.timeout(180, method="thread")
 def test_homemade() -> None:
     """Test lichess-bot with a homemade engine running Stockfish (Homemade)."""
     if platform != "linux" and platform != "win32":

--- a/test_bot/test_bot.py
+++ b/test_bot/test_bot.py
@@ -62,6 +62,7 @@ def download_lc0() -> None:
     """Download Leela Chess Zero 0.29.0."""
     if os.path.exists("./TEMP/lc0.exe"):
         return
+
     response = requests.get("https://github.com/LeelaChessZero/lc0/releases/download/v0.29.0/lc0-v0.29.0-windows-cpu-dnnl.zip",
                             allow_redirects=True)
     response.raise_for_status()

--- a/test_bot/test_bot.py
+++ b/test_bot/test_bot.py
@@ -287,6 +287,12 @@ def test_homemade() -> None:
     if platform != "linux" and platform != "win32":
         pytest.skip("Platform must be Linux or Windows.")
 
+    try:
+        download_sf()
+    except Exception:
+        logger.exception("Could not download the Stockfish chess engine")
+        pytest.skip("Could not download the Stockfish chess engine")
+
     with open("./config.yml.default") as file:
         CONFIG = yaml.safe_load(file)
     CONFIG["token"] = ""

--- a/test_bot/test_external_moves.py
+++ b/test_bot/test_external_moves.py
@@ -111,7 +111,6 @@ def download_opening_book() -> None:
 
 
 os.makedirs("TEMP", exist_ok=True)
-download_opening_book()
 
 
 def get_online_move_wrapper(li: LICHESS_TYPE, board: chess.Board, game: Game, online_moves_cfg: Configuration,
@@ -124,6 +123,7 @@ def test_external_moves() -> None:
     """Test that the code for external moves works properly."""
     li = MockLichess()
     game = get_game()
+    download_opening_book()
     online_cfg, online_cfg_2, draw_or_resign_cfg, polyglot_cfg = get_configs()
 
     starting_fen = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"


### PR DESCRIPTION
## Type of pull request:
- [ ] Bug fix
- [ ] Feature
- [x] Other

## Description:

This PR delays downloading the chess engines used for testing until the test that uses them actually runs. This way, the test script can start faster and run the downloads in parallel. Plus, any tooling that reads the test file (VS Code plugins that track test completion) does not have to wait for engine/book downloads.

Another change is to skip a test when an engine or book download fails instead of failing it. The [Sjeng website](https://sjeng.org/) seems to have been down for several weeks now. GitHub actions still works because it's retained a cached copy.

Finally, a logger instance local to test_bot.py is used instead of importing the one from lichess_bot.py.

## Related Issues:

N/A

## Checklist:

- [x] I have read and followed the [contribution guidelines](/docs/CONTRIBUTING.md).
- [x] I have added necessary documentation (if applicable).
- [x] The changes pass all existing tests.

## Screenshots/logs (if applicable):

N/A