### PR TITLE
Return to game if engine makes bad move

### DIFF
--- a/lib/engine_wrapper.py
+++ b/lib/engine_wrapper.py
@@ -187,9 +187,12 @@ class EngineWrapper:
                 BadMove = (chess.IllegalMoveError, chess.InvalidMoveError)
                 if any(isinstance(e, BadMove) for e in error.args):
                     logger.error("Ending game due to bot attempting an illegal move.")
+                    logger.error(error)
                     game_ender = li.abort if game.is_abortable() else li.resign
                     game_ender(game.id)
-                raise
+                    return
+                else:
+                    raise
 
         # Heed min_time
         elapsed = setup_timer.time_since_reset()


### PR DESCRIPTION
## Type of pull request:
- [x] Bug fix
- [ ] Feature
- [ ] Other

## Description:

If an engine picks a bad move (i.e., illegal or invalid), then the game is aborted or the engine resigns. In either case, the program should return to the play_game() function to await the next message from lichess.

## Related Issues:

#1053. This may or may not fix the problem there, but it may lead to a more graceful shutdown of engines after an illegal/invalid move.

## Checklist:

- [x] I have read and followed the [contribution guidelines](/docs/CONTRIBUTING.md).
- [x] I have added necessary documentation (if applicable).
- [x] The changes pass all existing tests.

## Screenshots/logs (if applicable):

N/A