### PR TITLE
Add max simultaneous games per user option

### DIFF
--- a/config.yml.default
+++ b/config.yml.default
@@ -169,6 +169,7 @@ challenge:                         # Incoming challenges.
 # recent_bot_challenge_age: 60     # Maximum age of a bot challenge to be considered recent in seconds
 # max_recent_bot_challenges: 2     # Maximum number of recent challenges that can be accepted from the same bot
   bullet_requires_increment: false # Require that bullet game challenges from bots have a non-zero increment
+  max_simultaneous_games_per_user: 5  # Maximum number of simultaneous games with the same user
 
 greeting:
   # Optional substitution keywords (include curly braces):

--- a/lib/config.py
+++ b/lib/config.py
@@ -210,6 +210,7 @@ def insert_default_values(CONFIG: CONFIG_DICT_TYPE) -> None:
     set_config_default(CONFIG, "challenge", key="min_days", default=1)
     set_config_default(CONFIG, "challenge", key="block_list", default=[], force_empty_values=True)
     set_config_default(CONFIG, "challenge", key="allow_list", default=[], force_empty_values=True)
+    set_config_default(CONFIG, "challenge", key="max_simultaneous_games_per_user", default=5)
     set_config_default(CONFIG, "correspondence", key="checkin_period", default=600)
     set_config_default(CONFIG, "correspondence", key="move_time", default=60, force_empty_values=True)
     set_config_default(CONFIG, "correspondence", key="disconnect_time", default=300)

--- a/lib/lichess_bot.py
+++ b/lib/lichess_bot.py
@@ -36,6 +36,7 @@ from collections.abc import Iterator, MutableSequence
 from http.client import RemoteDisconnected
 from queue import Empty
 from multiprocessing.pool import Pool
+from collections import Counter
 from typing import Optional, Union, TypedDict, cast
 from types import FrameType
 MULTIPROCESSING_LIST_TYPE = MutableSequence[model.Challenge]
@@ -614,7 +615,7 @@ def handle_challenge(event: EventType, li: LICHESS_TYPE, challenge_queue: MULTIP
     if chlng.from_self:
         return
 
-    players_with_active_games = list(map(lambda game: game["opponent"]["username"], li.get_ongoing_games()))
+    players_with_active_games = Counter(game["opponent"]["username"] for game in li.get_ongoing_games())
 
     is_supported, decline_reason = chlng.is_supported(challenge_config, recent_bot_challenges, players_with_active_games)
     if is_supported:

--- a/lib/lichess_bot.py
+++ b/lib/lichess_bot.py
@@ -614,7 +614,9 @@ def handle_challenge(event: EventType, li: LICHESS_TYPE, challenge_queue: MULTIP
     if chlng.from_self:
         return
 
-    is_supported, decline_reason = chlng.is_supported(challenge_config, recent_bot_challenges)
+    players_with_active_games = list(map(lambda game: game["opponent"]["username"], li.get_ongoing_games()))
+
+    is_supported, decline_reason = chlng.is_supported(challenge_config, recent_bot_challenges, players_with_active_games)
     if is_supported:
         challenge_queue.append(chlng)
         sort_challenges(challenge_queue, challenge_config)

--- a/lib/model.py
+++ b/lib/model.py
@@ -109,8 +109,8 @@ class Challenge:
                               or self.decline_due_to(self.challenger.name not in config.block_list, "generic")
                               or self.decline_due_to(self.challenger.name in allowed_opponents, "generic")
                               or self.decline_due_to(self.is_supported_recent(config, recent_bot_challenges), "later")
-                              or self.decline_due_to(players_with_active_games.count(self.challenger.name) <
-                                                     config.max_simultaneous_games_per_user, "generic")
+                              or self.decline_due_to(players_with_active_games.count(self.challenger.name)
+                                                     < config.max_simultaneous_games_per_user, "generic")
                               or self.decline_due_to(is_supported_extra(self), "generic"))
 
             return not decline_reason, decline_reason

--- a/lib/model.py
+++ b/lib/model.py
@@ -6,7 +6,7 @@ import datetime
 from enum import Enum
 from lib.timer import Timer, msec, seconds, sec_str, to_msec, to_seconds, years
 from lib.config import Configuration
-from collections import defaultdict
+from collections import defaultdict, Counter
 from lib.types import UserProfileType, ChallengeType, GameEventType, PlayerType
 
 logger = logging.getLogger(__name__)
@@ -92,7 +92,7 @@ class Challenge:
         return "" if requirement_met else decline_reason
 
     def is_supported(self, config: Configuration, recent_bot_challenges: defaultdict[str, list[Timer]],
-                     players_with_active_games: list[str]) -> tuple[bool, str]:
+                     players_with_active_games: Counter[str]) -> tuple[bool, str]:
         """Whether the challenge is supported."""
         try:
             if self.from_self:
@@ -109,8 +109,8 @@ class Challenge:
                               or self.decline_due_to(self.challenger.name not in config.block_list, "generic")
                               or self.decline_due_to(self.challenger.name in allowed_opponents, "generic")
                               or self.decline_due_to(self.is_supported_recent(config, recent_bot_challenges), "later")
-                              or self.decline_due_to(players_with_active_games.count(self.challenger.name)
-                                                     < config.max_simultaneous_games_per_user, "generic")
+                              or self.decline_due_to(players_with_active_games[self.challenger.name]
+                                                     < config.max_simultaneous_games_per_user, "later")
                               or self.decline_due_to(is_supported_extra(self), "generic"))
 
             return not decline_reason, decline_reason

--- a/lib/model.py
+++ b/lib/model.py
@@ -91,8 +91,8 @@ class Challenge:
         """
         return "" if requirement_met else decline_reason
 
-    def is_supported(self, config: Configuration,
-                     recent_bot_challenges: defaultdict[str, list[Timer]]) -> tuple[bool, str]:
+    def is_supported(self, config: Configuration, recent_bot_challenges: defaultdict[str, list[Timer]],
+                     players_with_active_games: list[str]) -> tuple[bool, str]:
         """Whether the challenge is supported."""
         try:
             if self.from_self:
@@ -109,6 +109,8 @@ class Challenge:
                               or self.decline_due_to(self.challenger.name not in config.block_list, "generic")
                               or self.decline_due_to(self.challenger.name in allowed_opponents, "generic")
                               or self.decline_due_to(self.is_supported_recent(config, recent_bot_challenges), "later")
+                              or self.decline_due_to(players_with_active_games.count(self.challenger.name) <
+                                                     config.max_simultaneous_games_per_user, "generic")
                               or self.decline_due_to(is_supported_extra(self), "generic"))
 
             return not decline_reason, decline_reason

--- a/test_bot/test_model.py
+++ b/test_bot/test_model.py
@@ -4,7 +4,7 @@ import datetime
 from lib import model
 import yaml
 from lib import config
-from collections import defaultdict
+from collections import defaultdict, Counter
 from lib.timer import Timer
 from lib.types import ChallengeType, UserProfileType, GameEventType, PlayerType
 
@@ -52,10 +52,10 @@ def test_challenge() -> None:
     assert challenge_model.speed == "bullet"
     assert challenge_model.time_control["show"] == "1.5+1"
     assert challenge_model.color == "white"
-    assert challenge_model.is_supported(configuration, recent_challenges, []) == (True, "")
+    assert challenge_model.is_supported(configuration, recent_challenges, Counter()) == (True, "")
 
     CONFIG["challenge"]["min_base"] = 120
-    assert challenge_model.is_supported(configuration, recent_challenges, []) == (False, "timeControl")
+    assert challenge_model.is_supported(configuration, recent_challenges, Counter()) == (False, "timeControl")
 
 
 def test_game() -> None:

--- a/test_bot/test_model.py
+++ b/test_bot/test_model.py
@@ -52,10 +52,10 @@ def test_challenge() -> None:
     assert challenge_model.speed == "bullet"
     assert challenge_model.time_control["show"] == "1.5+1"
     assert challenge_model.color == "white"
-    assert challenge_model.is_supported(configuration, recent_challenges) == (True, "")
+    assert challenge_model.is_supported(configuration, recent_challenges, []) == (True, "")
 
     CONFIG["challenge"]["min_base"] = 120
-    assert challenge_model.is_supported(configuration, recent_challenges) == (False, "timeControl")
+    assert challenge_model.is_supported(configuration, recent_challenges, []) == (False, "timeControl")
 
 
 def test_game() -> None:

--- a/wiki/Configure-lichess-bot.md
+++ b/wiki/Configure-lichess-bot.md
@@ -195,6 +195,7 @@ will precede the `go` command to start thinking with `sd 5`. The other `go_comma
   - `allow_list`: An indented list of usernames from which challenges are exclusively accepted. A challenge from a user not on this list is declined. If this option is not present or empty, any user's challenge may be accepted.
   - `recent_bot_challenge_age`: Maximum age of a bot challenge to be considered recent in seconds
   - `max_recent_bot_challenges`: Maximum number of recent challenges that can be accepted from the same bot
+  - `max_simultaneous_games_per_user`: Maximum number of games that can be played simultaneously with the same user
 
 ## Greeting
 - `greeting`: Send messages via chat to the bot's opponent. The string `{me}` will be replaced by the bot's lichess account name. The string `{opponent}` will be replaced by the opponent's lichess account name. Any other word between curly brackets will be removed. If you want to put a curly bracket in the message, use two: `{{` or `}}`.


### PR DESCRIPTION
## Type of pull request:
- [ ] Bug fix
- [x] Feature
- [ ] Other

## Description:

A bot can now limit the number of games it is playing at a given time with the same user.

## Related Issues:

From [discord](https://discord.com/channels/280713822073913354/1322623400925200395/1322623400925200395).

## Checklist:

- [x] I have read and followed the [contribution guidelines](/docs/CONTRIBUTING.md).
- [x] I have added necessary documentation (if applicable).
- [x] The changes pass all existing tests.

## Screenshots/logs (if applicable):
