### PR TITLE
Replace flake8/flake8-docstrings with ruff

### DIFF
--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -32,10 +32,3 @@ jobs:
       run: |
         # Check for python syntax errors and inconsistent code style.
         ruff check --config test_bot/ruff.toml
-    - name: Lint with flake8-markdown
-      run: |
-        flake8-markdown "*.md"
-        flake8-markdown "wiki/*.md"
-    - name: Lint with flake8-docstrings
-      run: |
-        flake8 . --count --max-line-length=127 --statistics --select=D

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -28,7 +28,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         pip install -r test_bot/test-requirements.txt
-    - name: Lint with flake8
+    - name: Lint with ruff
       run: |
         # Check for python syntax errors and inconsistent code style.
         ruff check --config test_bot/ruff.toml

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -30,11 +30,8 @@ jobs:
         pip install -r test_bot/test-requirements.txt
     - name: Lint with flake8
       run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide.
-        # W503 and W504 are mutually exclusive. W504 is considered the best practice now.
-        flake8 . --count --max-complexity=10 --max-line-length=127 --statistics --ignore=D,W503
+        # Check for python syntax errors and inconsistent code style.
+        ruff check --config test_bot/ruff.toml
     - name: Lint with flake8-markdown
       run: |
         flake8-markdown "*.md"

--- a/.github/workflows/update_version.py
+++ b/.github/workflows/update_version.py
@@ -3,6 +3,9 @@ import yaml
 import datetime
 import os
 
+# File is part of an implicit namespace package. Add an `__init__.py`.
+# ruff: noqa: INP001
+
 with open("lib/versioning.yml") as version_file:
     versioning_info = yaml.safe_load(version_file)
 

--- a/.github/workflows/update_version.py
+++ b/.github/workflows/update_version.py
@@ -22,5 +22,5 @@ versioning_info["lichess_bot_version"] = new_version
 with open("lib/versioning.yml", "w") as version_file:
     yaml.dump(versioning_info, version_file, sort_keys=False)
 
-with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+with open(os.environ["GITHUB_OUTPUT"], "a") as fh:
     print(f"new_version={new_version}", file=fh)

--- a/extra_game_handlers.py
+++ b/extra_game_handlers.py
@@ -3,7 +3,7 @@ from lib import model
 from lib.types import OPTIONS_TYPE
 
 
-def game_specific_options(game: model.Game) -> OPTIONS_TYPE:
+def game_specific_options(game: model.Game) -> OPTIONS_TYPE:  # noqa: ARG001
     """
     Return a dictionary of engine options based on game aspects.
 
@@ -12,7 +12,7 @@ def game_specific_options(game: model.Game) -> OPTIONS_TYPE:
     return {}
 
 
-def is_supported_extra(challenge: model.Challenge) -> bool:
+def is_supported_extra(challenge: model.Challenge) -> bool:  # noqa: ARG001
     """
     Determine whether to accept a challenge.
 

--- a/homemade.py
+++ b/homemade.py
@@ -20,8 +20,6 @@ logger = logging.getLogger(__name__)
 class ExampleEngine(MinimalEngine):
     """An example engine that all homemade engines inherit."""
 
-    pass
-
 
 # Bot names and ideas from tom7's excellent eloWorld video
 

--- a/homemade.py
+++ b/homemade.py
@@ -28,7 +28,7 @@ class ExampleEngine(MinimalEngine):
 class RandomMove(ExampleEngine):
     """Get a random move."""
 
-    def search(self, board: chess.Board, *args: HOMEMADE_ARGS_TYPE) -> PlayResult:
+    def search(self, board: chess.Board, *args: HOMEMADE_ARGS_TYPE) -> PlayResult:  # noqa: ARG002
         """Choose a random move."""
         return PlayResult(random.choice(list(board.legal_moves)), None)
 
@@ -36,7 +36,7 @@ class RandomMove(ExampleEngine):
 class Alphabetical(ExampleEngine):
     """Get the first move when sorted by san representation."""
 
-    def search(self, board: chess.Board, *args: HOMEMADE_ARGS_TYPE) -> PlayResult:
+    def search(self, board: chess.Board, *args: HOMEMADE_ARGS_TYPE) -> PlayResult:  # noqa: ARG002
         """Choose the first move alphabetically."""
         moves = list(board.legal_moves)
         moves.sort(key=board.san)
@@ -46,7 +46,7 @@ class Alphabetical(ExampleEngine):
 class FirstMove(ExampleEngine):
     """Get the first move when sorted by uci representation."""
 
-    def search(self, board: chess.Board, *args: HOMEMADE_ARGS_TYPE) -> PlayResult:
+    def search(self, board: chess.Board, *args: HOMEMADE_ARGS_TYPE) -> PlayResult:  # noqa: ARG002
         """Choose the first move alphabetically in uci representation."""
         moves = list(board.legal_moves)
         moves.sort(key=str)
@@ -60,7 +60,12 @@ class ComboEngine(ExampleEngine):
     This engine demonstrates how one can use `time_limit`, `draw_offered`, and `root_moves`.
     """
 
-    def search(self, board: chess.Board, time_limit: Limit, ponder: bool, draw_offered: bool, root_moves: MOVE) -> PlayResult:
+    def search(self,
+               board: chess.Board,
+               time_limit: Limit,
+               ponder: bool,  # noqa: ARG002
+               draw_offered: bool,
+               root_moves: MOVE) -> PlayResult:
         """
         Choose a move using multiple different methods.
 

--- a/lib/config.py
+++ b/lib/config.py
@@ -243,9 +243,9 @@ def insert_default_values(CONFIG: CONFIG_DICT_TYPE) -> None:
         for ponder in ["ponder", "uci_ponder"]:
             set_config_default(CONFIG, section, key=ponder, default=False)
 
-    for type in ["hello", "goodbye"]:
+    for greeting in ["hello", "goodbye"]:
         for target in ["", "_spectators"]:
-            set_config_default(CONFIG, "greeting", key=type + target, default="", force_empty_values=True)
+            set_config_default(CONFIG, "greeting", key=greeting + target, default="", force_empty_values=True)
 
     if CONFIG["matchmaking"]["include_challenge_block_list"]:
         CONFIG["matchmaking"]["block_list"].extend(CONFIG["challenge"]["block_list"])

--- a/lib/config.py
+++ b/lib/config.py
@@ -320,10 +320,11 @@ def validate_config(CONFIG: CONFIG_DICT_TYPE) -> None:
 
     pgn_directory = CONFIG["pgn_directory"]
     in_docker = os.environ.get("LICHESS_BOT_DOCKER")
-    config_warn(not pgn_directory or not in_docker, "Games will be saved to '{}', please ensure this folder is in a mounted "
-                                                    "volume; Using the Docker's container internal file system will prevent "
-                                                    "you accessing the saved files and can lead to disk "
-                                                    "saturation.".format(pgn_directory))
+    config_warn(not pgn_directory or not in_docker,
+                f"Games will be saved to '{pgn_directory}', please ensure this folder is in a mounted "
+                "volume; Using the Docker's container internal file system will prevent "
+                "you accessing the saved files and can lead to disk "
+                "saturation.")
 
     valid_pgn_grouping_options = ["game", "opponent", "all"]
     config_pgn_choice = CONFIG["pgn_file_grouping"]

--- a/lib/config.py
+++ b/lib/config.py
@@ -258,7 +258,7 @@ def log_config(CONFIG: CONFIG_DICT_TYPE, alternate_log_function: Callable[[str],
     :param CONFIG: The bot's config.
     """
     logger_config = CONFIG.copy()
-    logger_config["token"] = "logger"
+    logger_config["token"] = "logger"  # noqa: S105 (Possible hardcoded password)
     destination = alternate_log_function or logger.debug
     destination(f"Config:\n{yaml.dump(logger_config, sort_keys=False)}")
     destination("====================")

--- a/lib/conversation.py
+++ b/lib/conversation.py
@@ -55,7 +55,7 @@ class Conversation:
 
         :param line: Information about the message.
         """
-        logger.info(f'*** {self.game.url()} [{line.room}] {line.username}: {line.text}')
+        logger.info(f"*** {self.game.url()} [{line.room}] {line.username}: {line.text}")
         if line.text[0] == self.command_prefix:
             self.command(line, line.text[1:].lower())
 
@@ -97,7 +97,7 @@ class Conversation:
         :param line: Information about the original message that we reply to.
         :param reply: The reply to send.
         """
-        logger.info(f'*** {self.game.url()} [{line.room}] {self.game.username}: {reply}')
+        logger.info(f"*** {self.game.url()} [{line.room}] {self.game.username}: {reply}")
         self.li.chat(self.game.id, line.room, reply)
 
     def send_message(self, room: str, message: str) -> None:

--- a/lib/conversation.py
+++ b/lib/conversation.py
@@ -68,7 +68,7 @@ class Conversation:
         """
         from_self = line.username == self.game.username
         is_eval = cmd.startswith("eval")
-        if cmd == "commands" or cmd == "help":
+        if cmd in ("commands", "help"):
             self.send_reply(line,
                             "Supported commands: !wait (wait a minute for my first move), !name, "
                             "!eval (or any text starting with !eval), !queue")

--- a/lib/engine_wrapper.py
+++ b/lib/engine_wrapper.py
@@ -271,8 +271,7 @@ class EngineWrapper:
         # Use null_score to have no effect on draw/resign decisions
         null_score = chess.engine.PovScore(chess.engine.Mate(1), board.turn)
         self.scores.append(result.info.get("score", null_score))
-        result = self.offer_draw_or_resign(result, board)
-        return result
+        return self.offer_draw_or_resign(result, board)
 
     def comment_index(self, move_stack_index: int) -> int:
         """
@@ -431,9 +430,7 @@ class EngineWrapper:
 
     def name(self) -> str:
         """Get the name of the engine."""
-        engine_info: dict[str, str] = dict(self.engine.id)
-        name = engine_info["name"]
-        return name
+        return self.engine.id["name"]
 
     def get_pid(self) -> str:
         """Get the pid of the engine."""

--- a/lib/engine_wrapper.py
+++ b/lib/engine_wrapper.py
@@ -1215,7 +1215,8 @@ def dtz_scorer(tablebase: chess.syzygy.Tablebase, board: chess.Board) -> Union[i
 
 
 def dtz_to_wdl(dtz: Union[int, float]) -> int:
-    """Convert DTZ scores to syzygy WDL scores.
+    """
+    Convert DTZ scores to syzygy WDL scores.
 
     A DTZ of +/-100 returns a draw score of +/-1 instead of a win/loss score of +/-2 because
     a 50-move draw can be forced before checkmate can be forced.

--- a/lib/engine_wrapper.py
+++ b/lib/engine_wrapper.py
@@ -62,7 +62,7 @@ def create_engine(engine_config: Configuration, game: Optional[model.Game] = Non
     elif engine_type == "uci":
         Engine = UCIEngine
     elif engine_type == "homemade":
-        Engine = getHomemadeEngine(cfg.name)
+        Engine = get_homemade_engine(cfg.name)
     else:
         raise ValueError(
             f"    Invalid engine type: {engine_type}. Expected xboard, uci, or homemade.")
@@ -618,7 +618,7 @@ class FillerEngine:
 test_suffix = "-for-lichess-bot-testing-only"
 
 
-def getHomemadeEngine(name: str) -> type[MinimalEngine]:
+def get_homemade_engine(name: str) -> type[MinimalEngine]:
     """
     Get the homemade engine with name `name`. e.g. If `name` is `RandomMove` then we will return `homemade.RandomMove`.
 

--- a/lib/engine_wrapper.py
+++ b/lib/engine_wrapper.py
@@ -544,9 +544,9 @@ class MinimalEngine(EngineWrapper):
     `notify`, etc.
     """
 
-    def __init__(self, commands: COMMANDS_TYPE, options: OPTIONS_GO_EGTB_TYPE, stderr: Optional[int],
-                 draw_or_resign: Configuration, game: Optional[model.Game] = None, name: Optional[str] = None,
-                 **popen_args: str) -> None:
+    def __init__(self, commands: COMMANDS_TYPE, options: OPTIONS_GO_EGTB_TYPE, stderr: Optional[int],  # noqa: ARG002
+                 draw_or_resign: Configuration, game: Optional[model.Game] = None, name: Optional[str] = None,  # noqa: ARG002
+                 **popen_args: str) -> None:  # noqa: ARG002 Unused argument popen_args
         """
         Initialize the values of the engine that all homemade engines inherit.
 

--- a/lib/engine_wrapper.py
+++ b/lib/engine_wrapper.py
@@ -23,7 +23,7 @@ from lib.types import (ReadableType, ChessDBMoveType, LichessEGTBMoveType, OPTIO
                        COMMANDS_TYPE, MOVE, InfoStrDict, InfoDictKeys, InfoDictValue, GO_COMMANDS_TYPE, EGTPATH_TYPE,
                        ENGINE_INPUT_ARGS_TYPE, ENGINE_INPUT_KWARGS_TYPE)
 from extra_game_handlers import game_specific_options
-from typing import Any, Optional, Union, Literal, Type, cast
+from typing import Any, Optional, Union, Literal, cast
 from types import TracebackType
 LICHESS_TYPE = Union[lichess.Lichess, test_bot.lichess.Lichess]
 
@@ -119,7 +119,7 @@ class EngineWrapper:
         self.engine.__enter__()
         return self
 
-    def __exit__(self, exc_type: Optional[Type[BaseException]],
+    def __exit__(self, exc_type: Optional[type[BaseException]],
                  exc_value: Optional[BaseException],
                  traceback: Optional[TracebackType]) -> None:
         """Exit context and allow engine to shutdown nicely if there was no exception."""

--- a/lib/engine_wrapper.py
+++ b/lib/engine_wrapper.py
@@ -590,7 +590,6 @@ class MinimalEngine(EngineWrapper):
         self.engine.<method_name>(<*args>, <**kwargs>)
         self.notify(<method_name>, <*args>, <**kwargs>)
         """
-        pass
 
 
 class FillerEngine:

--- a/lib/engine_wrapper.py
+++ b/lib/engine_wrapper.py
@@ -723,7 +723,7 @@ def game_clock_time(board: chess.Board,
     times = {"wtime": msec(game.state["wtime"]), "btime": msec(game.state["btime"])}
     side = wbtime(board)
     times[side] = max(msec(1), times[side] - overhead)
-    logger.info(f"Searching for wtime {msec_str(times["wtime"])} btime {msec_str(times["btime"])} for game {game.id}")
+    logger.info(f"Searching for wtime {msec_str(times['wtime'])} btime {msec_str(times['btime'])} for game {game.id}")
     return chess.engine.Limit(white_clock=to_seconds(times["wtime"]),
                               black_clock=to_seconds(times["btime"]),
                               white_inc=to_seconds(msec(game.state["winc"])),

--- a/lib/engine_wrapper.py
+++ b/lib/engine_wrapper.py
@@ -56,7 +56,7 @@ def create_engine(engine_config: Configuration, game: Optional[model.Game] = Non
 
     stderr = None if cfg.silence_stderr else subprocess.DEVNULL
 
-    Engine: Union[type[UCIEngine], type[XBoardEngine], type[MinimalEngine]]
+    Engine: type[Union[UCIEngine, XBoardEngine, MinimalEngine]]
     if engine_type == "xboard":
         Engine = XBoardEngine
     elif engine_type == "uci":
@@ -1201,7 +1201,7 @@ def dtz_scorer(tablebase: chess.syzygy.Tablebase, board: chess.Board) -> Union[i
     return dtz + (math.copysign(board.halfmove_clock, dtz) if dtz else 0)
 
 
-def dtz_to_wdl(dtz: Union[int, float]) -> int:
+def dtz_to_wdl(dtz: float) -> int:
     """
     Convert DTZ scores to syzygy WDL scores.
 

--- a/lib/engine_wrapper.py
+++ b/lib/engine_wrapper.py
@@ -114,7 +114,7 @@ class EngineWrapper:
             self.engine.close()
             raise
 
-    def __enter__(self) -> EngineWrapper:
+    def __enter__(self) -> EngineWrapper:  # noqa: PYI034 (return Self not available until 3.11)
         """Enter context so engine communication will be properly shutdown."""
         self.engine.__enter__()
         return self

--- a/lib/lichess.py
+++ b/lib/lichess.py
@@ -9,6 +9,7 @@ import logging
 import traceback
 from collections import defaultdict
 import datetime
+import contextlib
 from lib.timer import Timer, seconds, sec_str
 from typing import Optional, Union, cast
 import chess.engine
@@ -315,13 +316,11 @@ class Lichess:
 
     def decline_challenge(self, challenge_id: str, reason: str = "generic") -> None:
         """Decline a challenge."""
-        try:
+        with contextlib.suppress(Exception):
             self.api_post("decline", challenge_id,
                           data=f"reason={reason}",
                           headers={"Content-Type": "application/x-www-form-urlencoded"},
                           raise_for_status=False)
-        except Exception:
-            pass
 
     def get_profile(self) -> UserProfileType:
         """Get the bot's profile (e.g. username)."""
@@ -332,11 +331,9 @@ class Lichess:
     def get_ongoing_games(self) -> list[GameType]:
         """Get the bot's ongoing games."""
         ongoing_games: list[GameType] = []
-        try:
+        with contextlib.suppress(Exception):
             response = cast(dict[str, list[GameType]], self.api_get_json("playing"))
             ongoing_games = response["nowPlaying"]
-        except Exception:
-            pass
         return ongoing_games
 
     def resign(self, game_id: str) -> None:

--- a/lib/lichess.py
+++ b/lib/lichess.py
@@ -47,8 +47,6 @@ MAX_CHAT_MESSAGE_LEN = 140  # The maximum characters in a chat message.
 class RateLimited(RuntimeError):
     """Exception raised when we are rate limited (status code 429)."""
 
-    pass
-
 
 def is_new_rate_limit(response: requests.models.Response) -> bool:
     """Check if the status code is 429, which means that we are rate limited."""

--- a/lib/lichess_bot.py
+++ b/lib/lichess_bot.py
@@ -197,7 +197,7 @@ def logging_configurer(level: int, filename: Optional[str], disable_auto_logs: b
         auto_file_handler = logging.handlers.TimedRotatingFileHandler(auto_log_filename,
                                                                       delay=True,
                                                                       encoding="utf-8",
-                                                                      when='midnight',
+                                                                      when="midnight",
                                                                       backupCount=7)
         auto_file_handler.setLevel(logging.DEBUG)
 
@@ -588,10 +588,10 @@ def start_game(event: EventType,
     game_id = event["game"]["id"]
     if game_id in startup_correspondence_games:
         if enough_time_to_queue(event, config):
-            logger.info(f'--- Enqueue {config.url + game_id}')
+            logger.info(f"--- Enqueue {config.url + game_id}")
             correspondence_queue.put_nowait(game_id)
         else:
-            logger.info(f'--- Will start {config.url + game_id} as soon as possible')
+            logger.info(f"--- Will start {config.url + game_id} as soon as possible")
             low_time_games.append(event["game"])
         startup_correspondence_games.remove(game_id)
     else:
@@ -1245,7 +1245,7 @@ def check_python_version() -> None:
 
 def start_program() -> None:
     """Start lichess-bot and restart when needed."""
-    multiprocessing.set_start_method('spawn')
+    multiprocessing.set_start_method("spawn")
     try:
         while should_restart():
             disable_restart()

--- a/lib/lichess_bot.py
+++ b/lib/lichess_bot.py
@@ -357,9 +357,9 @@ def lichess_bot_main(li: LICHESS_TYPE,
     startup_correspondence_games = [game["gameId"]
                                     for game in all_games
                                     if game["speed"] == "correspondence"]
-    active_games = set(game["gameId"]
-                       for game in all_games
-                       if game["gameId"] not in startup_correspondence_games)
+    active_games = {game["gameId"]
+                    for game in all_games
+                    if game["gameId"] not in startup_correspondence_games}
     low_time_games: list[GameType] = []
 
     last_check_online_time = Timer(hours(1))
@@ -775,7 +775,7 @@ def delete_takeback_record(game: model.Game) -> None:
 
 def prune_takeback_records(all_games: list[GameType]) -> None:
     """Delete takeback records from games that have ended."""
-    active_game_ids = set(game["gameId"] for game in all_games)
+    active_game_ids = {game["gameId"] for game in all_games}
     takeback_file_template = takeback_record_file_name("*")
     prefix, suffix = takeback_file_template.split("*")
     for takeback_file_name in glob.glob(takeback_file_template):

--- a/lib/lichess_bot.py
+++ b/lib/lichess_bot.py
@@ -23,6 +23,7 @@ import itertools
 import glob
 import platform
 import importlib.metadata
+import contextlib
 import test_bot.lichess
 from lib.config import load_config, Configuration, log_config
 from lib.conversation import Conversation, ChatLine
@@ -768,10 +769,8 @@ def record_takeback(game: model.Game, accepted_count: int) -> None:
 def delete_takeback_record(game: model.Game) -> None:
     """Delete the takeback record from a game if it has finished."""
     if is_game_over(game):
-        try:
+        with contextlib.suppress(Exception):
             os.remove(takeback_record_file_name(game.id))
-        except Exception:
-            pass
 
 
 def prune_takeback_records(all_games: list[GameType]) -> None:
@@ -782,10 +781,8 @@ def prune_takeback_records(all_games: list[GameType]) -> None:
     for takeback_file_name in glob.glob(takeback_file_template):
         game_id = takeback_file_name.removeprefix(prefix).removesuffix(suffix)
         if game_id not in active_game_ids:
-            try:
+            with contextlib.suppress(Exception):
                 os.remove(takeback_file_name)
-            except Exception:
-                pass
 
 
 def takeback_record_file_name(game_id: str) -> str:

--- a/lib/lichess_bot.py
+++ b/lib/lichess_bot.py
@@ -89,7 +89,7 @@ def disable_restart() -> None:
     restart = False
 
 
-def signal_handler(signal: int, frame: Optional[FrameType]) -> None:
+def signal_handler(signal: int, frame: Optional[FrameType]) -> None:  # noqa: ARG001
     """Terminate lichess-bot."""
     global terminated
     global force_quit

--- a/lib/lichess_bot.py
+++ b/lib/lichess_bot.py
@@ -230,7 +230,7 @@ def logging_listener_proc(queue: LOGGING_QUEUE_TYPE, level: int, log_filename: O
             time.sleep(0.1)
         except InterruptedError:
             pass
-        except Exception:
+        except Exception:  # noqa: S110
             pass
 
         if task is None:

--- a/lib/matchmaking.py
+++ b/lib/matchmaking.py
@@ -2,6 +2,7 @@
 import random
 import logging
 import datetime
+import contextlib
 import test_bot.lichess
 from lib import model
 from lib.timer import Timer, seconds, minutes, days, years
@@ -145,10 +146,8 @@ class Matchmaking:
         """Update our user profile data, to get our latest rating."""
         if self.last_user_profile_update_time.is_expired():
             self.last_user_profile_update_time.reset()
-            try:
+            with contextlib.suppress(Exception):
                 self.user_profile = self.li.get_profile()
-            except Exception:
-                pass
 
     def get_weights(self, online_bots: list[UserProfileType], rating_preference: str, min_rating: int, max_rating: int,
                     game_type: str) -> list[int]:

--- a/lib/timer.py
+++ b/lib/timer.py
@@ -98,6 +98,6 @@ class Timer:
         """How much time is left until it expires."""
         return max(seconds(0), self.duration - self.time_since_reset())
 
-    def starting_timestamp(self, format: str) -> str:
+    def starting_timestamp(self, timestamp_format: str) -> str:
         """When the timer started."""
-        return (datetime.datetime.now() - self.time_since_reset()).strftime(format)
+        return (datetime.datetime.now() - self.time_since_reset()).strftime(timestamp_format)

--- a/lib/types.py
+++ b/lib/types.py
@@ -1,5 +1,5 @@
 """Some type hints that can be accessed by all other python files."""
-from typing import Any, Callable, Optional, Union, TypedDict, Literal, Type
+from typing import Any, Callable, Optional, Union, TypedDict, Literal
 from chess.engine import PovWdl, PovScore, PlayResult, Limit, Opponent
 from chess import Move, Board
 from queue import Queue
@@ -455,5 +455,5 @@ class BackoffDetails(_BackoffDetails, total=False):
     value: Any  # present in the on_predicate decorator case
 
 
-ENGINE_INPUT_ARGS_TYPE = Union[None, OPTIONS_TYPE, Type[BaseException], BaseException, TracebackType, Board, Limit, str, bool]
+ENGINE_INPUT_ARGS_TYPE = Union[None, OPTIONS_TYPE, type[BaseException], BaseException, TracebackType, Board, Limit, str, bool]
 ENGINE_INPUT_KWARGS_TYPE = Union[None, int, bool, list[Move], Opponent]

--- a/test_bot/buggy_engine.py
+++ b/test_bot/buggy_engine.py
@@ -8,7 +8,7 @@ assert input() == "uci"
 
 def send_command(command: str) -> None:
     """Send UCI commands to lichess-bot without output buffering."""
-    print(command, flush=True)
+    print(command, flush=True)  # noqa: T201 (print() found)
 
 
 send_command("id name Procrastinator")

--- a/test_bot/conftest.py
+++ b/test_bot/conftest.py
@@ -5,6 +5,7 @@ from _pytest.config import ExitCode
 from _pytest.main import Session
 from typing import Union
 
+
 def pytest_sessionfinish(session: Session, exitstatus: Union[int, ExitCode]) -> None:  # noqa: ARG001
     """
     Remove files created when testing lichess-bot.

--- a/test_bot/conftest.py
+++ b/test_bot/conftest.py
@@ -5,8 +5,7 @@ from _pytest.config import ExitCode
 from _pytest.main import Session
 from typing import Union
 
-
-def pytest_sessionfinish(session: Session, exitstatus: Union[int, ExitCode]) -> None:
+def pytest_sessionfinish(session: Session, exitstatus: Union[int, ExitCode]) -> None:  # noqa: ARG001
     """
     Remove files created when testing lichess-bot.
 

--- a/test_bot/homemade.py
+++ b/test_bot/homemade.py
@@ -8,6 +8,8 @@ from lib import model
 from typing import Optional
 from lib.types import OPTIONS_GO_EGTB_TYPE, COMMANDS_TYPE, MOVE
 
+# ruff: noqa: ARG002
+
 platform = sys.platform
 file_extension = ".exe" if platform == "win32" else ""
 

--- a/test_bot/homemade.py
+++ b/test_bot/homemade.py
@@ -18,7 +18,7 @@ class Stockfish(ExampleEngine):
     """A homemade engine that uses Stockfish."""
 
     def __init__(self, commands: COMMANDS_TYPE, options: OPTIONS_GO_EGTB_TYPE, stderr: Optional[int],
-                 draw_or_resign: Configuration, game: Optional[model.Game], **popen_args: str):
+                 draw_or_resign: Configuration, game: Optional[model.Game], **popen_args: str) -> None:
         """Start Stockfish."""
         super().__init__(commands, options, stderr, draw_or_resign, game, **popen_args)
         self.engine = chess.engine.SimpleEngine.popen_uci(f"./TEMP/sf{file_extension}")

--- a/test_bot/lichess.py
+++ b/test_bot/lichess.py
@@ -115,7 +115,7 @@ class EventStream:
     def iter_lines(self) -> Generator[bytes, None, None]:
         """Send the events to lichess-bot."""
         if self.sent_game:
-            yield b''
+            yield b""
             time.sleep(1)
         else:
             yield json.dumps(

--- a/test_bot/lichess.py
+++ b/test_bot/lichess.py
@@ -12,7 +12,8 @@ from lib.timer import to_msec
 from lib.types import (UserProfileType, ChallengeType, REQUESTS_PAYLOAD_TYPE, GameType, OnlineType, PublicDataType,
                        BackoffDetails)
 
-# ruff: noqa: ARG002 Unused method argument
+# Unused method argument
+# ruff: noqa: ARG002
 
 logger = logging.getLogger(__name__)
 

--- a/test_bot/lichess.py
+++ b/test_bot/lichess.py
@@ -151,7 +151,6 @@ class Lichess:
 
     def upgrade_to_bot_account(self) -> None:
         """Isn't used in tests."""
-        pass
 
     def make_move(self, game_id: str, move: chess.engine.PlayResult) -> None:
         """Send a move to the opponent engine thread."""
@@ -159,15 +158,12 @@ class Lichess:
 
     def accept_takeback(self, game_id: str, accept: bool) -> None:
         """Isn't used in tests."""
-        pass
 
     def chat(self, game_id: str, room: str, text: str) -> None:
         """Isn't used in tests."""
-        pass
 
     def abort(self, game_id: str) -> None:
         """Isn't used in tests."""
-        pass
 
     def get_event_stream(self) -> EventStream:
         """Send the `EventStream`."""
@@ -184,11 +180,9 @@ class Lichess:
 
     def accept_challenge(self, challenge_id: str) -> None:
         """Isn't used in tests."""
-        pass
 
     def decline_challenge(self, challenge_id: str, reason: str = "generic") -> None:
         """Isn't used in tests."""
-        pass
 
     def get_profile(self) -> UserProfileType:
         """Return a simple profile for the bot that lichess-bot uses when testing."""
@@ -209,7 +203,6 @@ class Lichess:
 
     def resign(self, game_id: str) -> None:
         """Isn't used in tests."""
-        pass
 
     def get_game_pgn(self, game_id: str) -> str:
         """Return a simple PGN."""
@@ -235,7 +228,6 @@ class Lichess:
 
     def cancel(self, challenge_id: str) -> None:
         """Isn't used in tests."""
-        pass
 
     def online_book_get(self, path: str, params: Optional[dict[str, Union[str, int]]] = None,
                         stream: bool = False) -> OnlineType:

--- a/test_bot/lichess.py
+++ b/test_bot/lichess.py
@@ -12,6 +12,7 @@ from lib.timer import to_msec
 from lib.types import (UserProfileType, ChallengeType, REQUESTS_PAYLOAD_TYPE, GameType, OnlineType, PublicDataType,
                        BackoffDetails)
 
+# ruff: noqa: ARG002 Unused method argument
 
 logger = logging.getLogger(__name__)
 

--- a/test_bot/ruff.toml
+++ b/test_bot/ruff.toml
@@ -6,10 +6,47 @@ line-length = 127
 [lint]
 select = ["ALL"]
 
-# D203: Require blank line after class declaration before docstring
-# D212: Start multiline docstring on same line as triple-quote
-# D404: Docstring should not start with the word "This".
-ignore = ["D203", "D212", "D404"]
+ignore = [
+    "A004", # Import is shadowing a Python builtin
+    "ANN401", # Dynamically typed expressions (typing.Any) are disallowed
+    "B008", # Do not perform function call in argument defaults
+    "BLE001", # Do not catch blind exception: Exception
+    "COM812", # Trailing comma missing
+    "D203", # Require blank line after class declaration before docstring
+    "D212", # Start multiline docstring on same line as triple-quote
+    "D404", # Docstring should not start with the word "This"
+    "DTZ", # datetime without timezone
+    "EM101", # Exception must not use a string literal, assign to variable first
+    "EM102", # Exception must not use an f-string literal, assign to variable first
+    "ERA001", # Found commented-out code
+    "FA100", # Add from __future__ import annotations to simplify typing
+    "FBT", # Boolean argument in function definition
+    "G", # Logging
+    "I001", # Import block is un-sorted or un-formatted
+    "N803", # Argument name should be lowercase
+    "N806", # Variable in function should be lowercase
+    "N818", # Exception name should be named with an Error suffix
+    "PERF203", # try-except within a loop incurs performance overhead
+    "PLR0913", #Too many arguments in function definition
+    "PLR0915", # Too many statements
+    "PLR2004", # Magic value used in comparison, consider replacing `20` with a constant variable
+    "PLW0603", # Using the global statement to update variable is discouraged
+    "PT018", # Assertion should be broken down into multiple parts
+    "PTH", # Replace builtin functions with Path methods
+    "RET505", # Unnecessary else after return statement
+    "RET508", # Unnecessary elif after break statement
+    "RUF005", # Consider [*list1, None] instead of concatenation (list1 + [None])
+    "RUF021", # Parenthesize `a and b` expressions when chaining `and` and `or` together, to make the precedence clear
+    "S101", # Use of assert detected
+    "S113", # Probable use of `requests` call without timeout
+    "S311", # Standard pseudo-random generators are not suitable for cryptographic purposes
+    "SIM108", #Use ternary operator instead of `if`-`else`-block
+    "TC001", # Move application import into a type-checking block
+    "TC003", # Move standard library import into a type-checking block
+    "TRY", # Try-except suggestions
+    "UP035", # Import from collections.abc instead of typing
+    "UP007", # Use `X | Y` for type annotations
+]
 
 [lint.mccabe]
 max-complexity = 10

--- a/test_bot/ruff.toml
+++ b/test_bot/ruff.toml
@@ -1,0 +1,20 @@
+target-version = "py39"
+
+# The GitHub editor is 127 chars wide.
+line-length = 127
+
+[lint]
+# D: Docstrings (pydocstyle)
+# E: Code style
+# F: Pyflakes
+# W: Warnings
+# C90: Complexity
+select = ["D", "E", "F", "W", "C90"]
+
+# D203: Require blank line after class declaration before docstring
+# D212: Start multiline docstring on same line as triple-quote
+# D404: Docstring should not start with the word "This".
+ignore = ["D203", "D212", "D404"]
+
+[lint.mccabe]
+max-complexity = 10

--- a/test_bot/ruff.toml
+++ b/test_bot/ruff.toml
@@ -4,12 +4,7 @@ target-version = "py39"
 line-length = 127
 
 [lint]
-# D: Docstrings (pydocstyle)
-# E: Code style
-# F: Pyflakes
-# W: Warnings
-# C90: Complexity
-select = ["D", "E", "F", "W", "C90"]
+select = ["ALL"]
 
 # D203: Require blank line after class declaration before docstring
 # D212: Start multiline docstring on same line as triple-quote

--- a/test_bot/test-requirements.txt
+++ b/test_bot/test-requirements.txt
@@ -1,8 +1,7 @@
 pytest==8.3.4
 pytest-timeout==2.3.1
-flake8==7.1.1
 flake8-markdown==0.6.0
-flake8-docstrings==1.7.0
+ruff==0.8.4
 mypy==1.14.0
 types-requests==2.32.0.20241016
 types-PyYAML==6.0.12.20240917

--- a/test_bot/test-requirements.txt
+++ b/test_bot/test-requirements.txt
@@ -1,6 +1,5 @@
 pytest==8.3.4
 pytest-timeout==2.3.1
-flake8-markdown==0.6.0
 ruff==0.8.4
 mypy==1.14.0
 types-requests==2.32.0.20241016

--- a/test_bot/test_bot.py
+++ b/test_bot/test_bot.py
@@ -268,7 +268,7 @@ def test_lc0() -> None:
 @pytest.mark.timeout(150, method="thread")
 def test_arasan() -> None:
     """Test lichess-bot with Arasan (XBoard)."""
-    if platform != "linux" and platform != "win32":
+    if platform not in ("linux", "win32"):
         pytest.skip("Platform must be Windows or Linux.")
     with open("./config.yml.default") as file:
         CONFIG = yaml.safe_load(file)

--- a/test_bot/test_bot.py
+++ b/test_bot/test_bot.py
@@ -46,9 +46,12 @@ def download_sf() -> None:
     with open(archive_name, "wb") as file:
         file.write(response.content)
 
-    archive_open = zipfile.ZipFile if archive_ext == "zip" else tarfile.TarFile
-    with archive_open(archive_name, "r") as archive_ref:
-        archive_ref.extractall("./TEMP/")
+    if archive_ext == "zip":
+        with zipfile.ZipFile(archive_name, "r") as archive_ref:
+            archive_ref.extractall("./TEMP/")  # noqa: S202
+    else:
+        with tarfile.TarFile(archive_name, "r") as archive_ref:
+            archive_ref.extractall("./TEMP/", filter="data")
 
     exe_ext = ".exe" if platform == "win32" else ""
     shutil.copyfile(f"./TEMP/stockfish/{sf_base}{exe_ext}", stockfish_path)
@@ -69,7 +72,7 @@ def download_lc0() -> None:
     with open("./TEMP/lc0_zip.zip", "wb") as file:
         file.write(response.content)
     with zipfile.ZipFile("./TEMP/lc0_zip.zip", "r") as zip_ref:
-        zip_ref.extractall("./TEMP/")
+        zip_ref.extractall("./TEMP/")  # noqa: S202
 
 
 def download_arasan() -> None:
@@ -83,9 +86,12 @@ def download_arasan() -> None:
     response.raise_for_status()
     with open(f"./TEMP/arasan.{archive_ext}", "wb") as file:
         file.write(response.content)
-    archive_open = zipfile.ZipFile if archive_ext == "zip" else tarfile.TarFile
-    with archive_open(f"./TEMP/arasan.{archive_ext}", "r") as archive_ref:
-        archive_ref.extractall("./TEMP/")
+    if archive_ext == "zip":
+        with zipfile.ZipFile(f"./TEMP/arasan.{archive_ext}", "r") as archive_ref:
+            archive_ref.extractall("./TEMP/")  # noqa: S202
+    else:
+        with tarfile.TarFile(f"./TEMP/arasan.{archive_ext}", "r") as archive_ref:
+            archive_ref.extractall("./TEMP/", filter="data")
     shutil.copyfile(f"./TEMP/arasanx-64{file_extension}", f"./TEMP/arasan{file_extension}")
     if platform != "win32":
         st = os.stat(f"./TEMP/arasan{file_extension}")

--- a/test_bot/test_bot.py
+++ b/test_bot/test_bot.py
@@ -323,9 +323,9 @@ def test_buggy_engine() -> None:
     CONFIG["engine"]["dir"] = "test_bot"
 
     def engine_path(CONFIG: CONFIG_DICT_TYPE) -> str:
-        dir: str = CONFIG["engine"]["dir"]
+        directory: str = CONFIG["engine"]["dir"]
         name: str = CONFIG["engine"]["name"].removesuffix(".py")
-        path = os.path.join(dir, name)
+        path = os.path.join(directory, name)
         if platform == "win32":
             path += ".bat"
         else:

--- a/test_bot/test_external_moves.py
+++ b/test_bot/test_external_moves.py
@@ -96,8 +96,7 @@ def get_game() -> Game:
                                            "winc": 2000,
                                            "binc": 2000,
                                            "status": "started"}}
-    game = Game(game_event, "b", "https://lichess.org", timedelta(seconds=60))
-    return game
+    return Game(game_event, "b", "https://lichess.org", timedelta(seconds=60))
 
 
 def download_opening_book() -> None:

--- a/test_bot/test_lichess.py
+++ b/test_bot/test_lichess.py
@@ -14,32 +14,32 @@ def test_lichess() -> None:
     li = lichess.Lichess(token, "https://lichess.org/", "0.0.0", logging.DEBUG, 3)
     assert len(li.get_online_bots()) > 20
     profile = li.get_profile()
-    profile['seenAt'] = 1700000000000
-    assert profile == {'blocking': False,
-                       'count': {'ai': 3, 'all': 12, 'bookmark': 0, 'draw': 1, 'drawH': 1, 'import': 0,
-                                 'loss': 8, 'lossH': 5, 'me': 0, 'playing': 0, 'rated': 0, 'win': 3, 'winH': 3},
-                       'createdAt': 1627834995597, 'followable': True, 'following': False, 'id': 'badsunfish',
-                       'perfs': {'blitz': {'games': 0, 'prog': 0, 'prov': True, 'rating': 1500, 'rd': 500},
-                                 'bullet': {'games': 0, 'prog': 0, 'prov': True, 'rating': 1500, 'rd': 500},
-                                 'classical': {'games': 0, 'prog': 0, 'prov': True, 'rating': 1500, 'rd': 500},
-                                 'correspondence': {'games': 0, 'prog': 0, 'prov': True, 'rating': 1500, 'rd': 500},
-                                 'rapid': {'games': 0, 'prog': 0, 'prov': True, 'rating': 1500, 'rd': 500}},
-                       'playTime': {'total': 1873, 'tv': 0}, 'seenAt': 1700000000000, 'title': 'BOT',
-                       'url': 'https://lichess.org/@/BadSunfish', 'username': 'BadSunfish'}
+    profile["seenAt"] = 1700000000000
+    assert profile == {"blocking": False,
+                       "count": {"ai": 3, "all": 12, "bookmark": 0, "draw": 1, "drawH": 1, "import": 0,
+                                 "loss": 8, "lossH": 5, "me": 0, "playing": 0, "rated": 0, "win": 3, "winH": 3},
+                       "createdAt": 1627834995597, "followable": True, "following": False, "id": "badsunfish",
+                       "perfs": {"blitz": {"games": 0, "prog": 0, "prov": True, "rating": 1500, "rd": 500},
+                                 "bullet": {"games": 0, "prog": 0, "prov": True, "rating": 1500, "rd": 500},
+                                 "classical": {"games": 0, "prog": 0, "prov": True, "rating": 1500, "rd": 500},
+                                 "correspondence": {"games": 0, "prog": 0, "prov": True, "rating": 1500, "rd": 500},
+                                 "rapid": {"games": 0, "prog": 0, "prov": True, "rating": 1500, "rd": 500}},
+                       "playTime": {"total": 1873, "tv": 0}, "seenAt": 1700000000000, "title": "BOT",
+                       "url": "https://lichess.org/@/BadSunfish", "username": "BadSunfish"}
     assert li.get_ongoing_games() == []
     assert li.is_online("NNWithSF") is False
     public_data = li.get_public_data("lichapibot")
     for key in public_data["perfs"]:
         public_data["perfs"][key]["rd"] = 0
-    assert public_data == {'blocking': False, 'count': {'ai': 1, 'all': 15774, 'bookmark': 0, 'draw': 3009, 'drawH': 3009,
-                                                        'import': 0, 'loss': 6423, 'lossH': 6423,
-                                                        'me': 0, 'playing': 0, 'rated': 15121, 'win': 6342, 'winH': 6341},
-                           'createdAt': 1524037267522, 'followable': True, 'following': False, 'id': 'lichapibot',
-                           'perfs': {'blitz': {'games': 2430, 'prog': 3, 'prov': True, 'rating': 2388, 'rd': 0},
-                                     'bullet': {'games': 7293, 'prog': 9, 'prov': True, 'rating': 2298, 'rd': 0},
-                                     'classical': {'games': 0, 'prog': 0, 'prov': True, 'rating': 1500, 'rd': 0},
-                                     'correspondence': {'games': 0, 'prog': 0, 'prov': True, 'rating': 1500, 'rd': 0},
-                                     'rapid': {'games': 993, 'prog': -80, 'prov': True, 'rating': 2363, 'rd': 0}},
-                           'playTime': {'total': 4111502, 'tv': 1582068}, 'profile': {},
-                           'seenAt': 1669272254317, 'title': 'BOT', 'tosViolation': True,
-                           'url': 'https://lichess.org/@/lichapibot', 'username': 'lichapibot'}
+    assert public_data == {"blocking": False, "count": {"ai": 1, "all": 15774, "bookmark": 0, "draw": 3009, "drawH": 3009,
+                                                        "import": 0, "loss": 6423, "lossH": 6423,
+                                                        "me": 0, "playing": 0, "rated": 15121, "win": 6342, "winH": 6341},
+                           "createdAt": 1524037267522, "followable": True, "following": False, "id": "lichapibot",
+                           "perfs": {"blitz": {"games": 2430, "prog": 3, "prov": True, "rating": 2388, "rd": 0},
+                                     "bullet": {"games": 7293, "prog": 9, "prov": True, "rating": 2298, "rd": 0},
+                                     "classical": {"games": 0, "prog": 0, "prov": True, "rating": 1500, "rd": 0},
+                                     "correspondence": {"games": 0, "prog": 0, "prov": True, "rating": 1500, "rd": 0},
+                                     "rapid": {"games": 993, "prog": -80, "prov": True, "rating": 2363, "rd": 0}},
+                           "playTime": {"total": 4111502, "tv": 1582068}, "profile": {},
+                           "seenAt": 1669272254317, "title": "BOT", "tosViolation": True,
+                           "url": "https://lichess.org/@/lichapibot", "username": "lichapibot"}


### PR DESCRIPTION
## Type of pull request:
- [ ] Bug fix
- [ ] Feature
- [x] Other

## Description:

Flake8-docstrings is deprecated because pydocstyle
(https://github.com/pycqa/pydocstyle) is deprecated. The
checker/linter/formatter ruff is recommended in its place.

## Related Issues:

N/A

## Checklist:

- [x] I have read and followed the [contribution guidelines](/docs/CONTRIBUTING.md).
- [x] I have added necessary documentation (if applicable).
- [x] The changes pass all existing tests.

## Screenshots/logs (if applicable):

N/A