### PR TITLE
Use a trivial engine for tests

### DIFF
--- a/test_bot/test_bot.py
+++ b/test_bot/test_bot.py
@@ -110,7 +110,7 @@ class TrivialEngine:
 
     def play(self, board: chess.Board, limit: chess.engine.Limit, ponder: bool) -> chess.engine.PlayResult:
         """Choose the first legal move."""
-        return chess.engine.PlayResult(list(board.legal_moves)[0], None)
+        return chess.engine.PlayResult(next(iter(board.legal_moves)), None)
 
     def quit(self) -> None:
         """Do nothing."""

--- a/test_bot/test_bot.py
+++ b/test_bot/test_bot.py
@@ -108,7 +108,7 @@ logger = logging.getLogger(__name__)
 class TrivialEngine:
     """A trivial engine that should be trivial to beat."""
 
-    def play(self, board: chess.Board, limit: chess.engine.Limit, ponder: bool) -> chess.engine.PlayResult:
+    def play(self, board: chess.Board, *_: object) -> chess.engine.PlayResult:
         """Choose the first legal move."""
         return chess.engine.PlayResult(next(iter(board.legal_moves)), None)
 
@@ -142,17 +142,14 @@ def lichess_org_simulator(opponent_path: Optional[str],
     while not board.is_game_over():
         if board.turn == chess.WHITE:
             if not board.move_stack:
-                move = engine.play(board,
-                                   chess.engine.Limit(time=1),
-                                   ponder=False)
+                move = engine.play(board, chess.engine.Limit(time=1))
             else:
                 move_timer = Timer()
                 move = engine.play(board,
                                    chess.engine.Limit(white_clock=to_seconds(wtime - seconds(2.0)),
                                                       white_inc=to_seconds(increment),
                                                       black_clock=to_seconds(btime),
-                                                      black_inc=to_seconds(increment)),
-                                   ponder=False)
+                                                      black_inc=to_seconds(increment)))
                 wtime -= move_timer.time_since_reset()
                 wtime += increment
             engine_move = move.move


### PR DESCRIPTION
## Type of pull request:
- [x] Bug fix
- [ ] Feature
- [x] Other

## Description:

Instead of a hobbled stockfish engine for game tests, use a trivial engine that just picks the first legal move on a board. This should avoid the random timeouts in tests when games go on too long due to the hobbled test engine still making reasonable moves. Plus, it should cut down the amount of logging done during tests.

## Related Issues:

N/A

## Checklist:

- [x] I have read and followed the [contribution guidelines](/docs/CONTRIBUTING.md).
- [x] I have added necessary documentation (if applicable).
- [x] The changes pass all existing tests.

## Screenshots/logs (if applicable):

N/A