### PR TITLE
Fix broken docker link

### DIFF
--- a/wiki/How-to-Install.md
+++ b/wiki/How-to-Install.md
@@ -38,7 +38,7 @@ PowerShell note: If the `activate` command does not work in PowerShell, execute 
 - Copy `config.yml.default` to `config.yml`.
 
 ### Docker
-If you have a [Docker](https://www.docker.com/) host, you can use the ```lichess-bot-devs/lichess-bot``` [image in DockerHub](https://hub.docker.com/repository/docker/lichess-bot-devs/lichess-bot).  
+If you have a [Docker](https://www.docker.com/) host, you can use the ```lichess-bot-devs/lichess-bot``` [image in DockerHub](https://hub.docker.com/r/lichessbotdevs/lichess-bot).  
 It requires a folder where you have to copy `config.yml.default` to `config.yml`.
 
 See [Running with Docker](https://github.com/lichess-bot-devs/lichess-bot/wiki/How-to-use-the-Docker-image) once you've created the OAuth token and setup the engine.  


### PR DESCRIPTION
## Type of pull request:
- [x] Bug fix
- [ ] Feature
- [ ] Other

## Description:

Fixes a link that doesn't work as the name of the account is `lichessbotdevs` without dashes, as they aren't allowed in a username.

## Related Issues:

From [discord](https://discord.com/channels/280713822073913354/1326648214417309696/1326648214417309696).

## Checklist:

- [x] I have read and followed the [contribution guidelines](/docs/CONTRIBUTING.md).
- [x] I have added necessary documentation (if applicable).
- [x] The changes pass all existing tests.

## Screenshots/logs (if applicable):
