### PR TITLE
Reduce the need for dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+      versioning-strategy: increase
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-chess==1.11.1
-PyYAML==6.0.2
-requests==2.32.3
-backoff==2.2.1
-rich==13.9.4
+chess~=1.11
+PyYAML~=6.0
+requests~=2.32
+backoff~=2.2
+rich~=13.9

--- a/test_bot/test-requirements.txt
+++ b/test_bot/test-requirements.txt
@@ -1,6 +1,6 @@
-pytest==8.3.4
-pytest-timeout==2.3.1
-ruff==0.9.0
-mypy==1.14.1
-types-requests==2.32.0.20241016
-types-PyYAML==6.0.12.20241230
+pytest~=8.3
+pytest-timeout~=2.3
+ruff~=0.9
+mypy~=1.14
+types-requests~=2.32
+types-PyYAML~=6.0


### PR DESCRIPTION
## Type of pull request:
- [ ] Bug fix
- [ ] Feature
- [x] Other

## Description:

Allow for the installation of compatible upgraded dependencies without the need for a PR. The compatibility requirement (~=) allows for minor version upgrades that should be backwards compatible according to semantic versioning. Major version upgrades (for example, chess 1.11.1 to chess 2.0) still require a PR since they will more than likely need changes to lichess-bot code.

The user can upgrade to the latest compatible dependencies by running `pip install --upgrade -r requirements.txt` at any time.

## Related Issues:

## Checklist:

- [x] I have read and followed the [contribution guidelines](/docs/CONTRIBUTING.md).
- [x] I have added necessary documentation (if applicable).
- [x] The changes pass all existing tests.

## Screenshots/logs (if applicable):
