### PR TITLE
Use arasan version with no Windows virus warnings

### DIFF
--- a/test_bot/test_bot.py
+++ b/test_bot/test_bot.py
@@ -80,7 +80,7 @@ def download_arasan() -> None:
     if os.path.exists(f"./TEMP/arasan{file_extension}"):
         return
     if platform == "win32":
-        response = requests.get("https://arasanchess.org/arasan24.2.2.zip", allow_redirects=True)
+        response = requests.get("https://arasanchess.org/arasan24.1.zip", allow_redirects=True)
     else:
         response = requests.get("https://arasanchess.org/arasan-linux-binaries-24.2.2.tar.gz", allow_redirects=True)
     response.raise_for_status()


### PR DESCRIPTION
## Type of pull request:
- [ ] Bug fix
- [ ] Feature
- [x] Other

## Description:

Windows has started flagging versions of the Arasan chess engine binary (versions 24.2 and later) with virus warnings. Whether these are false positives remain to be seen. In any event, this PR switches the version used for testing the lichess-bot XBoard interface.

## Related Issues:


## Checklist:

- [x] I have read and followed the [contribution guidelines](/docs/CONTRIBUTING.md).
- [x] I have added necessary documentation (if applicable).
- [x] The changes pass all existing tests.

## Screenshots/logs (if applicable):
