### PR TITLE
Store chat messages

### DIFF
--- a/lib/conversation.py
+++ b/lib/conversation.py
@@ -46,6 +46,7 @@ class Conversation:
         self.li = li
         self.version = version
         self.challengers = challenge_queue
+        self.messages: list[ChatLine] = []
 
     command_prefix = "!"
 
@@ -55,6 +56,7 @@ class Conversation:
 
         :param line: Information about the message.
         """
+        self.messages.append(line)
         logger.info(f"*** {self.game.url()} [{line.room}] {line.username}: {line.text}")
         if line.text[0] == self.command_prefix:
             self.command(line, line.text[1:].lower())


### PR DESCRIPTION
## Type of pull request:
- [ ] Bug fix
- [x] Feature
- [ ] Other

## Description:

Stores chat messages for the duration of the game to allow users to build more complicated chat mechanisms (e.g. letting people vote the result of the game, and after the end saying something depending on the votes).

## Related Issues:

None

## Checklist:

- [x] I have read and followed the [contribution guidelines](/docs/CONTRIBUTING.md).
- [x] I have added necessary documentation (if applicable).
- [x] The changes pass all existing tests.

## Screenshots/logs (if applicable):
