### PR TITLE
Reorder setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ Can run on:
 ## Steps
 1. [Install lichess-bot](https://github.com/lichess-bot-devs/lichess-bot/wiki/How-to-Install)
 2. [Create a lichess OAuth token](https://github.com/lichess-bot-devs/lichess-bot/wiki/How-to-create-a-Lichess-OAuth-token)
-3. [Upgrade to a BOT account](https://github.com/lichess-bot-devs/lichess-bot/wiki/Upgrade-to-a-BOT-account)
-4. [Setup the engine](https://github.com/lichess-bot-devs/lichess-bot/wiki/Setup-the-engine)
-5. [Configure lichess-bot](https://github.com/lichess-bot-devs/lichess-bot/wiki/Configure-lichess-bot)
+3. [Setup the engine](https://github.com/lichess-bot-devs/lichess-bot/wiki/Setup-the-engine)
+4. [Configure lichess-bot](https://github.com/lichess-bot-devs/lichess-bot/wiki/Configure-lichess-bot)
+5. [Upgrade to a BOT account](https://github.com/lichess-bot-devs/lichess-bot/wiki/Upgrade-to-a-BOT-account)
 6. [Run lichess-bot](https://github.com/lichess-bot-devs/lichess-bot/wiki/How-to-Run-lichess%E2%80%90bot)
 
 ## Advanced options

--- a/wiki/Configure-lichess-bot.md
+++ b/wiki/Configure-lichess-bot.md
@@ -304,6 +304,6 @@ matchmaking:
       challenge_mode: casual
 ```
 
-**Next step**: [Run lichess-bot](https://github.com/lichess-bot-devs/lichess-bot/wiki/How-to-Run-lichess%E2%80%90bot)
+**Next step**: [Upgrade to a BOT account](https://github.com/lichess-bot-devs/lichess-bot/wiki/Upgrade-to-a-BOT-account)
 
 **Previous step**: [Setup the engine](https://github.com/lichess-bot-devs/lichess-bot/wiki/Setup-the-engine)

--- a/wiki/How-to-Run-lichess‐bot.md
+++ b/wiki/How-to-Run-lichess‐bot.md
@@ -50,4 +50,4 @@ WantedBy=multi-user.target
 - If `quit_after_all_games_finish` is set to `true` in your config file, lichess-bot will wait for all games to exit. Otherwise, all games will exit immediately.
 - It may take several seconds for lichess-bot to quit once all games have exited.
 
-**Previous step**: [Configure lichess-bot](https://github.com/lichess-bot-devs/lichess-bot/wiki/Configure-lichess-bot)
+**Previous step**: [Upgrade to a BOT account](https://github.com/lichess-bot-devs/lichess-bot/wiki/Upgrade-to-a-BOT-account)

--- a/wiki/How-to-create-a-Lichess-OAuth-token.md
+++ b/wiki/How-to-create-a-Lichess-OAuth-token.md
@@ -5,6 +5,6 @@
 - A `token` (e.g. `xxxxxxxxxxxxxxxx`) will be displayed. Store this in the `config.yml` file as the `token` field. You can also set the token in the environment variable `$LICHESS_BOT_TOKEN`.
 - **NOTE: You won't see this token again on Lichess, so do save it.**
 
-**Next step**: [Upgrade to a BOT account](https://github.com/lichess-bot-devs/lichess-bot/wiki/Upgrade-to-a-BOT-account)
+**Next step**: [Setup the engine](https://github.com/lichess-bot-devs/lichess-bot/wiki/Setup-the-engine)
 
 **Previous step**: [Install lichess-bot](https://github.com/lichess-bot-devs/lichess-bot/wiki/How-to-Install)

--- a/wiki/Setup-the-engine.md
+++ b/wiki/Setup-the-engine.md
@@ -29,4 +29,4 @@ As an optional convenience, there is a folder named `engines` within the lichess
 
 **Next step**: [Configure lichess-bot](https://github.com/lichess-bot-devs/lichess-bot/wiki/Configure-lichess-bot)
 
-**Previous step**: [Upgrade to a BOT accout](https://github.com/lichess-bot-devs/lichess-bot/wiki/Upgrade-to-a-BOT-account)
+**Previous step**: [Create a lichess OAuth token](https://github.com/lichess-bot-devs/lichess-bot/wiki/How-to-create-a-Lichess-OAuth-token)

--- a/wiki/Upgrade-to-a-BOT-account.md
+++ b/wiki/Upgrade-to-a-BOT-account.md
@@ -2,6 +2,8 @@
 **WARNING: This is irreversible. [Read more about upgrading to bot account](https://lichess.org/api#operation/botAccountUpgrade).**
 - run `python3 lichess-bot.py -u`.
 
-**Next step**: [Setup the engine](https://github.com/lichess-bot-devs/lichess-bot/wiki/Setup-the-engine)
+If successful, this step will start a lichess session and the bot will start playing games. In the future, only the commands in the next step will hvae to be run.
 
-**Previous step**: [Create a Lichess OAuth token](https://github.com/lichess-bot-devs/lichess-bot/wiki/How-to-create-a-Lichess-OAuth-token)
+**Next step**: [Run lichess-bot](https://github.com/lichess-bot-devs/lichess-bot/wiki/How-to-Run-lichess%E2%80%90bot)
+
+**Previous step**: [Configure lichess-bot](https://github.com/lichess-bot-devs/lichess-bot/wiki/Configure-lichess-bot)


### PR DESCRIPTION
## Type of pull request:
- [x] Bug fix
- [ ] Feature
- [ ] Other

## Description:

If user's follow instructions exactly, they will get an error when trying to upgrade their lichess account to a bot account. This is because the user's chess bot is checked for validity when the configuration file is read to get the lichess token. The setup steps are reordered so that upgrading is done after the user fully configures lichess-bot and sets up their engine.

## Related Issues:

Closes #1085

## Checklist:

- [x] I have read and followed the [contribution guidelines](/docs/CONTRIBUTING.md).
- [x] I have added necessary documentation (if applicable).
- [x] The changes pass all existing tests.

## Screenshots/logs (if applicable):

