### PR TITLE
Restart if there is a network exception

### DIFF
--- a/lib/lichess_bot.py
+++ b/lib/lichess_bot.py
@@ -1256,6 +1256,9 @@ def start_program() -> None:
             except RequestException:
                 restart = True
                 logger.exception("Restarting lichess-bot due to a network error:")
+            if terminated or force_quit:
+                logger.info("Termination requested - stopping restart cycle")
+                break
             time.sleep(10 if should_restart() else 0)
     except Exception:
         logger.exception("Quitting lichess-bot due to an error:")


### PR DESCRIPTION
## Type of pull request:
- [ ] Bug fix
- [x] Feature
- [ ] Other

## Description:

Restart lichess-bot if an exception is raised due to network errors. This also makes the bot continue ruuning is the WiFi stops working for some time.

## Related Issues:

closes #1088 

## Checklist:

- [x] I have read and followed the [contribution guidelines](/docs/CONTRIBUTING.md).
- [x] I have added necessary documentation (if applicable).
- [x] The changes pass all existing tests.

## Screenshots/logs (if applicable):
