### PR TITLE
Handle None values in pgn_queue

### DIFF
--- a/lib/lichess_bot.py
+++ b/lib/lichess_bot.py
@@ -152,7 +152,8 @@ def write_pgn_records(pgn_queue: PGN_QUEUE_TYPE, config: Configuration, username
         try:
             event = pgn_queue.get()
             mark_task_done = True
-            save_pgn_record(event, config, username)
+            if event:
+                save_pgn_record(event, config, username)
         except InterruptedError:
             pass
         except Exception:

--- a/lib/lichess_types.py
+++ b/lib/lichess_types.py
@@ -251,7 +251,7 @@ class GameEventType(TypedDict, total=False):
 
 
 CONTROL_QUEUE_TYPE = Queue[EventType]
-PGN_QUEUE_TYPE = Queue[EventType]
+PGN_QUEUE_TYPE = Queue[EventType | None]
 
 
 class PublicDataType(TypedDict, total=False):

--- a/lib/lichess_types.py
+++ b/lib/lichess_types.py
@@ -251,7 +251,7 @@ class GameEventType(TypedDict, total=False):
 
 
 CONTROL_QUEUE_TYPE = Queue[EventType]
-PGN_QUEUE_TYPE = Queue[EventType | None]
+PGN_QUEUE_TYPE = Queue[Optional[EventType]]
 
 
 class PublicDataType(TypedDict, total=False):


### PR DESCRIPTION
## Type of pull request:
- [x] Bug fix
- [ ] Feature
- [ ] Other

## Description:

Sometimes, probably when a lichess-bot session is ended with Ctrl-C, the function that handles the pgn_queue will receive a None value. This causes an error and prevents PGN files from being written.

This change ignores None values when they arrive from the queue.

## Related Issues:

## Checklist:

- [x] I have read and followed the [contribution guidelines](/docs/CONTRIBUTING.md).
- [x] I have added necessary documentation (if applicable).
- [x] The changes pass all existing tests.

## Screenshots/logs (if applicable):
