### PR TITLE
Limit simultaneous challenges from one user

### DIFF
--- a/lib/lichess_bot.py
+++ b/lib/lichess_bot.py
@@ -607,9 +607,10 @@ def handle_challenge(event: EventType, li: lichess.Lichess, challenge_queue: MUL
     if chlng.from_self:
         return
 
-    players_with_active_games = Counter(game["opponent"]["username"] for game in li.get_ongoing_games())
+    opponent_engagements = Counter(game["opponent"]["username"] for game in li.get_ongoing_games())
+    opponent_engagements.update(challenge.challenger.name for challenge in challenge_queue)
 
-    is_supported, decline_reason = chlng.is_supported(challenge_config, recent_bot_challenges, players_with_active_games)
+    is_supported, decline_reason = chlng.is_supported(challenge_config, recent_bot_challenges, opponent_engagements)
     if is_supported:
         challenge_queue.append(chlng)
         sort_challenges(challenge_queue, challenge_config)

--- a/lib/model.py
+++ b/lib/model.py
@@ -92,7 +92,7 @@ class Challenge:
         return "" if requirement_met else decline_reason
 
     def is_supported(self, config: Configuration, recent_bot_challenges: defaultdict[str, list[Timer]],
-                     players_with_active_games: Counter[str]) -> tuple[bool, str]:
+                     opponent_engagements: Counter[str]) -> tuple[bool, str]:
         """Whether the challenge is supported."""
         try:
             if self.from_self:
@@ -109,7 +109,7 @@ class Challenge:
                               or self.decline_due_to(self.challenger.name not in config.block_list, "generic")
                               or self.decline_due_to(self.challenger.name in allowed_opponents, "generic")
                               or self.decline_due_to(self.is_supported_recent(config, recent_bot_challenges), "later")
-                              or self.decline_due_to(players_with_active_games[self.challenger.name]
+                              or self.decline_due_to(opponent_engagements[self.challenger.name]
                                                      < config.max_simultaneous_games_per_user, "later")
                               or self.decline_due_to(is_supported_extra(self), "generic"))
 


### PR DESCRIPTION
## Type of pull request:
- [x] Bug fix
- [ ] Feature
- [ ] Other

## Description:

If an opponent sends multiple challenges is rapid succession to a bot, the challenges will be queued up for acceptance since there will be a delay before any are turned into an active game. This allows a single opponent to take up all of a bot's games.

This change adds the number of active challenges to the number of active games to limit the number of games from a single opponent.

## Related Issues:

Closes #1097 

## Checklist:

- [x] I have read and followed the [contribution guidelines](/docs/CONTRIBUTING.md).
- [x] I have added necessary documentation (if applicable).
- [x] The changes pass all existing tests.

## Screenshots/logs (if applicable):
