### PR TITLE
Bots that are disabled or have tos violation aren't shown anymore

### DIFF
--- a/config.yml.default
+++ b/config.yml.default
@@ -205,7 +205,6 @@ matchmaking:
 # opponent_max_rating: 4000        # Opponents rating should be below this value (4000 is the maximum rating in lichess).
   opponent_rating_difference: 300  # The maximum difference in rating between the bot's rating and opponent's rating.
   rating_preference: "none"        # One of "none", "high", "low".
-  opponent_allow_tos_violation: false # Set to 'true' to allow challenging bots that violated the Lichess Terms of Service.
   challenge_mode: "random"         # Set it to the mode in which challenges are sent. Possible options are 'casual', 'rated' and 'random'.
   challenge_filter: none           # If a bot declines a challenge, do not issue a similar challenge to that bot. Possible options are 'none', 'coarse', and 'fine'.
 # block_list:                      # The list of bots that will not be challenged

--- a/lib/config.py
+++ b/lib/config.py
@@ -230,7 +230,6 @@ def insert_default_values(CONFIG: CONFIG_DICT_TYPE) -> None:
     set_config_default(CONFIG, "matchmaking", key="opponent_min_rating", default=600, force_empty_values=True)
     set_config_default(CONFIG, "matchmaking", key="opponent_max_rating", default=4000, force_empty_values=True)
     set_config_default(CONFIG, "matchmaking", key="rating_preference", default="none")
-    set_config_default(CONFIG, "matchmaking", key="opponent_allow_tos_violation", default=True)
     set_config_default(CONFIG, "matchmaking", key="challenge_variant", default="random")
     set_config_default(CONFIG, "matchmaking", key="challenge_mode", default="random")
     set_config_default(CONFIG, "matchmaking", key="overrides", default={}, force_empty_values=True)

--- a/lib/lichess_types.py
+++ b/lib/lichess_types.py
@@ -56,8 +56,6 @@ class UserProfileType(TypedDict, total=False):
     username: str
     perfs: dict[str, PerfType]
     createdAt: int
-    disabled: bool
-    tosViolation: bool
     profile: ProfileType
     seenAt: int
     patron: int

--- a/lib/matchmaking.py
+++ b/lib/matchmaking.py
@@ -199,14 +199,11 @@ class Matchmaking:
             min_rating = bot_rating - rating_diff
             max_rating = bot_rating + rating_diff
         logger.info(f"Seeking {game_type} game with opponent rating in [{min_rating}, {max_rating}] ...")
-        allow_tos_violation = match_config.opponent_allow_tos_violation
 
         def is_suitable_opponent(bot: UserProfileType) -> bool:
             perf = bot.get("perfs", {}).get(game_type, {})
             return (bot["username"] != self.username()
                     and not self.in_block_list(bot["username"])
-                    and not bot.get("disabled")
-                    and (allow_tos_violation or not bot.get("tosViolation"))  # Terms of Service violation.
                     and perf.get("games", 0) > 0
                     and min_rating <= perf.get("rating", 0) <= max_rating)
 

--- a/wiki/Configure-lichess-bot.md
+++ b/wiki/Configure-lichess-bot.md
@@ -246,7 +246,6 @@ will precede the `go` command to start thinking with `sd 5`. The other `go_comma
   - `opponent_max_rating`: The maximum rating of the opponent bot. The maximum rating in lichess is 4000.
   - `opponent_rating_difference`: The maximum difference between the bot's rating and the opponent bot's rating.
   - `rating_preference`: Whether the bot should prefer challenging high or low rated players, or have no preference.
-  - `opponent_allow_tos_violation`: Whether to challenge bots that violated Lichess Terms of Service. Note that even rated games against them will not affect ratings.
   - `challenge_mode`: Possible options are `casual`, `rated` and `random`.
   - `challenge_filter`: Whether and how to prevent challenging a bot after that bot declines a challenge. Options are `none`, `coarse`, and `fine`.
     - `none` does not prevent challenging a bot that declined a challenge.
@@ -285,7 +284,6 @@ matchmaking:
 # opponent_min_rating: 600
 # opponent_max_rating: 4000
   opponent_rating_difference: 100
-  opponent_allow_tos_violation: true
   challenge_mode: "random"
   challenge_filter: none
   overrides:


### PR DESCRIPTION
## Type of pull request:
- [ ] Bug fix
- [ ] Feature
- [x] Other

## Description:

Disabled bots (i.e. account closed) and bots with tos violation aren't shown in the bot list anymore. The change was done [here](https://github.com/lichess-org/lila/pull/16369).

## Related Issues:

None

## Checklist:

- [x] I have read and followed the [contribution guidelines](/docs/CONTRIBUTING.md).
- [x] I have added necessary documentation (if applicable).
- [x] The changes pass all existing tests.

## Screenshots/logs (if applicable):
