### PR TITLE
Deprecate Python 3.9

### DIFF
--- a/lib/versioning.yml
+++ b/lib/versioning.yml
@@ -1,4 +1,4 @@
 lichess_bot_version: 2025.5.5.2
-minimum_python_version: '3.9'
-deprecated_python_version: '3.8'
-deprecation_date: 2023-05-01
+minimum_python_version: '3.10'
+deprecated_python_version: '3.9'
+deprecation_date: 2025-10-05


### PR DESCRIPTION
## Type of pull request:
- [ ] Bug fix
- [ ] Feature
- [X] Other

## Description:

Begin warning users that Python 3.9 will not be supported after it reaches end-of-life in October 2025.

## Related Issues:

This will allow work on the next section of #677.

## Checklist:

- [x] I have read and followed the [contribution guidelines](/docs/CONTRIBUTING.md).
- [x] I have added necessary documentation (if applicable).
- [x] The changes pass all existing tests.

## Screenshots/logs (if applicable):
