### PR TITLE
Remove token from log message on token_test error

### DIFF
--- a/lib/lichess.py
+++ b/lib/lichess.py
@@ -75,6 +75,10 @@ def is_final(exception: Exception) -> bool:
 
 def backoff_handler(details: BackoffDetails) -> None:
     """Log exceptions inside functions with the backoff decorator."""
+    args = details["args"]
+    kwargs = details["kwargs"]
+    if "token_test" in args:
+        kwargs["data"] = "<token redacted>"
     logger.debug("Backing off {wait:0.1f} seconds after {tries} tries "
                  "calling function {target} with args {args} and kwargs {kwargs}".format(**details))
     logger.debug(f"Exception: {traceback.format_exc()}")


### PR DESCRIPTION
## Type of pull request:
- [x] Bug fix
- [ ] Feature
- [ ] Other

## Description:

Removes the user's bot token from the error message before logging. This will prevent the leaking of lichess tokens when posting logs for troubleshooting.

## Related Issues:

Closes #1133

## Checklist:

- [x] I have read and followed the [contribution guidelines](/docs/CONTRIBUTING.md).
- [x] I have added necessary documentation (if applicable).
- [x] The changes pass all existing tests.

## Screenshots/logs (if applicable):
