### PR TITLE
Handle new error message when challenging bots

### DIFF
--- a/lib/lichess.py
+++ b/lib/lichess.py
@@ -61,6 +61,11 @@ stop = Stop()
 class RateLimitedError(RuntimeError):
     """Exception raised when we are rate limited (status code 429)."""
 
+    def __init__(self, message: str, timeout: datetime.timedelta) -> None:
+        """Create a rate-limited error with the time left until the rate limit expires."""
+        super().__init__(message)
+        self.timeout = timeout
+
 
 def is_new_rate_limit(response: requests.models.Response) -> bool:
     """Check if the status code is 429, which means that we are rate limited."""
@@ -263,7 +268,8 @@ class Lichess:
         path_template = ENDPOINTS[endpoint_name]
         if self.is_rate_limited(path_template):
             raise RateLimitedError(f"{path_template} is rate-limited. "
-                                   f"Will retry in {sec_str(self.rate_limit_time_left(path_template))} seconds.")
+                                   f"Will retry in {sec_str(self.rate_limit_time_left(path_template))} seconds.",
+                                   self.rate_limit_time_left(path_template))
         return path_template
 
     def set_rate_limit_delay(self, path_template: str, delay_time: datetime.timedelta) -> None:

--- a/lib/lichess_types.py
+++ b/lib/lichess_types.py
@@ -188,6 +188,7 @@ class ChallengeType(TypedDict, total=False):
     declineReason: str
     declineReasonKey: str
     initialFen: str
+    error: dict[str, Union[str, dict[str, str]]]
 
 
 class EventType(TypedDict, total=False):

--- a/lib/matchmaking.py
+++ b/lib/matchmaking.py
@@ -105,7 +105,8 @@ class Matchmaking:
             challenge_id = response.get("id", "")
             if not challenge_id:
                 logger.error(response)
-                self.add_to_block_list(username)
+                if "error" not in response:
+                    self.add_to_block_list(username)
                 self.show_earliest_challenge_time()
             return challenge_id
         except Exception as e:

--- a/lib/matchmaking.py
+++ b/lib/matchmaking.py
@@ -58,7 +58,7 @@ class Matchmaking:
             logger.info(f"Challenge id {self.challenge_id} cancelled.")
             self.discard_challenge(self.challenge_id)
             self.show_earliest_challenge_time()
-        return bool(matchmaking_enabled and (time_has_passed or challenge_expired)) and min_wait_time_passed
+        return bool(matchmaking_enabled and (time_has_passed or challenge_expired) and min_wait_time_passed)
 
     def create_challenge(self, username: str, base_time: int, increment: int, days: int, variant: str,
                          mode: str) -> str:

--- a/lib/matchmaking.py
+++ b/lib/matchmaking.py
@@ -12,7 +12,6 @@ from lib.config import Configuration
 from typing import Optional, Union
 from lib.lichess_types import UserProfileType, PerfType, EventType, FilterType
 MULTIPROCESSING_LIST_TYPE = Sequence[model.Challenge]
-DAILY_TIMERS_TYPE = list[Timer]
 
 logger = logging.getLogger(__name__)
 

--- a/lib/timer.py
+++ b/lib/timer.py
@@ -1,8 +1,7 @@
 """A timer for use in lichess-bot."""
 
-from datetime import datetime, timedelta
+from datetime import timedelta
 from time import perf_counter
-from typing import Optional
 
 
 def msec(time_in_msec: float) -> timedelta:
@@ -72,8 +71,7 @@ class Timer:
     the timer was created or since it was last reset.
     """
 
-    def __init__(self, duration: timedelta = zero_seconds,
-                 backdated_timestamp: Optional[datetime] = None) -> None:
+    def __init__(self, duration: timedelta = zero_seconds) -> None:
         """
         Start the timer.
 
@@ -82,9 +80,6 @@ class Timer:
         """
         self.duration = duration
         self.starting_time = perf_counter()
-
-        if backdated_timestamp:
-            self.starting_time -= to_seconds(datetime.now() - backdated_timestamp)
 
     def is_expired(self) -> bool:
         """Check if a timer is expired."""
@@ -101,7 +96,3 @@ class Timer:
     def time_until_expiration(self) -> timedelta:
         """How much time is left until it expires."""
         return max(seconds(0), self.duration - self.time_since_reset())
-
-    def starting_timestamp(self, timestamp_format: str) -> str:
-        """When the timer started."""
-        return (datetime.now() - self.time_since_reset()).strftime(timestamp_format)

--- a/test_bot/test_timer.py
+++ b/test_bot/test_timer.py
@@ -1,6 +1,6 @@
 """Test functions dedicated to time measurement and conversion."""
 
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from lib import timer
 
@@ -40,10 +40,6 @@ def test_init() -> None:
     assert t.duration == duration
     assert t.starting_time is not None
 
-    backdated_timestamp = datetime.now() - timedelta(seconds=10)
-    t = timer.Timer(backdated_timestamp=backdated_timestamp)
-    assert t.starting_time is not None
-    assert t.time_since_reset() >= timedelta(seconds=10)
 
 def test_is_expired() -> None:
     """Test timer expiration."""
@@ -86,10 +82,3 @@ def test_time() -> None:
     t = timer.Timer(timedelta(seconds=10))
     t.starting_time -= 5
     assert timer.sec_str(t.time_until_expiration()) == timer.sec_str(timedelta(seconds=5))
-
-def test_starting_timestamp() -> None:
-    """Test timestamp conversion and integration."""
-    t = timer.Timer(timedelta(seconds=10))
-    timestamp_format = "%Y-%m-%d %H:%M:%S"
-    expected_timestamp = (datetime.now() - t.time_since_reset()).strftime(timestamp_format)
-    assert t.starting_timestamp(timestamp_format) == expected_timestamp

--- a/wiki/Configure-lichess-bot.md
+++ b/wiki/Configure-lichess-bot.md
@@ -242,6 +242,9 @@ will precede the `go` command to start thinking with `sd 5`. The other `go_comma
   - `allow_during_games`: Whether to issue new challenges while the bot is already playing games. If true, no more than 10 minutes will pass between matchmaking challenges.
   - `challenge_variant`: The variant for the challenges. If set to `random` a variant from the ones enabled in `challenge.variants` will be chosen at random.
   - `challenge_timeout`: The time (in minutes) the bot has to be idle before it creates a challenge.
+
+  Bots are limited to playing 100 games against other bots per day, so setting `challenge_timeout` to a small value will result in this limit being reached quickly. There is no limit to the number of games a bot can play against humans.
+
   - `challenge_initial_time`: A list of initial times (in seconds and to be chosen at random) for the challenges.
   - `challenge_increment`: A list of increments (in seconds and to be chosen at random) for the challenges.
   - `challenge_days`: A list of number of days for a correspondence challenge (to be chosen at random).


### PR DESCRIPTION
Detect when the rate limiting status code (429) is due to issuing a challenge after playing more than 100 games in a day. Use the message in the response to delay issuing another challenge.

## Type of pull request:
- [ ] Bug fix
- [ ] Feature
- [x] Other

## Description:

The biggest change is setting the time delay according to the `["ratelimit"]["seconds"]` field in the response.

## Related Issues:

Closes #1135

## Checklist:

- [x] I have read and followed the [contribution guidelines](/docs/CONTRIBUTING.md).
- [x] I have added necessary documentation (if applicable).
- [x] The changes pass all existing tests.

## Screenshots/logs (if applicable):
