### PR TITLE
Handle failed token test without leaking token

### DIFF
--- a/lib/lichess.py
+++ b/lib/lichess.py
@@ -113,13 +113,14 @@ class Lichess:
 
         # Confirm that the OAuth token has the proper permission to play on lichess
         token_response = cast(TOKEN_TESTS_TYPE, self.api_post("token_test", data=token))
-        token_info = token_response[token]
+        token_info = token_response.get(token)
 
         if not token_info:
-            raise RuntimeError("Token in config file is not recognized by lichess. "
-                               "Please check that it was copied correctly into your configuration file.")
+            raise RuntimeError("There was an error in retrieving information about the bot's token. "
+                               "Please check that it was copied correctly into your configuration file "
+                               "and try again.")
 
-        scopes = token_info["scopes"]
+        scopes = token_info.get("scopes", "")
         if "bot:play" not in scopes.split(","):
             raise RuntimeError("Please use an API access token for your bot that "
                                'has the scope "Play games with the bot API (bot:play)". '


### PR DESCRIPTION
## Type of pull request:
- [x] Bug fix
- [ ] Feature
- [ ] Other

## Description:

If the line `token_info = token_response[token]` fails with a `KeyError` (due to an error response from lichess), the user's token will be printed in the error message. Use `token_response.get()` to prevent this.

## Related Issues:

## Checklist:

- [x] I have read and followed the [contribution guidelines](/docs/CONTRIBUTING.md).
- [x] I have added necessary documentation (if applicable).
- [x] The changes pass all existing tests.

## Screenshots/logs (if applicable):
