### PR TITLE
Document settings affecting daily game limit usage

### DIFF
--- a/lib/config.py
+++ b/lib/config.py
@@ -8,6 +8,7 @@ import requests
 from abc import ABCMeta
 from typing import Any, Union, ItemsView, Callable
 from lib.lichess_types import CONFIG_DICT_TYPE, FilterType
+from lib.timer import minutes, days
 
 logger = logging.getLogger(__name__)
 
@@ -342,6 +343,11 @@ def validate_config(CONFIG: CONFIG_DICT_TYPE) -> None:
                     "no challenges being created.")
         config_warn(matchmaking.get("opponent_rating_difference", 0) >= 0,
                     "matchmaking.opponent_rating_difference < 0 will result in no challenges being created.")
+        max_games_per_day = 100
+        game_timeout = minutes(matchmaking["challenge_timeout"])
+        config_warn(game_timeout*max_games_per_day >= days(1),
+                    f"A bot is only allowed to play {max_games_per_day} games per day against other bots. Please check your "
+                    "config file to make sure your bot won't use up all its allotted games quickly.")
 
     pgn_directory = CONFIG["pgn_directory"]
     in_docker = os.environ.get("LICHESS_BOT_DOCKER")

--- a/wiki/Configure-lichess-bot.md
+++ b/wiki/Configure-lichess-bot.md
@@ -1,6 +1,19 @@
 # Configuring lichess-bot
 There are many possible options within `config.yml` for configuring lichess-bot.
 
+## Note on daily game limits
+
+Lichess allows a bot to play 100 games against other bots in a single day (games against humans are unlimited). Several settings below can influence how quickly this game allowance is used up. These include the following:
+- `challenge:`
+  - `concurrency`: Playing multiple simultaneous games will use up games faster.
+  - `accept bot` and `only_bot`: Only bot games use up the allotted games.
+  - `min_increment`, `min_base`, and `time_controls`: Shorter games use up the allotted games faster.
+  - `recent_bot_challenge_age`, `max_recent_bot_challenges`, `max_simultaneous_games_per_user`: To prevent a single bot from using up all your bot's games.
+- `matchmaking:`
+  - `allow_during_games`: Starting simultaneous games uses up games faster.
+  - `challenge_timeout`: Longer timeouts between games will spread out games over a day.
+  - `challenge_initial_time` and `challenge_increment`: Shorter games use up the allotted games faster.
+
 ## Engine options
 - `interpreter`: Specify whether your engine requires an interpreter to run (e.g. `java`, `python`).
 - `interpreter_options`: A list of options passed to the interpreter (e.g. `-jar` for `java`).

--- a/wiki/Configure-lichess-bot.md
+++ b/wiki/Configure-lichess-bot.md
@@ -6,7 +6,7 @@ There are many possible options within `config.yml` for configuring lichess-bot.
 Lichess allows a bot to play 100 games against other bots in a single day (games against humans are unlimited). Several settings below can influence how quickly this game allowance is used up. These include the following:
 - `challenge:`
   - `concurrency`: Playing multiple simultaneous games will use up games faster.
-  - `accept bot` and `only_bot`: Only bot games use up the allotted games.
+  - `accept_bot` and `only_bot`: Games against other bots use up the allotted games.
   - `min_increment`, `min_base`, and `time_controls`: Shorter games use up the allotted games faster.
   - `recent_bot_challenge_age`, `max_recent_bot_challenges`, `max_simultaneous_games_per_user`: To prevent a single bot from using up all your bot's games.
 - `matchmaking:`


### PR DESCRIPTION
## Type of pull request:
- [ ] Bug fix
- [ ] Feature
- [x] Other

## Description:

Provide a warning to users if matchmaking: challenge_timeout is short enough for a bot to run out of daily games in less than 24 hours.

Document other settings that may affect how quickly a bot's daily game quote is used up.

## Related Issues:

The PR is in reponse to [this comment](https://github.com/lichess-bot-devs/lichess-bot/pull/1137#issuecomment-3360505628) from Thibault.

## Checklist:

- [x] I have read and followed the [contribution guidelines](/docs/CONTRIBUTING.md).
- [x] I have added necessary documentation (if applicable).
- [x] The changes pass all existing tests.

## Screenshots/logs (if applicable):
