### PR TITLE
Use Timers instead of bools to filter opponents to allow temporary stops to challenges

### DIFF
--- a/lib/lichess.py
+++ b/lib/lichess.py
@@ -268,9 +268,9 @@ class Lichess:
         """
         path_template = ENDPOINTS[endpoint_name]
         if self.is_rate_limited(path_template):
-            raise RateLimitedError(f"{path_template} is rate-limited. "
-                                   f"Will retry in {sec_str(self.rate_limit_time_left(path_template))} seconds.",
-                                   self.rate_limit_time_left(path_template))
+            time_left = self.rate_limit_time_left(path_template)
+            raise RateLimitedError(
+                f"{path_template} is rate-limited. Will retry in {sec_str(time_left)} seconds.", time_left)
         return path_template
 
     def set_rate_limit_delay(self, path_template: str, delay_time: datetime.timedelta) -> None:

--- a/lib/lichess_types.py
+++ b/lib/lichess_types.py
@@ -188,7 +188,8 @@ class ChallengeType(TypedDict, total=False):
     declineReason: str
     declineReasonKey: str
     initialFen: str
-    error: dict[str, Union[str, dict[str, str]]]
+    error: str
+    ratelimit: dict[str, Union[str, int]]
 
 
 class EventType(TypedDict, total=False):


### PR DESCRIPTION
## Type of pull request:
- [ ] Bug fix
- [x] Feature
- [ ] Other

## Description:

Instead of preventing the challenging of another bot that declines a challenge for the rest of the lichess-bot run, default to a one-day timeout. Block lists still work, but are implemented as a 10-year timeout.

The primary reason for this PR is an upcoming change in lichess. Challenging another bot that has already played 100 games today will result in a 400 status code and an error message with information about when the bot's timeout will expire.

## Related Issues:

This commit to lila tells bots how long to wait before challenging another bot that has reached the 100-bot-game per day limit: https://github.com/lichess-org/lila/commit/53f2c4d2f321da1d4cd05b7c30d417dd1e902a49

## Checklist:

- [x] I have read and followed the [contribution guidelines](/docs/CONTRIBUTING.md).
- [x] I have added necessary documentation (if applicable).
- [x] The changes pass all existing tests.

## Screenshots/logs (if applicable):
