### PR TITLE
Distinguish between standard and chess960 From Position games

### DIFF
--- a/lib/lichess_bot.py
+++ b/lib/lichess_bot.py
@@ -832,9 +832,8 @@ def setup_board(game: model.Game) -> chess.Board:
     if game.variant_name.lower() == "chess960":
         board = chess.Board(game.initial_fen, chess960=True)
     elif game.variant_name == "From Position":
-        board_standard = chess.Board(game.initial_fen)
-        board_960 = chess.Board(game.initial_fen, chess960=True)
-        board = board_standard if board_standard == board_960 else board_960
+        fen = cast(str, game.initial_fen)
+        board = chess.Board(fen, chess960=model.is_chess_960(fen))
 
     else:
         VariantBoard = find_variant(game.variant_name)

--- a/lib/model.py
+++ b/lib/model.py
@@ -3,6 +3,7 @@ import math
 from urllib.parse import urljoin
 import logging
 import datetime
+import chess
 from enum import Enum
 from lib.timer import Timer, msec, seconds, sec_str, to_msec, to_seconds, years
 from lib.config import Configuration
@@ -10,6 +11,11 @@ from collections import defaultdict, Counter
 from lib.lichess_types import UserProfileType, ChallengeType, GameEventType, PlayerType
 
 logger = logging.getLogger(__name__)
+
+
+def is_chess_960(fen: str) -> bool:
+    """Determine whether an FEN string represents a chess960 game."""
+    return chess.Board(fen) != chess.Board(fen, chess960=True)
 
 
 class Challenge:
@@ -35,7 +41,16 @@ class Challenge:
 
     def is_supported_variant(self, challenge_cfg: Configuration) -> bool:
         """Check whether the variant is supported."""
-        return self.variant in challenge_cfg.variants
+        if self.variant not in challenge_cfg.variants:
+            return False
+
+        if self.initial_fen == "startpos":
+            return True
+
+        if is_chess_960(self.initial_fen):
+            return "chess960" in challenge_cfg.variants
+
+        return True
 
     def is_supported_time_control(self, challenge_cfg: Configuration) -> bool:
         """Check whether the time control is supported."""


### PR DESCRIPTION
## Type of pull request:
- [x] Bug fix
- [ ] Feature
- [ ] Other

## Description:

There is no indication in the GameFullEvent whether a From Position game uses Chess960 rules or not. This change determines what kind of game is being played by seeing whether the `chess.Board` option `chess960=True` changes the state of the board. If it does, then the game is a 960 game.

## Related Issues:

Closes #1146

## Checklist:

- [x] I have read and followed the [contribution guidelines](/docs/CONTRIBUTING.md).
- [x] I have added necessary documentation (if applicable).
- [x] The changes pass all existing tests.

## Screenshots/logs (if applicable):
