### PR TITLE
Fix syzygy

### DIFF
--- a/lib/engine_wrapper.py
+++ b/lib/engine_wrapper.py
@@ -1206,7 +1206,7 @@ def dtz_scorer(tablebase: chess.syzygy.Tablebase, board: chess.Board) -> int | f
     For a zeroing move (capture or pawn move), a DTZ of +/-0.5 is returned.
     """
     dtz: int | float = -tablebase.probe_dtz(board)
-    dtz = dtz if board.halfmove_clock else math.copysign(.5, dtz)
+    dtz = dtz if board.halfmove_clock or not dtz else math.copysign(.5, dtz)
     return dtz + (math.copysign(board.halfmove_clock, dtz) if dtz else 0)
 
 


### PR DESCRIPTION
## Type of pull request:
- [x] Bug fix
- [ ] Feature
- [ ] Other

## Description:

The 0.5 we would add for zeroing moves so that we would count 0.5 as theit dtz instead of the dtz after the move was being added to drawn positions as well.

## Related Issues:

#1158 

## Checklist:

- [x] I have read and followed the [contribution guidelines](/docs/CONTRIBUTING.md).
- [x] I have added necessary documentation (if applicable).
- [x] The changes pass all existing tests.

## Screenshots/logs (if applicable):
