### PR TITLE
Assume game is active until lichess says otherwise

### DIFF
--- a/lib/lichess.py
+++ b/lib/lichess.py
@@ -401,13 +401,16 @@ class Lichess:
         self.set_user_agent(profile["username"])
         return profile
 
-    def get_ongoing_games(self) -> list[GameType]:
-        """Get the bot's ongoing games."""
-        ongoing_games: list[GameType] = []
+    def get_ongoing_games(self) -> list[GameType] | None:
+        """
+        Get the bot's ongoing games.
+
+        If an error occurs when retreiving the games, None is returned.
+        """
         with contextlib.suppress(Exception):
             response = cast(dict[str, list[GameType]], self.api_get_json("playing"))
-            ongoing_games = response["nowPlaying"]
-        return ongoing_games
+            return response["nowPlaying"]
+        return None
 
     def resign(self, game_id: str) -> None:
         """Resign a game."""

--- a/lib/lichess_bot.py
+++ b/lib/lichess_bot.py
@@ -342,7 +342,7 @@ def lichess_bot_main(li: lichess.Lichess,
 
     one_game_completed = False
 
-    all_games = li.get_ongoing_games()
+    all_games = li.get_ongoing_games() or []
     prune_takeback_records(all_games)
     startup_correspondence_games = [game["gameId"]
                                     for game in all_games
@@ -531,7 +531,10 @@ def sort_challenges(challenge_queue: MULTIPROCESSING_LIST_TYPE, challenge_config
 
 def game_is_active(li: lichess.Lichess, game_id: str) -> bool:
     """Determine if a game is still being played."""
-    return game_id in (ongoing_game["gameId"] for ongoing_game in li.get_ongoing_games())
+    active_games = li.get_ongoing_games()
+    if active_games is None:
+        return True
+    return game_id in (ongoing_game["gameId"] for ongoing_game in active_games)
 
 
 def start_game_thread(active_games: set[str], game_id: str, play_game_args: PlayGameArgsType, pool: POOL_TYPE) -> None:
@@ -604,7 +607,8 @@ def handle_challenge(event: EventType, li: lichess.Lichess, challenge_queue: MUL
     if chlng.from_self:
         return
 
-    opponent_engagements = Counter(game["opponent"]["username"] for game in li.get_ongoing_games())
+    active_games = li.get_ongoing_games() or []
+    opponent_engagements = Counter(game["opponent"]["username"] for game in active_games)
     opponent_engagements.update(challenge.challenger.name for challenge in challenge_queue)
 
     is_supported, decline_reason = chlng.is_supported(challenge_config, recent_bot_challenges, opponent_engagements)


### PR DESCRIPTION
## Type of pull request:
- [x] Bug fix
- [ ] Feature
- [ ] Other

## Description:

When a communication error occurs during a game, the function `game_is_active()` checks with lichess if the current game is still ongoing before trying to reconnect. If that function errors, then the game is aborted locally and never reconnects.

With this change, a failure to retrieve the list of active games results in the function returning `True`.

## Related Issues:

Closes #1163

## Checklist:

- [x] I have read and followed the [contribution guidelines](/docs/CONTRIBUTING.md).
- [x] I have added necessary documentation (if applicable).
- [x] The changes pass all existing tests.

## Screenshots/logs (if applicable):
