### PR TITLE
Remove active games when challenge canceled

### DIFF
--- a/lib/lichess_bot.py
+++ b/lib/lichess_bot.py
@@ -397,6 +397,9 @@ def lichess_bot_main(li: lichess.Lichess,
                                  online_block_list)
             elif event["type"] == "challengeDeclined":
                 matchmaker.declined_challenge(event)
+            elif event["type"] == "challengeCanceled":
+                active_games.discard(event["game"]["id"])
+                log_proc_count("Freed", active_games)
             elif event["type"] == "gameStart":
                 matchmaker.accepted_challenge(event)
                 start_game(event,


### PR DESCRIPTION
Fixes #1166

## Type of pull request:
- [x] Bug fix
- [ ] Feature
- [ ] Other

## Description:

If a challenge is accepted by a bot, but the challenge is canceled before the game starts, then the game ID remains in the `active_games` set and will never be removed. This effectively reduces the number of simultaneous games a bot can play by one each time it happens. This change removes the game ID from `active_games` when a challenge is canceled.

## Related Issues:

Fixes #1166

## Checklist:

- [x] I have read and followed the [contribution guidelines](/docs/CONTRIBUTING.md).
- [x] I have added necessary documentation (if applicable).
- [x] The changes pass all existing tests.

## Screenshots/logs (if applicable):
