### PR TITLE
Fix ID extraction from challenge event

### DIFF
--- a/lib/lichess_bot.py
+++ b/lib/lichess_bot.py
@@ -398,7 +398,7 @@ def lichess_bot_main(li: lichess.Lichess,
             elif event["type"] == "challengeDeclined":
                 matchmaker.declined_challenge(event)
             elif event["type"] == "challengeCanceled":
-                active_games.discard(event["game"]["id"])
+                active_games.discard(event["challenge"]["id"])
                 log_proc_count("Freed", active_games)
             elif event["type"] == "gameStart":
                 matchmaker.accepted_challenge(event)


### PR DESCRIPTION
## Type of pull request:
- [x] Bug fix
- [ ] Feature
- [ ] Other

## Description:

Use correct tag to extract challenge ID from `challengeCanceled` event.

## Related Issues:

Fixes #1169

## Checklist:

- [x] I have read and followed the [contribution guidelines](/docs/CONTRIBUTING.md).
- [x] I have added necessary documentation (if applicable).
- [x] The changes pass all existing tests.

## Screenshots/logs (if applicable):
