### PR TITLE
Fix stderr output option

### DIFF
--- a/lib/engine_wrapper.py
+++ b/lib/engine_wrapper.py
@@ -54,7 +54,7 @@ def create_engine(engine_config: Configuration, game: model.Game | None = None) 
         for k, v in cfg.engine_options.items():
             commands.append(f"--{k}={v}" if v is not None else f"--{k}")
 
-    stderr = None if cfg.silence_stderr else subprocess.DEVNULL
+    stderr = subprocess.DEVNULL if cfg.silence_stderr else None
 
     Engine: type[UCIEngine | XBoardEngine | MinimalEngine]
     if engine_type == "xboard":


### PR DESCRIPTION
## Type of pull request:
- [x] Bug fix
- [ ] Feature
- [ ] Other

## Description:

Prior to this fix, the action of the `silence_stderr` configuration was reversed. That is, `silence_stderr: True` caused `stderr` output to be printed and vice versa.

With this PR, `silence_stderr: True` causes `stderr` output to be suppressed, and `silence_stderr: False` causes it to be printed to the terminal (but not logged).

## Related Issues:

Bug discovered in discussion  #1198.

## Checklist:

- [x] I have read and followed the [contribution guidelines](/docs/CONTRIBUTING.md).
- [x] I have added necessary documentation (if applicable).
- [x] The changes pass all existing tests.

## Screenshots/logs (if applicable):