### PR TITLE
Reconnect control stream on network errors instead of terminating

### DIFF
--- a/lib/lichess_bot.py
+++ b/lib/lichess_bot.py
@@ -125,12 +125,10 @@ def watch_control_stream(control_queue: CONTROL_QUEUE_TYPE, li: lichess.Lichess)
                     else:
                         control_queue.put_nowait({"type": "ping"})
         except Exception:
-            if stop.terminated:
-                break
             logger.warning(f"Control stream error, reconnecting:\n{traceback.format_exc()}")
             time.sleep(1)
 
-    control_queue.put_nowait({"type": "terminated", "error": None})
+    control_queue.put_nowait({"type": "terminated"})
 
 
 def do_correspondence_ping(control_queue: CONTROL_QUEUE_TYPE, period: datetime.timedelta) -> None:
@@ -381,7 +379,6 @@ def lichess_bot_main(li: lichess.Lichess,
 
             if event["type"] == "terminated":
                 stop.restart = True
-                logger.debug(f"Terminating exception:\n{event['error']}")
                 control_queue.task_done()
                 break
 

--- a/lib/lichess_bot.py
+++ b/lib/lichess_bot.py
@@ -126,10 +126,12 @@ def watch_control_stream(control_queue: CONTROL_QUEUE_TYPE, li: lichess.Lichess)
                     else:
                         control_queue.put_nowait({"type": "ping"})
         except Exception:
-            error = traceback.format_exc()
-            break
+            if stop.terminated:
+                break
+            logger.warning(f"Control stream error, reconnecting:\n{traceback.format_exc()}")
+            time.sleep(1)
 
-    control_queue.put_nowait({"type": "terminated", "error": error})
+    control_queue.put_nowait({"type": "terminated", "error": None})
 
 
 def do_correspondence_ping(control_queue: CONTROL_QUEUE_TYPE, period: datetime.timedelta) -> None:

--- a/lib/lichess_bot.py
+++ b/lib/lichess_bot.py
@@ -114,7 +114,6 @@ def upgrade_account(li: lichess.Lichess) -> bool:
 
 def watch_control_stream(control_queue: CONTROL_QUEUE_TYPE, li: lichess.Lichess) -> None:
     """Put the events in a queue."""
-    error = None
     while not stop.terminated:
         try:
             with li.get_event_stream() as response:


### PR DESCRIPTION
## Problem

`watch_control_stream` handles all exceptions with `break`, which exits the reconnect loop, sends `{"type": "terminated"}` to the control queue, and triggers a full bot restart (including a 10-second sleep in the outer restart loop). Any transient network error — including a read timeout on a TCP connection stuck in CLOSE_WAIT — therefore takes the bot offline for 10+ seconds.

Related discussion: #1200

## Fix

On exception, log at WARNING level and `continue` the loop (1-second backoff) instead of `break`. The stream reconnects immediately without interrupting active game processes or requiring a full restart.

Only `stop.terminated` (SIGINT) causes the loop to exit and send `"terminated"`, which is the intended shutdown path.

## Before / After

```python
# before
except Exception:
    error = traceback.format_exc()
    break                            # kills reconnect loop → full restart

# after
except Exception:
    if stop.terminated:
        break
    logger.warning(f"Control stream error, reconnecting:\n{traceback.format_exc()}")
    time.sleep(1)                    # brief backoff, then reconnect
```

## Notes

- `time` and `traceback` are already imported at the top of `lichess_bot.py`
- The `error` field in the `"terminated"` message was only ever populated on the exception path; it is now always `None` since exceptions are handled by reconnecting
- Existing tests pass unchanged since `watch_control_stream` is exercised through the fake Lichess server which closes streams cleanly (no exception path hit)