### PR TITLE
Use the OAuth token for online move requests from lichess

### DIFF
--- a/lib/engine_wrapper.py
+++ b/lib/engine_wrapper.py
@@ -890,10 +890,10 @@ def get_lichess_cloud_move(li: lichess.Lichess, board: chess.Board, game: model.
     variant = "standard" if board.uci_variant == "chess" else str(board.uci_variant)  # `str` is there only for mypy.
 
     with contextlib.suppress(Exception):
-        data = li.online_book_get("https://lichess.org/api/cloud-eval",
-                                  params={"fen": board.fen(),
-                                          "multiPv": multipv,
-                                          "variant": variant})
+        data = li.authenticated_online_book_get("https://lichess.org/api/cloud-eval",
+                                                params={"fen": board.fen(),
+                                                        "multiPv": multipv,
+                                                        "variant": variant})
         if "error" not in data:
             depth = data["depth"]
             knodes = data["knodes"]
@@ -944,7 +944,7 @@ def get_opening_explorer_move(li: lichess.Lichess, board: chess.Board, game: mod
         params: dict[str, str | int]
         if source == "masters":
             params = {"fen": board.fen(), "moves": 100}
-            response = li.online_book_get("https://explorer.lichess.ovh/masters", params)
+            response = li.authenticated_online_book_get("https://explorer.lichess.ovh/masters", params)
             comment = {"string": "lichess-bot-source:Lichess Opening Explorer (Masters)"}
         elif source == "player":
             player = opening_explorer_cfg.player_name
@@ -952,11 +952,11 @@ def get_opening_explorer_move(li: lichess.Lichess, board: chess.Board, game: mod
                 player = game.username
             params = {"player": player, "fen": board.fen(), "moves": 100, "variant": variant,
                       "recentGames": 0, "color": "white" if side == "wtime" else "black"}
-            response = li.online_book_get("https://explorer.lichess.ovh/player", params, True)
+            response = li.authenticated_online_book_get("https://explorer.lichess.ovh/player", params, True)
             comment = {"string": "lichess-bot-source:Lichess Opening Explorer (Player)"}
         else:
             params = {"fen": board.fen(), "moves": 100, "variant": variant, "topGames": 0, "recentGames": 0}
-            response = li.online_book_get("https://explorer.lichess.ovh/lichess", params)
+            response = li.authenticated_online_book_get("https://explorer.lichess.ovh/lichess", params)
             comment = {"string": "lichess-bot-source:Lichess Opening Explorer (Lichess)"}
         moves = []
         for possible_move in response["moves"]:
@@ -1087,8 +1087,8 @@ def get_lichess_egtb_move(li: lichess.Lichess, game: model.Game, board: chess.Bo
     metric: Literal["dtz", "dtc"] = "dtz" if pieces < 8 else "dtc"
     is_op1 = is_op1_position(board)
     if pieces <= max_pieces and (pieces < 8 or is_op1):
-        data = li.online_book_get(f"https://tablebase.lichess.ovh/{variant}",
-                                  params={"fen": board.fen()})
+        data = li.authenticated_online_book_get(f"https://tablebase.lichess.ovh/{variant}",
+                                                params={"fen": board.fen()})
         if quality == "best":
             move = data["moves"][0]["uci"]
             wdl = name_to_wld[data["moves"][0]["category"]] * -1

--- a/lib/engine_wrapper.py
+++ b/lib/engine_wrapper.py
@@ -890,10 +890,9 @@ def get_lichess_cloud_move(li: lichess.Lichess, board: chess.Board, game: model.
     variant = "standard" if board.uci_variant == "chess" else str(board.uci_variant)  # `str` is there only for mypy.
 
     with contextlib.suppress(Exception):
-        data = li.authenticated_online_book_get("https://lichess.org/api/cloud-eval",
-                                                params={"fen": board.fen(),
-                                                        "multiPv": multipv,
-                                                        "variant": variant})
+        data = li.online_book_get("https://lichess.org/api/cloud-eval",
+                                  params={"fen": board.fen(), "multiPv": multipv, "variant": variant},
+                                  authenticated=True)
         if "error" not in data:
             depth = data["depth"]
             knodes = data["knodes"]
@@ -944,7 +943,7 @@ def get_opening_explorer_move(li: lichess.Lichess, board: chess.Board, game: mod
         params: dict[str, str | int]
         if source == "masters":
             params = {"fen": board.fen(), "moves": 100}
-            response = li.authenticated_online_book_get("https://explorer.lichess.ovh/masters", params)
+            response = li.online_book_get("https://explorer.lichess.ovh/masters", params, authenticated=True)
             comment = {"string": "lichess-bot-source:Lichess Opening Explorer (Masters)"}
         elif source == "player":
             player = opening_explorer_cfg.player_name
@@ -952,11 +951,11 @@ def get_opening_explorer_move(li: lichess.Lichess, board: chess.Board, game: mod
                 player = game.username
             params = {"player": player, "fen": board.fen(), "moves": 100, "variant": variant,
                       "recentGames": 0, "color": "white" if side == "wtime" else "black"}
-            response = li.authenticated_online_book_get("https://explorer.lichess.ovh/player", params, True)
+            response = li.online_book_get("https://explorer.lichess.ovh/player", params, True, authenticated=True)
             comment = {"string": "lichess-bot-source:Lichess Opening Explorer (Player)"}
         else:
             params = {"fen": board.fen(), "moves": 100, "variant": variant, "topGames": 0, "recentGames": 0}
-            response = li.authenticated_online_book_get("https://explorer.lichess.ovh/lichess", params)
+            response = li.online_book_get("https://explorer.lichess.ovh/lichess", params, authenticated=True)
             comment = {"string": "lichess-bot-source:Lichess Opening Explorer (Lichess)"}
         moves = []
         for possible_move in response["moves"]:
@@ -1087,8 +1086,8 @@ def get_lichess_egtb_move(li: lichess.Lichess, game: model.Game, board: chess.Bo
     metric: Literal["dtz", "dtc"] = "dtz" if pieces < 8 else "dtc"
     is_op1 = is_op1_position(board)
     if pieces <= max_pieces and (pieces < 8 or is_op1):
-        data = li.authenticated_online_book_get(f"https://tablebase.lichess.ovh/{variant}",
-                                                params={"fen": board.fen()})
+        data = li.online_book_get(f"https://tablebase.lichess.ovh/{variant}",
+                                  params={"fen": board.fen()}, authenticated=True)
         if quality == "best":
             move = data["moves"][0]["uci"]
             wdl = name_to_wld[data["moves"][0]["category"]] * -1

--- a/lib/engine_wrapper.py
+++ b/lib/engine_wrapper.py
@@ -951,7 +951,7 @@ def get_opening_explorer_move(li: lichess.Lichess, board: chess.Board, game: mod
                 player = game.username
             params = {"player": player, "fen": board.fen(), "moves": 100, "variant": variant,
                       "recentGames": 0, "color": "white" if side == "wtime" else "black"}
-            response = li.online_book_get("https://explorer.lichess.ovh/player", params, True, authenticated=True)
+            response = li.online_book_get("https://explorer.lichess.ovh/player", params, stream=True, authenticated=True)
             comment = {"string": "lichess-bot-source:Lichess Opening Explorer (Player)"}
         else:
             params = {"fen": board.fen(), "moves": 100, "variant": variant, "topGames": 0, "recentGames": 0}

--- a/lib/lichess.py
+++ b/lib/lichess.py
@@ -448,7 +448,7 @@ class Lichess:
 
     def online_book_get(self, path: str, params: dict[str, str | int] | None = None,
                         stream: bool = False) -> OnlineType:
-        """Get an external move from online sources (chessdb or lichess.org)."""
+        """Get an external move from chessdb."""
         @backoff.on_exception(backoff.constant,
                               (RemoteDisconnected, RequestsConnectionError, HTTPError, ReadTimeout),
                               max_time=60,
@@ -462,6 +462,23 @@ class Lichess:
             json_response: OnlineType = self.other_session.get(path, timeout=2, params=params, stream=stream).json()
             return json_response
         return online_book_get()
+
+    def authenticated_online_book_get(self, path: str, params: dict[str, str | int] | None = None,
+                                      stream: bool = False) -> OnlineType:
+        """Get an external move from lichess.org."""
+        @backoff.on_exception(backoff.constant,
+                              (RemoteDisconnected, RequestsConnectionError, HTTPError, ReadTimeout),
+                              max_time=60,
+                              max_tries=self.max_retries,
+                              interval=0.1,
+                              giveup=is_final,
+                              on_backoff=backoff_handler,
+                              backoff_log_level=logging.DEBUG,
+                              giveup_log_level=logging.DEBUG)
+        def authenticated_online_book_get() -> OnlineType:
+            json_response: OnlineType = self.session.get(path, timeout=2, params=params, stream=stream).json()
+            return json_response
+        return authenticated_online_book_get()
 
     def is_online(self, user_id: str) -> bool:
         """Check if lichess.org thinks the bot is online or not."""

--- a/lib/lichess.py
+++ b/lib/lichess.py
@@ -446,7 +446,7 @@ class Lichess:
         """Cancel a challenge."""
         self.api_post("cancel", challenge_id, raise_for_status=False)
 
-    def online_book_get(self, path: str, params: dict[str, str | int] | None = None,
+    def online_book_get(self, path: str, params: dict[str, str | int] | None = None, *,
                         stream: bool = False, authenticated: bool = False) -> OnlineType:
         """Get an external move from online sources (chessdb or lichess.org)."""
         @backoff.on_exception(backoff.constant,

--- a/lib/lichess.py
+++ b/lib/lichess.py
@@ -447,8 +447,8 @@ class Lichess:
         self.api_post("cancel", challenge_id, raise_for_status=False)
 
     def online_book_get(self, path: str, params: dict[str, str | int] | None = None,
-                        stream: bool = False) -> OnlineType:
-        """Get an external move from chessdb."""
+                        stream: bool = False, authenticated: bool = False) -> OnlineType:
+        """Get an external move from online sources (chessdb or lichess.org)."""
         @backoff.on_exception(backoff.constant,
                               (RemoteDisconnected, RequestsConnectionError, HTTPError, ReadTimeout),
                               max_time=60,
@@ -459,26 +459,10 @@ class Lichess:
                               backoff_log_level=logging.DEBUG,
                               giveup_log_level=logging.DEBUG)
         def online_book_get() -> OnlineType:
-            json_response: OnlineType = self.other_session.get(path, timeout=2, params=params, stream=stream).json()
+            session = self.session if authenticated else self.other_session  # Choose session based on authentication need
+            json_response: OnlineType = session.get(path, timeout=2, params=params, stream=stream).json()
             return json_response
         return online_book_get()
-
-    def authenticated_online_book_get(self, path: str, params: dict[str, str | int] | None = None,
-                                      stream: bool = False) -> OnlineType:
-        """Get an external move from lichess.org."""
-        @backoff.on_exception(backoff.constant,
-                              (RemoteDisconnected, RequestsConnectionError, HTTPError, ReadTimeout),
-                              max_time=60,
-                              max_tries=self.max_retries,
-                              interval=0.1,
-                              giveup=is_final,
-                              on_backoff=backoff_handler,
-                              backoff_log_level=logging.DEBUG,
-                              giveup_log_level=logging.DEBUG)
-        def authenticated_online_book_get() -> OnlineType:
-            json_response: OnlineType = self.session.get(path, timeout=2, params=params, stream=stream).json()
-            return json_response
-        return authenticated_online_book_get()
 
     def is_online(self, user_id: str) -> bool:
         """Check if lichess.org thinks the bot is online or not."""

--- a/test_bot/lichess.py
+++ b/test_bot/lichess.py
@@ -253,6 +253,11 @@ class Lichess(OriginalLichess):
         """Isn't used in tests."""
         return {}
 
+    def authenticated_online_book_get(self, path: str, params: dict[str, str | int] | None = None,
+                                      stream: bool = False) -> OnlineType:
+        """Isn't used in tests."""
+        return {}
+
     def is_online(self, user_id: str) -> bool:
         """Return that a bot is online."""
         return True

--- a/test_bot/lichess.py
+++ b/test_bot/lichess.py
@@ -248,7 +248,7 @@ class Lichess(OriginalLichess):
     def cancel(self, challenge_id: str) -> None:
         """Isn't used in tests."""
 
-    def online_book_get(self, path: str, params: dict[str, str | int] | None = None,
+    def online_book_get(self, path: str, params: dict[str, str | int] | None = None, *,
                         stream: bool = False, authenticated: bool = False) -> OnlineType:
         """Isn't used in tests."""
         return {}

--- a/test_bot/lichess.py
+++ b/test_bot/lichess.py
@@ -249,12 +249,7 @@ class Lichess(OriginalLichess):
         """Isn't used in tests."""
 
     def online_book_get(self, path: str, params: dict[str, str | int] | None = None,
-                        stream: bool = False) -> OnlineType:
-        """Isn't used in tests."""
-        return {}
-
-    def authenticated_online_book_get(self, path: str, params: dict[str, str | int] | None = None,
-                                      stream: bool = False) -> OnlineType:
+                        stream: bool = False, authenticated: bool = False) -> OnlineType:
         """Isn't used in tests."""
         return {}
 

--- a/test_bot/test_external_moves.py
+++ b/test_bot/test_external_moves.py
@@ -46,6 +46,11 @@ class MockLichess(Lichess):
 
         return online_book_get()
 
+    def authenticated_online_book_get(self, path: str, params: dict[str, str | int] | None = None,
+                                      stream: bool = False) -> OnlineType:
+        """Use online_book_get for tests."""
+        return self.online_book_get(path, params, stream)
+
     def is_website_up(self, url: str) -> bool:
         """Check if a website is up."""
         try:

--- a/test_bot/test_external_moves.py
+++ b/test_bot/test_external_moves.py
@@ -28,8 +28,12 @@ class MockLichess(Lichess):
         self.other_session = requests.Session()
 
     def online_book_get(self, path: str, params: dict[str, str | int] | None = None,
-                        stream: bool = False) -> OnlineType:
-        """Get an external move from online sources (chessdb or lichess.org)."""
+                        stream: bool = False, authenticated: bool = False) -> OnlineType:
+        """
+        Get an external move from online sources (chessdb or lichess.org).
+
+        Ignore authentication for tests.
+        """
 
         @backoff.on_exception(backoff.constant,
                               (RemoteDisconnected, RequestsConnectionError, HTTPError, ReadTimeout),

--- a/test_bot/test_external_moves.py
+++ b/test_bot/test_external_moves.py
@@ -28,7 +28,7 @@ class MockLichess(Lichess):
         self.other_session = requests.Session()
 
     def online_book_get(self, path: str, params: dict[str, str | int] | None = None,
-                        stream: bool = False, authenticated: bool = False) -> OnlineType:
+                        stream: bool = False, **_: dict[str, bool]) -> OnlineType:
         """
         Get an external move from online sources (chessdb or lichess.org).
 
@@ -45,9 +45,7 @@ class MockLichess(Lichess):
                               backoff_log_level=logging.DEBUG,
                               giveup_log_level=logging.DEBUG)
         def online_book_get() -> OnlineType:
-            # Always choose the unauthenticated session for tests.
-            session = self.other_session if authenticated else self.other_session
-            json_response: OnlineType = session.get(path, timeout=2, params=params, stream=stream).json()
+            json_response: OnlineType = self.other_session.get(path, timeout=2, params=params, stream=stream).json()
             return json_response
 
         return online_book_get()

--- a/test_bot/test_external_moves.py
+++ b/test_bot/test_external_moves.py
@@ -50,11 +50,6 @@ class MockLichess(Lichess):
 
         return online_book_get()
 
-    def authenticated_online_book_get(self, path: str, params: dict[str, str | int] | None = None,
-                                      stream: bool = False) -> OnlineType:
-        """Use online_book_get for tests."""
-        return self.online_book_get(path, params, stream)
-
     def is_website_up(self, url: str) -> bool:
         """Check if a website is up."""
         try:

--- a/test_bot/test_external_moves.py
+++ b/test_bot/test_external_moves.py
@@ -27,7 +27,7 @@ class MockLichess(Lichess):
         self.max_retries = 3
         self.other_session = requests.Session()
 
-    def online_book_get(self, path: str, params: dict[str, str | int] | None = None,
+    def online_book_get(self, path: str, params: dict[str, str | int] | None = None, *,
                         stream: bool = False, authenticated: bool = False) -> OnlineType:
         """
         Get an external move from online sources (chessdb or lichess.org).

--- a/test_bot/test_external_moves.py
+++ b/test_bot/test_external_moves.py
@@ -28,12 +28,13 @@ class MockLichess(Lichess):
         self.other_session = requests.Session()
 
     def online_book_get(self, path: str, params: dict[str, str | int] | None = None,
-                        stream: bool = False, **_: dict[str, bool]) -> OnlineType:
+                        stream: bool = False, authenticated: bool = False) -> OnlineType:
         """
         Get an external move from online sources (chessdb or lichess.org).
 
         Ignore authentication for tests.
         """
+        del authenticated
 
         @backoff.on_exception(backoff.constant,
                               (RemoteDisconnected, RequestsConnectionError, HTTPError, ReadTimeout),

--- a/test_bot/test_external_moves.py
+++ b/test_bot/test_external_moves.py
@@ -45,7 +45,9 @@ class MockLichess(Lichess):
                               backoff_log_level=logging.DEBUG,
                               giveup_log_level=logging.DEBUG)
         def online_book_get() -> OnlineType:
-            json_response: OnlineType = self.other_session.get(path, timeout=2, params=params, stream=stream).json()
+            # Always choose the unauthenticated session for tests.
+            session = self.other_session if authenticated else self.other_session
+            json_response: OnlineType = session.get(path, timeout=2, params=params, stream=stream).json()
             return json_response
 
         return online_book_get()


### PR DESCRIPTION
## Type of pull request:
- [x] Bug fix
- [ ] Feature
- [ ] Other

## Description:

lichess now requires opening book requests to be authenticated. I switched every lichess request to the authenticated session, as thibault [noted](https://lichess.org/@/thibault/blog/the-opening-explorer-now-requires-authentication/FSWh9Zg3) that they may do the same to the online egtb at some point.

Note: Duplicates the code quite a bit. Perhaps using session if the url includes `.lichess.` and other_session otherwise is a better option.

## Related Issues:

closes #1206 

## Checklist:

- [x] I have read and followed the [contribution guidelines](/docs/CONTRIBUTING.md).
- [x] I have added necessary documentation (if applicable).
- [x] The changes pass all existing tests.

## Screenshots/logs (if applicable):
