### PR TITLE
Increase number of bots queried from lichess

### DIFF
--- a/lib/lichess.py
+++ b/lib/lichess.py
@@ -431,7 +431,7 @@ class Lichess:
     def get_online_bots(self) -> list[UserProfileType]:
         """Get a list of bots that are online."""
         try:
-            online_bots_str = self.api_get_raw("online_bots")
+            online_bots_str = self.api_get_raw("online_bots", params={"nb": "512"})
             online_bots = list(filter(bool, online_bots_str.split("\n")))
             return list(map(json.loads, online_bots))
         except Exception:

--- a/lib/matchmaking.py
+++ b/lib/matchmaking.py
@@ -186,7 +186,9 @@ class Matchmaking:
 
         self.online_block_list.refresh()
         online_bots = self.li.get_online_bots()
+        logger.info(f"Found {len(online_bots)} online bots")
         online_bots = list(filter(is_suitable_opponent, online_bots))
+        logger.info(f"Choosing from {len(online_bots)} suitable opponents")
 
         def ready_for_challenge(bot: UserProfileType) -> bool:
             aspects = [variant, game_type, mode] if self.challenge_filter == FilterType.FINE else []


### PR DESCRIPTION
## Type of pull request:
- [ ] Bug fix
- [x] Feature
- [ ] Other

## Description:

Increase the number of bots queried from lichess from the default 100 to the maximum 512. This should allow for a wider variety of bots to challenge.

## Related Issues:

Closes #1208

## Checklist:

- [x] I have read and followed the [contribution guidelines](/docs/CONTRIBUTING.md).
- [x] I have added necessary documentation (if applicable).
- [x] The changes pass all existing tests.

## Screenshots/logs (if applicable):
