### PR TITLE
fix: skip random challenge when no bot is found

### DIFF
--- a/lib/matchmaking.py
+++ b/lib/matchmaking.py
@@ -237,8 +237,14 @@ class Matchmaking:
         logger.info("Challenging a random bot")
         self.update_user_profile()
         bot_username, base_time, increment, days, variant, mode = self.choose_opponent()
+        if not bot_username:
+            logger.info("No challenge will be created.")
+            self.challenge_id = ""
+            self.rate_limit_timer = Timer(seconds(60))
+            return
+
         logger.info(f"Will challenge {bot_username} for a {variant} game.")
-        challenge_id = self.create_challenge(bot_username, base_time, increment, days, variant, mode) if bot_username else ""
+        challenge_id = self.create_challenge(bot_username, base_time, increment, days, variant, mode)
         logger.info(f"Challenge id is {challenge_id or 'None'}.")
         self.challenge_id = challenge_id
 


### PR DESCRIPTION
Return immediately when matchmaking cannot pick an opponent, avoiding the misleading 'Will challenge None' log line.

Validation: python3 -m py_compile lichess-bot/lib/matchmaking.py

## Type of pull request:
- [X] Bug fix
- [ ] Feature
- [ ] Other

## Description:

When random matchmaking finds no suitable online bot, `choose_opponent()` returns no username. The
caller already avoids creating a challenge in that case, but it still logs `Will challenge None for a
standard game.`

This change returns immediately when no opponent was selected, clears the stored challenge id, and logs
that no challenge will be created.

## Related Issues:

[Reference any related issues that this pull request addresses or closes. Use the syntax `Closes #issue_number` to automatically close the linked issue upon merging.]

## Checklist:

- [x] I have read and followed the [contribution guidelines](/docs/CONTRIBUTING.md).
- [x] I have added necessary documentation (if applicable).
- [x] The changes pass all existing tests.

## Screenshots/logs (if applicable):

  ```text
  ERROR    No suitable bots found to challenge.
  INFO     Will challenge None for a standard game.

  After:

  ERROR    No suitable bots found to challenge.
  INFO     No challenge will be created.
