### PR TITLE
include_challenge_block_list should also imply using the online blocklist

### DIFF
--- a/config.yml.default
+++ b/config.yml.default
@@ -223,7 +223,7 @@ matchmaking:
 #   - user2
 # online_block_list:               # The urls from which to retrieve a list of bot names that will not be challenged. The list should be a text file where each line contains the name of a blocked bot
 #   - example.com/blocklist
-  include_challenge_block_list: false  # Do not challenge bots in the challenge: block_list in addition to the matchmaking block list.
+  include_challenge_block_list: false  # Do not challenge bots in the challenge: block_list/online_block_list in addition to the matchmaking block list.
 
 # overrides:                       # List of overrides for the matchmaking specifications above. When a challenge is created, either the default specification above or one of the overrides will be randomly chosen.
 #   bullet_only_horde:             # Name of the override. Can be anything as long as each override has a unique name ("bullet_only_horde" and "easy_chess960" in these examples).

--- a/lib/config.py
+++ b/lib/config.py
@@ -268,6 +268,7 @@ def process_block_list(CONFIG: CONFIG_DICT_TYPE) -> None:
     """
     if CONFIG["matchmaking"]["include_challenge_block_list"]:
         CONFIG["matchmaking"]["block_list"].extend(CONFIG["challenge"]["block_list"])
+        CONFIG["matchmaking"]["online_block_list"].extend(CONFIG["challenge"]["online_block_list"])
 
 
 def log_config(CONFIG: CONFIG_DICT_TYPE, alternate_log_function: Callable[[str], Any] | None = None) -> None:

--- a/wiki/Configure-lichess-bot.md
+++ b/wiki/Configure-lichess-bot.md
@@ -278,7 +278,7 @@ will precede the `go` command to start thinking with `sd 5`. The other `go_comma
     The `challenge_filter` option can be useful if your matchmaking settings result in a lot of declined challenges. The bots that accept challenges will be challenged more often than those that have declined. The filter will remain until lichess-bot quits or the connection with lichess.org is reset.
   - `block_list`: An indented list of usernames of bots that will not be challenged. If this option is not present, then the list is considered empty.
   - `online_block_list`: An indented list of urls from which additional block lists are retrieved. An online block list is a plain text file where each line contains a single username. If this option is not present, then the list is considered empty.
-  - `include_challenge_block_list`: If `true`, do not send challenges to the bots listed in the `challenge: block_list`. Default is `false`.
+  - `include_challenge_block_list`: If `true`, do not send challenges to the bots listed in the `challenge: block_list` or `challenge: online_block_list`. Default is `false`.
   - `overrides`: Create variations on the matchmaking settings above for more specific circumstances. If there are any subsections under `overrides`, the settings below that will override the settings in the matchmaking section. Any settings that do not appear will be taken from the settings above. <br/> <br/>
   The overrides section must have the following:
     - Name: A unique name must be given for each override. In the example configuration below, `easy_chess960` and `no_pressure_correspondence` are arbitrary strings to name the subsections and they are unique.


### PR DESCRIPTION
I and some other engine devs got caught out by this - setting include_challenge_block_list but still having engines make challenges to blocked bots.
