### PR TITLE
feat: reserve game slots for human players (#1212)

### DIFF
--- a/config.yml.default
+++ b/config.yml.default
@@ -135,6 +135,7 @@ correspondence:
 
 challenge:                         # Incoming challenges.
   concurrency: 1                   # Number of games to play simultaneously.
+  games_reserved_for_humans: 0     # Number of game slots (out of concurrency) kept free for human challengers. Bot games are limited to (concurrency - this) so humans can always challenge.
   sort_by: "best"                  # Possible values: "best" and "first".
   preference: "none"               # Possible values: "none", "human", "bot".
   accept_bot: true                 # Accepts challenges coming from other bots.

--- a/lib/config.py
+++ b/lib/config.py
@@ -205,6 +205,7 @@ def insert_default_values(CONFIG: CONFIG_DICT_TYPE) -> None:
     set_config_default(CONFIG, "engine", "polyglot", key="min_weight", default=1)
     set_config_default(CONFIG, "engine", "polyglot", key="normalization", default="none")
     set_config_default(CONFIG, "challenge", key="concurrency", default=1)
+    set_config_default(CONFIG, "challenge", key="games_reserved_for_humans", default=0)
     set_config_default(CONFIG, "challenge", key="sort_by", default="best")
     set_config_default(CONFIG, "challenge", key="preference", default="none")
     set_config_default(CONFIG, "challenge", key="accept_bot", default=False)

--- a/lib/config.py
+++ b/lib/config.py
@@ -318,6 +318,15 @@ def validate_config(CONFIG: CONFIG_DICT_TYPE) -> None:
     config_warn(CONFIG["challenge"]["concurrency"] > 0, "With challenge.concurrency set to 0, the bot won't accept or create "
                                                         "any challenges.")
 
+    config_assert(0 <= CONFIG["challenge"]["games_reserved_for_humans"] <= CONFIG["challenge"]["concurrency"],
+                  "challenge.games_reserved_for_humans must be between 0 and challenge.concurrency.")
+
+    config_warn(CONFIG["challenge"]["games_reserved_for_humans"] == 0
+                or CONFIG["challenge"]["preference"] == "human",
+                'challenge.games_reserved_for_humans reserves slots for humans, but challenge.preference is not '
+                '"human", so human challenges may be stalled behind bot challenges in the queue. Set '
+                'challenge.preference to "human" to prioritize human challengers.')
+
     config_assert(CONFIG["challenge"]["sort_by"] in ["best", "first"], "challenge.sort_by can be either `first` or `best`.")
     config_assert(CONFIG["challenge"]["preference"] in ["none", "human", "bot"],
                   "challenge.preference should be `none`, `human`, or `bot`.")

--- a/lib/lichess_bot.py
+++ b/lib/lichess_bot.py
@@ -502,8 +502,15 @@ def start_low_time_games(low_time_games: list[GameType], active_games: dict[str,
 
 
 def count_bot_games(active_games: dict[str, str]) -> int:
-    """Count active games whose opponent is known to be a bot."""
-    return sum(1 for name in active_games.values() if model.Player.is_bot_name(name))
+    """
+    Count active games whose opponent is known to be a bot.
+
+    Opponent names in `active_games` may be prefixed with a title (e.g.
+    "BOT sseh-c"), while `Player.bot_names` stores bare usernames. Compare the
+    bare username (the last whitespace-separated token) so the two match.
+    """
+    return sum(1 for name in active_games.values()
+               if model.Player.is_bot_name(name.split()[-1] if name else name))
 
 
 def accept_challenges(li: lichess.Lichess, challenge_queue: MULTIPROCESSING_LIST_TYPE, active_games: dict[str, str],

--- a/lib/lichess_bot.py
+++ b/lib/lichess_bot.py
@@ -307,15 +307,16 @@ def start(li: lichess.Lichess, user_profile: UserProfileType, config: Configurat
         pgn_listener.join()
 
 
-def log_proc_count(change: str, active_games: set[str]) -> None:
+def log_proc_count(change: str, active_games: dict[str, str]) -> None:
     """
     Log the number of active games and their IDs.
 
     :param change: Either "Freed", "Used", or "Queued".
-    :param active_games: A set containing the IDs of the active games.
+    :param active_games: A dict mapping active game IDs to opponent names.
     """
     symbol = "+++" if change == "Freed" else "---"
-    logger.info(f"{symbol} Process {change}. Count: {len(active_games)}. IDs: {active_games or None}")
+    game_ids = set(active_games) or None
+    logger.info(f"{symbol} Process {change}. Count: {len(active_games)}. IDs: {game_ids}")
 
 
 def lichess_bot_main(li: lichess.Lichess,
@@ -341,6 +342,8 @@ def lichess_bot_main(li: lichess.Lichess,
     :param one_game: Whether the bot should play only one game. Only used in `test_bot/test_bot.py` to test lichess-bot.
     """
     max_games = config.challenge.concurrency
+    reserved_for_humans = min(config.challenge.games_reserved_for_humans, max_games)
+    max_bot_games = max_games - reserved_for_humans
 
     one_game_completed = False
 
@@ -349,7 +352,7 @@ def lichess_bot_main(li: lichess.Lichess,
     startup_correspondence_games = [game["gameId"]
                                     for game in all_games
                                     if game["speed"] == "correspondence"]
-    active_games = {game["gameId"]
+    active_games = {game["gameId"]: game["opponent"]["username"]
                     for game in all_games
                     if game["gameId"] not in startup_correspondence_games}
     low_time_games: list[GameType] = []
@@ -383,7 +386,7 @@ def lichess_bot_main(li: lichess.Lichess,
                 break
 
             if event["type"] == "local_game_done":
-                active_games.discard(event["game"]["id"])
+                active_games.pop(event["game"]["id"], None)
                 matchmaker.game_done()
                 log_proc_count("Freed", active_games)
                 one_game_completed = True
@@ -398,7 +401,7 @@ def lichess_bot_main(li: lichess.Lichess,
             elif event["type"] == "challengeDeclined":
                 matchmaker.declined_challenge(event)
             elif event["type"] == "challengeCanceled":
-                active_games.discard(event["challenge"]["id"])
+                active_games.pop(event["challenge"]["id"], None)
                 log_proc_count("Freed", active_games)
             elif event["type"] == "gameStart":
                 matchmaker.accepted_challenge(event)
@@ -419,8 +422,8 @@ def lichess_bot_main(li: lichess.Lichess,
                                              play_game_args,
                                              active_games,
                                              max_games)
-            accept_challenges(li, challenge_queue, active_games, max_games)
-            matchmaker.challenge(active_games, challenge_queue, max_games)
+            accept_challenges(li, challenge_queue, active_games, max_games, max_bot_games)
+            matchmaker.challenge(active_games, challenge_queue, max_bot_games)
             check_online_status(li, user_profile, last_check_online_time)
 
             control_queue.task_done()
@@ -428,7 +431,7 @@ def lichess_bot_main(li: lichess.Lichess,
         close_pool(pool, active_games, config)
 
 
-def close_pool(pool: POOL_TYPE, active_games: set[str], config: Configuration) -> None:
+def close_pool(pool: POOL_TYPE, active_games: dict[str, str], config: Configuration) -> None:
     """Shut down pool after possibly waiting on games to finish depending on the configuration."""
     if config.quit_after_all_games_finish:
         if active_games:
@@ -466,7 +469,7 @@ def check_in_on_correspondence_games(pool: POOL_TYPE,
                                      correspondence_queue: CORRESPONDENCE_QUEUE_TYPE,
                                      challenge_queue: MULTIPROCESSING_LIST_TYPE,
                                      play_game_args: PlayGameArgsType,
-                                     active_games: set[str],
+                                     active_games: dict[str, str],
                                      max_games: int) -> None:
     """Start correspondence games."""
     global correspondence_games_to_start
@@ -483,30 +486,45 @@ def check_in_on_correspondence_games(pool: POOL_TYPE,
         game_id = correspondence_queue.get_nowait()
         correspondence_games_to_start -= 1
         correspondence_queue.task_done()
-        start_game_thread(active_games, game_id, play_game_args, pool)
+        opponent_name = event["game"].get("opponent", {}).get("username", "")
+        start_game_thread(active_games, game_id, opponent_name, play_game_args, pool)
 
 
-def start_low_time_games(low_time_games: list[GameType], active_games: set[str], max_games: int,
+def start_low_time_games(low_time_games: list[GameType], active_games: dict[str, str], max_games: int,
                          pool: POOL_TYPE, play_game_args: PlayGameArgsType) -> None:
     """Start the games based on how much time we have left."""
     low_time_games.sort(key=lambda g: g.get("secondsLeft", math.inf))
     while low_time_games and len(active_games) < max_games:
-        game_id = low_time_games.pop(0)["id"]
-        start_game_thread(active_games, game_id, play_game_args, pool)
+        low_time_game = low_time_games.pop(0)
+        game_id = low_time_game["id"]
+        opponent_name = low_time_game.get("opponent", {}).get("username", "")
+        start_game_thread(active_games, game_id, opponent_name, play_game_args, pool)
 
 
-def accept_challenges(li: lichess.Lichess, challenge_queue: MULTIPROCESSING_LIST_TYPE, active_games: set[str],
-                      max_games: int) -> None:
+def count_bot_games(active_games: dict[str, str]) -> int:
+    """Count active games whose opponent is known to be a bot."""
+    return sum(1 for name in active_games.values() if model.Player.is_bot_name(name))
+
+
+def accept_challenges(li: lichess.Lichess, challenge_queue: MULTIPROCESSING_LIST_TYPE, active_games: dict[str, str],
+                      max_games: int, max_bot_games: int) -> None:
     """Accept a challenge."""
     while len(active_games) < max_games and challenge_queue:
-        chlng = challenge_queue.pop(0)
+        chlng = challenge_queue[0]
         if chlng.from_self:
+            challenge_queue.pop(0)
             continue
 
+        # Reserve slots for humans: don't accept a bot challenge if doing so
+        # would exceed the bot-game limit, but keep looking for human ones.
+        if chlng.challenger.is_bot and count_bot_games(active_games) >= max_bot_games:
+            break
+
+        challenge_queue.pop(0)
         try:
             logger.info(f"Accept {chlng}")
             li.accept_challenge(chlng.id)
-            active_games.add(chlng.id)
+            active_games[chlng.id] = chlng.challenger.name
             log_proc_count("Queued", active_games)
         except (HTTPError, ReadTimeout) as exception:
             if isinstance(exception, HTTPError) and exception.response is not None and exception.response.status_code == 404:
@@ -549,9 +567,10 @@ def game_is_active(li: lichess.Lichess, game_id: str) -> bool:
     return game_id in (ongoing_game["gameId"] for ongoing_game in active_games)
 
 
-def start_game_thread(active_games: set[str], game_id: str, play_game_args: PlayGameArgsType, pool: POOL_TYPE) -> None:
+def start_game_thread(active_games: dict[str, str], game_id: str, opponent_name: str,
+                      play_game_args: PlayGameArgsType, pool: POOL_TYPE) -> None:
     """Start a game thread."""
-    active_games.add(game_id)
+    active_games[game_id] = opponent_name
     log_proc_count("Used", active_games)
     play_game_args["game_id"] = game_id
 
@@ -576,7 +595,7 @@ def start_game(event: EventType,
                config: Configuration,
                startup_correspondence_games: list[str],
                correspondence_queue: CORRESPONDENCE_QUEUE_TYPE,
-               active_games: set[str],
+               active_games: dict[str, str],
                low_time_games: list[GameType]) -> None:
     """
     Start a game.
@@ -600,7 +619,8 @@ def start_game(event: EventType,
             low_time_games.append(event["game"])
         startup_correspondence_games.remove(game_id)
     else:
-        start_game_thread(active_games, game_id, play_game_args, pool)
+        opponent_name = event["game"].get("opponent", {}).get("username", "")
+        start_game_thread(active_games, game_id, opponent_name, play_game_args, pool)
 
 
 def enough_time_to_queue(event: EventType, config: Configuration) -> bool:

--- a/lib/lichess_bot.py
+++ b/lib/lichess_bot.py
@@ -501,18 +501,6 @@ def start_low_time_games(low_time_games: list[GameType], active_games: dict[str,
         start_game_thread(active_games, game_id, opponent_name, play_game_args, pool)
 
 
-def count_bot_games(active_games: dict[str, str]) -> int:
-    """
-    Count active games whose opponent is known to be a bot.
-
-    Opponent names in `active_games` may be prefixed with a title (e.g.
-    "BOT sseh-c"), while `Player.bot_names` stores bare usernames. Compare the
-    bare username (the last whitespace-separated token) so the two match.
-    """
-    return sum(1 for name in active_games.values()
-               if model.Player.is_bot_name(name.split()[-1] if name else name))
-
-
 def accept_challenges(li: lichess.Lichess, challenge_queue: MULTIPROCESSING_LIST_TYPE, active_games: dict[str, str],
                       max_games: int, max_bot_games: int) -> None:
     """Accept a challenge."""
@@ -524,7 +512,7 @@ def accept_challenges(li: lichess.Lichess, challenge_queue: MULTIPROCESSING_LIST
 
         # Reserve slots for humans: don't accept a bot challenge if doing so
         # would exceed the bot-game limit, but keep looking for human ones.
-        if chlng.challenger.is_bot and count_bot_games(active_games) >= max_bot_games:
+        if chlng.challenger.is_bot and model.Player.count_bot_games(active_games) >= max_bot_games:
             break
 
         challenge_queue.pop(0)

--- a/lib/matchmaking.py
+++ b/lib/matchmaking.py
@@ -229,15 +229,18 @@ class Matchmaking:
         :param challenge_queue: The queue containing the challenges.
         :param max_bot_games: The maximum allowed number of simultaneous games against bots.
         """
-        max_games_for_matchmaking = (max_bot_games if self.matchmaking_cfg.allow_during_games
-                                     else min(1, max_bot_games))
+        # If matchmaking is not allowed while playing other games, don't create
+        # a challenge when any game (against a bot or a human) is in progress.
+        if not self.matchmaking_cfg.allow_during_games and active_games:
+            return
+
         # Count only games against bots: matchmaking only challenges bots, and
         # human games must not count toward the bot-game limit (otherwise a bot
         # whose slots are filled by humans would stop matchmaking even though
         # bot slots remain free).
         bot_game_count = (sum(1 for name in active_games.values() if model.Player.is_bot_name(name))
                           + len(challenge_queue))
-        if (bot_game_count >= max_games_for_matchmaking
+        if (bot_game_count >= max_bot_games
                 or (bot_game_count > 0 and self.last_challenge_created_delay.time_since_reset() < self.max_wait_time)
                 or not self.should_create_challenge()):
             return

--- a/lib/matchmaking.py
+++ b/lib/matchmaking.py
@@ -237,12 +237,8 @@ class Matchmaking:
         # Count only games against bots: matchmaking only challenges bots, and
         # human games must not count toward the bot-game limit (otherwise a bot
         # whose slots are filled by humans would stop matchmaking even though
-        # bot slots remain free). Opponent names may be title-prefixed (e.g.
-        # "BOT sseh-c") while bot_names holds bare usernames, so compare the
-        # bare username (the last whitespace-separated token).
-        bot_game_count = (sum(1 for name in active_games.values()
-                              if model.Player.is_bot_name(name.split()[-1] if name else name))
-                          + len(challenge_queue))
+        # bot slots remain free).
+        bot_game_count = model.Player.count_bot_games(active_games) + len(challenge_queue)
         if (bot_game_count >= max_bot_games
                 or (bot_game_count > 0 and self.last_challenge_created_delay.time_since_reset() < self.max_wait_time)
                 or not self.should_create_challenge()):

--- a/lib/matchmaking.py
+++ b/lib/matchmaking.py
@@ -231,9 +231,14 @@ class Matchmaking:
         """
         max_games_for_matchmaking = (max_bot_games if self.matchmaking_cfg.allow_during_games
                                      else min(1, max_bot_games))
-        game_count = len(active_games) + len(challenge_queue)
-        if (game_count >= max_games_for_matchmaking
-                or (game_count > 0 and self.last_challenge_created_delay.time_since_reset() < self.max_wait_time)
+        # Count only games against bots: matchmaking only challenges bots, and
+        # human games must not count toward the bot-game limit (otherwise a bot
+        # whose slots are filled by humans would stop matchmaking even though
+        # bot slots remain free).
+        bot_game_count = (sum(1 for name in active_games.values() if model.Player.is_bot_name(name))
+                          + len(challenge_queue))
+        if (bot_game_count >= max_games_for_matchmaking
+                or (bot_game_count > 0 and self.last_challenge_created_delay.time_since_reset() < self.max_wait_time)
                 or not self.should_create_challenge()):
             return
 

--- a/lib/matchmaking.py
+++ b/lib/matchmaking.py
@@ -220,15 +220,17 @@ class Matchmaking:
         value: str = config.lookup(parameter)
         return value if value != "random" else random.choice(choices)
 
-    def challenge(self, active_games: set[str], challenge_queue: MULTIPROCESSING_LIST_TYPE, max_games: int) -> None:
+    def challenge(self, active_games: dict[str, str], challenge_queue: MULTIPROCESSING_LIST_TYPE,
+                  max_bot_games: int) -> None:
         """
         Challenge an opponent.
 
-        :param active_games: The games that the bot is playing.
+        :param active_games: The games that the bot is playing (game ID -> opponent name).
         :param challenge_queue: The queue containing the challenges.
-        :param max_games: The maximum allowed number of simultaneous games.
+        :param max_bot_games: The maximum allowed number of simultaneous games against bots.
         """
-        max_games_for_matchmaking = max_games if self.matchmaking_cfg.allow_during_games else min(1, max_games)
+        max_games_for_matchmaking = (max_bot_games if self.matchmaking_cfg.allow_during_games
+                                     else min(1, max_bot_games))
         game_count = len(active_games) + len(challenge_queue)
         if (game_count >= max_games_for_matchmaking
                 or (game_count > 0 and self.last_challenge_created_delay.time_since_reset() < self.max_wait_time)

--- a/lib/matchmaking.py
+++ b/lib/matchmaking.py
@@ -237,8 +237,11 @@ class Matchmaking:
         # Count only games against bots: matchmaking only challenges bots, and
         # human games must not count toward the bot-game limit (otherwise a bot
         # whose slots are filled by humans would stop matchmaking even though
-        # bot slots remain free).
-        bot_game_count = (sum(1 for name in active_games.values() if model.Player.is_bot_name(name))
+        # bot slots remain free). Opponent names may be title-prefixed (e.g.
+        # "BOT sseh-c") while bot_names holds bare usernames, so compare the
+        # bare username (the last whitespace-separated token).
+        bot_game_count = (sum(1 for name in active_games.values()
+                              if model.Player.is_bot_name(name.split()[-1] if name else name))
                           + len(challenge_queue))
         if (bot_game_count >= max_bot_games
                 or (bot_game_count > 0 and self.last_challenge_created_delay.time_since_reset() < self.max_wait_time)

--- a/lib/model.py
+++ b/lib/model.py
@@ -5,6 +5,7 @@ import logging
 import datetime
 import chess
 from enum import Enum
+from typing import ClassVar
 from lib.blocklist import OnlineBlocklist
 from lib.timer import Timer, msec, seconds, sec_str, to_msec, to_seconds, years
 from lib.config import Configuration
@@ -308,6 +309,17 @@ class Game:
 class Player:
     """Store information about a player."""
 
+    # Names of players known to be bots. Populated as bot players are seen
+    # (from challenge and gameFull events, which carry the title) so that any
+    # part of lichess-bot can later tell whether a player is a bot given only
+    # their name -- e.g. in the gameStart event, which omits the title.
+    bot_names: ClassVar[set[str]] = set()
+
+    @classmethod
+    def is_bot_name(cls, name: str) -> bool:
+        """Whether a player name has been seen to belong to a bot."""
+        return name in cls.bot_names
+
     def __init__(self, player_info: PlayerType) -> None:
         """:param player_info: Contains information about a player."""
         self.title = player_info.get("title")
@@ -316,6 +328,8 @@ class Player:
         self.aiLevel = player_info.get("aiLevel")
         self.is_bot = self.title == "BOT" or self.aiLevel is not None
         self.name = f"AI level {self.aiLevel}" if self.aiLevel else player_info.get("name", "")
+        if self.is_bot and self.name:
+            Player.bot_names.add(self.name)
 
     def __str__(self) -> str:
         """Get a string representation of `Player`."""

--- a/lib/model.py
+++ b/lib/model.py
@@ -320,6 +320,18 @@ class Player:
         """Whether a player name has been seen to belong to a bot."""
         return name in cls.bot_names
 
+    @classmethod
+    def count_bot_games(cls, active_games: dict[str, str]) -> int:
+        """
+        Count active games whose opponent is known to be a bot.
+
+        Opponent names in `active_games` may be prefixed with a title (e.g.
+        "BOT sseh-c"), while `bot_names` holds bare usernames. Compare the bare
+        username (the last whitespace-separated token) so the two match.
+        """
+        return sum(1 for name in active_games.values()
+                   if cls.is_bot_name(name.split()[-1] if name else name))
+
     def __init__(self, player_info: PlayerType) -> None:
         """:param player_info: Contains information about a player."""
         self.title = player_info.get("title")

--- a/wiki/Configure-lichess-bot.md
+++ b/wiki/Configure-lichess-bot.md
@@ -173,6 +173,7 @@ will precede the `go` command to start thinking with `sd 5`. The other `go_comma
 ## Challenges the BOT should accept
 - `challenge`: Control what kind of games for which the bot should accept challenges. All of the following options must be satisfied by a challenge to be accepted.
   - `concurrency`: The maximum number of games to play simultaneously.
+  - `games_reserved_for_humans`: The number of game slots (out of `concurrency`) to keep open for human challengers. Bot challenges are limited to `concurrency` minus this value, so humans can still challenge the bot even when other bots are filling its games. Should be between 0 and `concurrency`. Works best with `preference` set to `"human"`.
   - `sort_by`: Whether to start games by the best rated/titled opponent `"best"` or by first-come-first-serve `"first"`.
   - `preference`: Whether to prioritize human opponents, bot opponents, or treat them equally.
   - `accept_bot`: Whether to accept challenges from other bots.


### PR DESCRIPTION
## Type of pull request:
- [ ] Bug fix
- [x] Feature
- [ ] Other

## Description:

Implements games_reserved_for_humans (#1212) — a setting that keeps a number of game slots free for human challengers so other bots can't occupy every slot. Following @MarkZH's suggested design: a Player.bot_names class registry (populated in Player.__init__ from challenge/gameFull events, with an is_bot_name() classmethod) lets the code identify a bot by name, working around the gameStart event omitting the title. active_games is now a dict[str, str] (game ID → opponent name) so bot vs. human games can be told apart. accept_challenges gates bot challenges against concurrency - games_reserved_for_humans while still accepting humans up to full concurrency, and Matchmaking.challenge (which only challenges bots) is capped at the same bot limit. Setting documented in config.yml.default and validated in config.py.

## Related Issues:

Closes #1212

## Checklist:

- [x] I have read and followed the [contribution guidelines](/docs/CONTRIBUTING.md).
- [x] I have added necessary documentation (if applicable).
- [x] The changes pass all existing tests.

## Screenshots/logs (if applicable):
