### PR TITLE
Skip maxed-out bots in matchmaking; log acceptance profile

### DIFF
--- a/lib/acceptance_profile.py
+++ b/lib/acceptance_profile.py
@@ -1,0 +1,45 @@
+"""Derive a machine-readable acceptance profile from the bot's challenge configuration.
+
+The profile summarizes which challenges this bot will accept, as declared in the
+`challenge:` section of the configuration file. It is logged at startup so bot
+operators can see at a glance what their bot accepts, and it matches the payload
+shape proposed for a future lichess `POST /api/bot/matchmaking/profile` endpoint
+(see https://github.com/lichess-org/lila server-side matchmaking pools proposal).
+"""
+import math
+from typing import Any
+
+from lib.config import Configuration
+
+
+def finite_or_none(value: float | int | None) -> float | int | None:
+    """Convert infinite config values (e.g. `max_days: .inf`) to None for JSON serialization."""
+    if value is None or (isinstance(value, float) and math.isinf(value)):
+        return None
+    return value
+
+
+def acceptance_profile(config: Configuration) -> dict[str, Any]:
+    """
+    Build the acceptance profile from the `challenge:` section of the config.
+
+    :param config: The bot's full configuration.
+    :return: A JSON-serializable dictionary describing which challenges the bot accepts.
+    """
+    challenge = config.challenge
+    return {"variants": list(challenge.variants or []),
+            "timeControls": list(challenge.time_controls or []),
+            "modes": list(challenge.modes or []),
+            "clock": {"initialMin": challenge.min_base,
+                      "initialMax": finite_or_none(challenge.max_base),
+                      "incrementMin": challenge.min_increment,
+                      "incrementMax": challenge.max_increment},
+            "days": {"min": finite_or_none(challenge.min_days),
+                     "max": finite_or_none(challenge.max_days)},
+            "ratingRange": {"min": challenge.min_rating,
+                            "max": challenge.max_rating},
+            "acceptBot": bool(challenge.accept_bot),
+            "onlyBot": bool(challenge.only_bot),
+            "concurrency": challenge.concurrency,
+            "hasAllowList": bool(challenge.allow_list),
+            "hasBlockList": bool(challenge.block_list or challenge.online_block_list)}

--- a/lib/acceptance_profile.py
+++ b/lib/acceptance_profile.py
@@ -1,4 +1,5 @@
-"""Derive a machine-readable acceptance profile from the bot's challenge configuration.
+"""
+Derive a machine-readable acceptance profile from the bot's challenge configuration.
 
 The profile summarizes which challenges this bot will accept, as declared in the
 `challenge:` section of the configuration file. It is logged at startup so bot
@@ -12,7 +13,7 @@ from typing import Any
 from lib.config import Configuration
 
 
-def finite_or_none(value: float | int | None) -> float | int | None:
+def finite_or_none(value: float | None) -> float | int | None:
     """Convert infinite config values (e.g. `max_days: .inf`) to None for JSON serialization."""
     if value is None or (isinstance(value, float) and math.isinf(value)):
         return None

--- a/lib/lichess_bot.py
+++ b/lib/lichess_bot.py
@@ -24,6 +24,7 @@ import glob
 import platform
 import importlib.metadata
 import contextlib
+from lib.acceptance_profile import acceptance_profile
 from lib.blocklist import OnlineBlocklist
 from lib.config import load_config, Configuration, log_config
 from lib.conversation import Conversation, ChatLine
@@ -256,6 +257,7 @@ def start(li: lichess.Lichess, user_profile: UserProfileType, config: Configurat
     :param one_game: Whether the bot should play only one game. Only used in `test_bot/test_bot.py` to test lichess-bot.
     """
     logger.info(f"You're now connected to {config.url} and awaiting challenges.")
+    logger.info(f"Challenge acceptance profile: {json.dumps(acceptance_profile(config))}")
     manager = multiprocessing.Manager()
     challenge_queue: MULTIPROCESSING_LIST_TYPE = manager.list()
     control_queue: CONTROL_QUEUE_TYPE = manager.Queue()

--- a/lib/lichess_types.py
+++ b/lib/lichess_types.py
@@ -51,6 +51,13 @@ class ProfileType(TypedDict, total=False):
     links: str
 
 
+class BotGamesType(TypedDict, total=False):
+    """Type hint for the daily bot-vs-bot game allowance status of a bot."""
+
+    maxedOut: bool
+    resetAt: str
+
+
 class UserProfileType(TypedDict, total=False):
     """Type hint for `user_profile`."""
 
@@ -71,6 +78,7 @@ class UserProfileType(TypedDict, total=False):
     blocking: bool
     followsYou: bool
     count: dict[str, int]
+    botGames: BotGamesType
 
 
 class ReadableType(TypedDict):

--- a/lib/matchmaking.py
+++ b/lib/matchmaking.py
@@ -11,7 +11,7 @@ from lib.lichess import Lichess, RateLimitedError
 from lib.config import Configuration
 from typing import cast, TypeAlias
 from lib.blocklist import OnlineBlocklist
-from lib.lichess_types import UserProfileType, PerfType, EventType, FilterType, ChallengeType
+from lib.lichess_types import UserProfileType, PerfType, EventType, FilterType, ChallengeType, BotGamesType
 MULTIPROCESSING_LIST_TYPE: TypeAlias = Sequence[model.Challenge]
 
 logger = logging.getLogger(__name__)
@@ -182,6 +182,7 @@ class Matchmaking:
             perf = bot.get("perfs", {}).get(game_type, {})
             return (bot["username"] != self.username()
                     and not self.in_block_list(bot["username"])
+                    and has_bot_games_remaining(bot)
                     and perf.get("games", 0) > 0
                     and min_rating <= perf.get("rating", 0) <= max_rating)
 
@@ -379,3 +380,19 @@ def game_category(variant: str, base_time: int, increment: int, num_days: int) -
     if game_duration < 1499:
         return "rapid"
     return "classical"
+
+
+def has_bot_games_remaining(bot: UserProfileType) -> bool:
+    """
+    Whether a bot can still play games against other bots today.
+
+    Lichess limits bots to 100 bot-vs-bot games per day. If the server marks a bot
+    as maxed out in the online bots listing (proposed `botGames` field), challenging
+    it is guaranteed to fail, so it is excluded from opponent selection. Bots without
+    the field are assumed to be available, so this is fully backward compatible.
+
+    :param bot: The user profile of the bot, as returned by the online bots endpoint.
+    :return: Whether the bot has bot-vs-bot games remaining today.
+    """
+    bot_games: BotGamesType = bot.get("botGames", {})
+    return not bot_games.get("maxedOut", False)

--- a/test_bot/test_acceptance_profile.py
+++ b/test_bot/test_acceptance_profile.py
@@ -1,0 +1,68 @@
+"""Test functions for the acceptance profile module."""
+import math
+
+from lib.acceptance_profile import acceptance_profile, finite_or_none
+from lib.config import Configuration
+
+
+def full_challenge_config() -> Configuration:
+    """Create a configuration with an explicit challenge section."""
+    return Configuration({
+        "challenge": {
+            "concurrency": 2,
+            "accept_bot": True,
+            "only_bot": False,
+            "max_increment": 20,
+            "min_increment": 0,
+            "max_base": 1800,
+            "min_base": 60,
+            "max_days": math.inf,
+            "min_days": 1,
+            "variants": ["standard", "chess960"],
+            "time_controls": ["bullet", "blitz"],
+            "modes": ["casual", "rated"],
+            "min_rating": 0,
+            "max_rating": 4000,
+            "block_list": [],
+            "online_block_list": [],
+            "allow_list": []
+        }
+    })
+
+
+def test_finite_or_none() -> None:
+    """Infinite and missing values become None; finite values pass through."""
+    assert finite_or_none(math.inf) is None
+    assert finite_or_none(None) is None
+    assert finite_or_none(14) == 14
+    assert finite_or_none(0) == 0
+
+
+def test_acceptance_profile_shape() -> None:
+    """The profile reflects the challenge config and is JSON serializable."""
+    import json
+
+    profile = acceptance_profile(full_challenge_config())
+    assert profile["variants"] == ["standard", "chess960"]
+    assert profile["timeControls"] == ["bullet", "blitz"]
+    assert profile["modes"] == ["casual", "rated"]
+    assert profile["clock"] == {"initialMin": 60, "initialMax": 1800, "incrementMin": 0, "incrementMax": 20}
+    assert profile["days"] == {"min": 1, "max": None}
+    assert profile["ratingRange"] == {"min": 0, "max": 4000}
+    assert profile["acceptBot"] is True
+    assert profile["onlyBot"] is False
+    assert profile["concurrency"] == 2
+    assert profile["hasAllowList"] is False
+    assert profile["hasBlockList"] is False
+    json.dumps(profile)  # Must not raise.
+
+
+def test_acceptance_profile_lists() -> None:
+    """Allow and block lists are exposed only as booleans, not contents."""
+    config = full_challenge_config()
+    config.config["challenge"]["allow_list"] = ["friendbot"]
+    config.config["challenge"]["online_block_list"] = ["example.com/blocklist"]
+    profile = acceptance_profile(config)
+    assert profile["hasAllowList"] is True
+    assert profile["hasBlockList"] is True
+    assert "friendbot" not in str(profile)

--- a/test_bot/test_matchmaking.py
+++ b/test_bot/test_matchmaking.py
@@ -1,6 +1,6 @@
 """Test functions for matchmaking module."""
 from unittest.mock import Mock
-from lib.matchmaking import game_category, Matchmaking
+from lib.matchmaking import game_category, has_bot_games_remaining, Matchmaking
 from lib.config import Configuration
 from lib.timer import Timer, seconds
 from lib.lichess_types import UserProfileType
@@ -246,3 +246,23 @@ def test_get_random_config_value__returns_from_choices_when_random() -> None:
     result = matchmaking.get_random_config_value(test_config, "challenge_mode", choices)
 
     assert result in choices, f"Expected result to be in {choices} but got '{result}'"
+
+
+def test_has_bot_games_remaining_without_field() -> None:
+    """Bots without the botGames field are assumed to have games remaining."""
+    bot: UserProfileType = {"username": "somebot", "perfs": {}}
+    assert has_bot_games_remaining(bot)
+
+
+def test_has_bot_games_remaining_maxed_out() -> None:
+    """Bots marked as maxed out by the server are excluded."""
+    bot: UserProfileType = {"username": "busybot",
+                            "perfs": {},
+                            "botGames": {"maxedOut": True, "resetAt": "2026-07-21T18:04:00Z"}}
+    assert not has_bot_games_remaining(bot)
+
+
+def test_has_bot_games_remaining_not_maxed_out() -> None:
+    """Bots with the botGames field but not maxed out remain available."""
+    bot: UserProfileType = {"username": "freshbot", "perfs": {}, "botGames": {"maxedOut": False}}
+    assert has_bot_games_remaining(bot)


### PR DESCRIPTION
## What this does

**1. Filter maxed-out bots out of opponent selection (forward-compatible).**
Lichess limits bots to 100 bot-vs-bot games per rolling day (`lila` `BotLimit.scala`). Today, a capped bot stays listed in `/api/bot/online`, so every matchmaking bot burns a failed challenge (and its cooldown) discovering the cap — one bot at a time, per day. This PR adds `has_bot_games_remaining()` to `lib/matchmaking.py`, excluding any bot whose online-bots entry carries a proposed `botGames: {maxedOut: true, resetAt: ...}` field. Bots without the field are treated as available, so behaviour is unchanged until lila ships the field (RFC issue on lichess-org/lila here: https://github.com/lichess-org/lila/issues/21015.)

**2. Log the bot's challenge acceptance profile at startup.**
New `lib/acceptance_profile.py` derives a JSON summary of the `challenge:` config section (variants, time controls, modes, clock/day bounds, rated/casual, concurrency) and logs it on connect. Helps operators see at a glance what their bot accepts, and matches the payload shape proposed for a future server-side matchmaking-profile endpoint. Allow/block lists are exposed only as booleans, never contents.

## Changes

- `lib/matchmaking.py`: `has_bot_games_remaining()` + one extra condition in `is_suitable_opponent`
- `lib/lichess_types.py`: `BotGamesType` TypedDict, `botGames` field on `UserProfileType`
- `lib/acceptance_profile.py`: new module
- `lib/lichess_bot.py`: one startup log line
- Tests: `test_bot/test_acceptance_profile.py` (new), 3 new cases in `test_bot/test_matchmaking.py`

## Testing

- `pytest test_bot/test_matchmaking.py test_bot/test_acceptance_profile.py test_bot/test_config.py` — 25 passed
- `mypy lib/` — clean
- `ruff check lib test_bot` — clean