### PR TITLE
Add test coverage for pondering

### DIFF
--- a/test_bot/ponder_engine.py
+++ b/test_bot/ponder_engine.py
@@ -1,0 +1,57 @@
+"""An engine that mimics a UCI engine that supports pondering."""
+
+import chess
+import typing
+
+if typing.TYPE_CHECKING:
+    from test_bot.test_games import scholars_mate
+else:
+    from test_games import scholars_mate
+
+assert input() == "uci"
+
+
+def send_command(command: str) -> None:
+    """Send UCI commands to lichess-bot without output buffering."""
+    print(command, flush=True)  # noqa: T201 (print() found)
+
+
+def bestmove_command(board: chess.Board) -> str:
+    """Choose the next scripted move and predict the opponent's reply for pondering."""
+    move_count = len(board.move_stack)
+    command = f"bestmove {scholars_mate[move_count]}"
+    if move_count + 1 < len(scholars_mate):
+        command += f" ponder {scholars_mate[move_count + 1]}"
+    return command
+
+
+send_command("id name UCI_Ponder_Test_Bot")
+send_command("id author lichess-bot-devs")
+send_command("uciok")
+
+board = chess.Board()
+pondering = False
+while True:
+    command, *remaining = input().split()
+    if command == "quit":
+        break
+    elif command == "isready":
+        send_command("readyok")
+    elif command == "position":
+        spec_type, *remaining = remaining
+        assert spec_type == "startpos"
+        board = chess.Board()
+        if remaining:
+            moves_label, *move_list = remaining
+            assert moves_label == "moves"
+            for move in move_list:
+                board.push_uci(move)
+    elif command == "go":
+        if "ponder" in remaining:
+            # Search quietly until "ponderhit" or "stop" arrives.
+            pondering = True
+        else:
+            send_command(bestmove_command(board))
+    elif command in ("ponderhit", "stop") and pondering:
+        pondering = False
+        send_command(bestmove_command(board))

--- a/test_bot/ponder_engine.py
+++ b/test_bot/ponder_engine.py
@@ -1,6 +1,7 @@
 """An engine that mimics a UCI engine that supports pondering."""
 
 import chess
+import sys
 import typing
 
 if typing.TYPE_CHECKING:
@@ -8,12 +9,21 @@ if typing.TYPE_CHECKING:
 else:
     from test_games import scholars_mate
 
+# lichess-bot turns the engine_options config into "--name=value" arguments.
+command_log = sys.argv[1].removeprefix("--command-log=")
+
 assert input() == "uci"
 
 
 def send_command(command: str) -> None:
     """Send UCI commands to lichess-bot without output buffering."""
     print(command, flush=True)  # noqa: T201 (print() found)
+
+
+def record_command(command: str) -> None:
+    """Record a search command so that the test can see which branches of this engine ran."""
+    with open(command_log, "a") as log:
+        log.write(f"{command}\n")
 
 
 def bestmove_command(board: chess.Board) -> str:
@@ -49,9 +59,12 @@ while True:
     elif command == "go":
         if "ponder" in remaining:
             # Search quietly until "ponderhit" or "stop" arrives.
+            record_command("go ponder")
             pondering = True
         else:
+            record_command("go")
             send_command(bestmove_command(board))
     elif command in ("ponderhit", "stop") and pondering:
+        record_command(command)
         pondering = False
         send_command(bestmove_command(board))

--- a/test_bot/slow_ponder_engine.py
+++ b/test_bot/slow_ponder_engine.py
@@ -1,0 +1,63 @@
+"""An engine that predicts the opponent's moves badly and is slow to end its ponder searches."""
+
+import chess
+import time
+import typing
+
+if typing.TYPE_CHECKING:
+    from test_bot.test_games import scholars_mate
+else:
+    from test_games import scholars_mate
+
+assert input() == "uci"
+
+
+def send_command(command: str) -> None:
+    """Send UCI commands to lichess-bot without output buffering."""
+    print(command, flush=True)  # noqa: T201 (print() found)
+
+
+def bestmove_command(board: chess.Board) -> str:
+    """Choose the next scripted move and predict an opponent reply that will never be played."""
+    move_count = len(board.move_stack)
+    command = f"bestmove {scholars_mate[move_count]}"
+    if move_count + 1 < len(scholars_mate):
+        command += " ponder h2h3"
+    return command
+
+
+send_command("id name Slow_Ponder_Bot")
+send_command("id author lichess-bot-devs")
+send_command("uciok")
+
+delay_performed = False
+board = chess.Board()
+pondering = False
+while True:
+    command, *remaining = input().split()
+    if command == "quit":
+        break
+    elif command == "isready":
+        send_command("readyok")
+    elif command == "position":
+        spec_type, *remaining = remaining
+        assert spec_type == "startpos"
+        board = chess.Board()
+        if remaining:
+            moves_label, *move_list = remaining
+            assert moves_label == "moves"
+            for move in move_list:
+                board.push_uci(move)
+    elif command == "go":
+        if "ponder" in remaining:
+            # Search quietly until "ponderhit" or "stop" arrives.
+            pondering = True
+        else:
+            send_command(bestmove_command(board))
+    elif command in ("ponderhit", "stop") and pondering:
+        pondering = False
+        if not delay_performed:
+            send_command("info string delaying end of ponder search")
+            delay_performed = True
+            time.sleep(2)
+        send_command(bestmove_command(board))

--- a/test_bot/slow_ponder_engine.py
+++ b/test_bot/slow_ponder_engine.py
@@ -1,6 +1,7 @@
 """An engine that predicts the opponent's moves badly and is slow to end its ponder searches."""
 
 import chess
+import sys
 import time
 import typing
 
@@ -9,12 +10,21 @@ if typing.TYPE_CHECKING:
 else:
     from test_games import scholars_mate
 
+# lichess-bot turns the engine_options config into "--name=value" arguments.
+command_log = sys.argv[1].removeprefix("--command-log=")
+
 assert input() == "uci"
 
 
 def send_command(command: str) -> None:
     """Send UCI commands to lichess-bot without output buffering."""
     print(command, flush=True)  # noqa: T201 (print() found)
+
+
+def record_command(command: str) -> None:
+    """Record a search command so that the test can see which branches of this engine ran."""
+    with open(command_log, "a") as log:
+        log.write(f"{command}\n")
 
 
 def bestmove_command(board: chess.Board) -> str:
@@ -51,10 +61,13 @@ while True:
     elif command == "go":
         if "ponder" in remaining:
             # Search quietly until "ponderhit" or "stop" arrives.
+            record_command("go ponder")
             pondering = True
         else:
+            record_command("go")
             send_command(bestmove_command(board))
     elif command in ("ponderhit", "stop") and pondering:
+        record_command(command)
         pondering = False
         if not delay_performed:
             send_command("info string delaying end of ponder search")

--- a/test_bot/test_bot.py
+++ b/test_bot/test_bot.py
@@ -139,6 +139,27 @@ def test_uci() -> None:
                                            "bo vs b - zzzzzzzz.pgn"))
 
 
+def test_uci_ponder() -> None:
+    """Test lichess-bot with a UCI engine that supports pondering."""
+    with open("./config.yml.default") as file:
+        CONFIG = yaml.safe_load(file)
+
+    with tempfile.TemporaryDirectory() as temp:
+        CONFIG["token"] = ""
+        CONFIG["engine"]["dir"] = "test_bot"
+        CONFIG["engine"]["name"] = "ponder_engine.py"
+        CONFIG["engine"]["ponder"] = True
+        CONFIG["engine"]["interpreter"] = sys.executable
+        CONFIG["pgn_directory"] = os.path.join(temp, "ponder_game_record")
+        CONFIG["engine"]["uci_options"] = {}
+        win = run_bot(CONFIG, logging_level)
+        logger.info("Finished Testing UCI with pondering")
+        assert win
+        time.sleep(0.1)  # Wait for file to be written.
+        assert os.path.isfile(os.path.join(CONFIG["pgn_directory"],
+                                           "bo vs b - zzzzzzzz.pgn"))
+
+
 def test_xboard() -> None:
     """Test lichess-bot with an XBoard engine."""
     with open("./config.yml.default") as file:
@@ -191,6 +212,27 @@ def test_buggy_engine() -> None:
         CONFIG["pgn_directory"] = os.path.join(temp, "bug_game_record")
         win = run_bot(CONFIG, logging_level)
         logger.info("Finished Testing Buggy Engine")
+        assert win
+        time.sleep(0.1)  # Wait for file to be written.
+        assert os.path.isfile(os.path.join(CONFIG["pgn_directory"],
+                                           "bo vs b - zzzzzzzz.pgn"))
+
+
+def test_slow_ponder_engine() -> None:
+    """Test lichess-bot with an engine whose ponder searches always miss and are slow to stop."""
+    with open("./config.yml.default") as file:
+        CONFIG = yaml.safe_load(file)
+
+    with tempfile.TemporaryDirectory() as temp:
+        CONFIG["token"] = ""
+        CONFIG["engine"]["dir"] = "test_bot"
+        CONFIG["engine"]["name"] = "slow_ponder_engine.py"
+        CONFIG["engine"]["ponder"] = True
+        CONFIG["engine"]["interpreter"] = sys.executable
+        CONFIG["pgn_directory"] = os.path.join(temp, "slow_ponder_game_record")
+        CONFIG["engine"]["uci_options"] = {}
+        win = run_bot(CONFIG, logging_level)
+        logger.info("Finished Testing Slow Ponder Engine")
         assert win
         time.sleep(0.1)  # Wait for file to be written.
         assert os.path.isfile(os.path.join(CONFIG["pgn_directory"],

--- a/test_bot/test_bot.py
+++ b/test_bot/test_bot.py
@@ -119,6 +119,20 @@ def run_bot(raw_config: CONFIG_DICT_TYPE, logging_level: int) -> bool:
     return result
 
 
+def engine_search_commands(command_log: str) -> list[str]:
+    """
+    Read back the search commands that a ponder test engine recorded while it played.
+
+    Each entry is written by the engine branch that handled the command, so the list shows which
+    branches actually ran: "go" for a normal search, "go ponder" for a ponder search, and
+    "ponderhit" or "stop" for how that ponder search ended.
+
+    :param command_log: The path that was given to the engine with the --command-log option.
+    """
+    with open(command_log) as log:
+        return log.read().splitlines()
+
+
 def test_uci() -> None:
     """Test lichess-bot with Stockfish (UCI)."""
     with open("./config.yml.default") as file:
@@ -152,9 +166,14 @@ def test_uci_ponder() -> None:
         CONFIG["engine"]["interpreter"] = sys.executable
         CONFIG["pgn_directory"] = os.path.join(temp, "ponder_game_record")
         CONFIG["engine"]["uci_options"] = {}
+        command_log = os.path.join(temp, "ponder_commands.txt")
+        CONFIG["engine"]["engine_options"] = {"command-log": command_log}
         win = run_bot(CONFIG, logging_level)
         logger.info("Finished Testing UCI with pondering")
         assert win
+        # The bot never ponders after its first move and the engine offers no ponder move along with
+        # its mating move, so the two middle moves are the ones that ponder, and both guesses are right.
+        assert engine_search_commands(command_log) == ["go", "go", "go ponder", "ponderhit", "go ponder", "ponderhit"]
         time.sleep(0.1)  # Wait for file to be written.
         assert os.path.isfile(os.path.join(CONFIG["pgn_directory"],
                                            "bo vs b - zzzzzzzz.pgn"))
@@ -231,9 +250,13 @@ def test_slow_ponder_engine() -> None:
         CONFIG["engine"]["interpreter"] = sys.executable
         CONFIG["pgn_directory"] = os.path.join(temp, "slow_ponder_game_record")
         CONFIG["engine"]["uci_options"] = {}
+        command_log = os.path.join(temp, "slow_ponder_commands.txt")
+        CONFIG["engine"]["engine_options"] = {"command-log": command_log}
         win = run_bot(CONFIG, logging_level)
         logger.info("Finished Testing Slow Ponder Engine")
         assert win
+        # Every ponder guess is wrong, so each ponder search is stopped and replaced by a real search.
+        assert engine_search_commands(command_log) == ["go", "go", "go ponder", "stop", "go", "go ponder", "stop", "go"]
         time.sleep(0.1)  # Wait for file to be written.
         assert os.path.isfile(os.path.join(CONFIG["pgn_directory"],
                                            "bo vs b - zzzzzzzz.pgn"))


### PR DESCRIPTION
The test suite enables `ponder: true` via `config.yml.default`, but none of the test engines ever return a ponder move, so python-chess never starts a ponder search — `go ponder`, `ponderhit`, and the `stop` wind-down are never exercised by any test.

This matters in practice: pondering produces unusually tight command timing (a `position`/`go ponder` pair arrives immediately after the engine emits `bestmove`, and `ponderhit` arrives with no preceding `position`). We recently debugged a production bot whose engine had a race in exactly that window — commands arriving right after `bestmove` were occasionally dropped, causing silent forfeits on time. The current suite structurally can't catch that class of bug for any engine author.

This PR adds two tests following the existing conventions in `test_bot/`:

* `test_uci_ponder` with `ponder_engine.py` (modeled on `uci_engine.py`): predicts the opponent's scripted moves correctly, so every ponder search ends in a `ponderhit`. It responds to commands immediately, so the tight post-`bestmove` timing is exercised for real.
* `test_slow_ponder_engine` with `slow_ponder_engine.py` (in the spirit of `buggy_engine.py`): always predicts a move that is never played and is slow to react to the resulting `stop`, verifying a ponder miss and a sluggish ponder wind-down don't deadlock the game or lose on time.

Both games still end in the scripted scholar's-mate win and PGN write. `pytest`, `ruff check --config test_bot/ruff.toml`, and `mypy --strict .` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)