### PR TITLE
Don't let a failed chat message cancel the move the engine owes

### DIFF
--- a/lib/lichess.py
+++ b/lib/lichess.py
@@ -390,9 +390,17 @@ class Lichess:
             logger.warning(f"This chat message is {len(text)} characters, which is longer "
                            f"than the maximum of {MAX_CHAT_MESSAGE_LEN}. It will not be sent.")
             logger.warning(f"Message: {text}")
+            return
 
         data = {"room": room, "text": text}
-        self.api_post("chat", game_id, data=data)
+        try:
+            self.api_post("chat", game_id, data=data)
+        except (HTTPError, ReadTimeout, RemoteDisconnected, RequestsConnectionError) as e:
+            # Chat is cosmetic. A failed chat message must never propagate an
+            # exception into the game loop, where it would cancel the move the
+            # engine owes (the state that prompted the move has already been
+            # consumed from the game stream, so the move would never be made).
+            logger.warning(f"Could not send chat message to the {room} room of game {game_id}: {e}")
 
     def abort(self, game_id: str) -> None:
         """Aborts a game."""

--- a/lib/lichess.py
+++ b/lib/lichess.py
@@ -396,10 +396,6 @@ class Lichess:
         try:
             self.api_post("chat", game_id, data=data)
         except (HTTPError, ReadTimeout, RemoteDisconnected, RequestsConnectionError) as e:
-            # Chat is cosmetic. A failed chat message must never propagate an
-            # exception into the game loop, where it would cancel the move the
-            # engine owes (the state that prompted the move has already been
-            # consumed from the game stream, so the move would never be made).
             logger.warning(f"Could not send chat message to the {room} room of game {game_id}: {e}")
 
     def abort(self, game_id: str) -> None:

--- a/test_bot/test_lichess.py
+++ b/test_bot/test_lichess.py
@@ -66,7 +66,7 @@ def test_over_long_chat_message_is_not_sent() -> None:
     def record_api_post(path: str, *_args: object, **_kwargs: object) -> None:
         posted.append(path)
 
-    li.api_post = record_api_post  # type: ignore[method-assign, assignment]
+    li.api_post = record_api_post  # type: ignore[assignment]
 
     li.chat("game_id", "player", "x" * (lichess.MAX_CHAT_MESSAGE_LEN + 1))
 

--- a/test_bot/test_lichess.py
+++ b/test_bot/test_lichess.py
@@ -3,6 +3,7 @@
 from lib import lichess
 from lib.timer import Timer, seconds
 from collections import defaultdict
+from requests.exceptions import HTTPError
 from requests.models import Response
 import logging
 import os
@@ -55,6 +56,33 @@ def test_challenge_429_without_retry_after_uses_exponential_backoff() -> None:
     assert first_response["rate_limit_timeout"] == seconds(60)
     assert second_response["rate_limit_timeout"] == seconds(120)
     assert li.challenge_rate_limit_backoff == seconds(240)
+
+
+def test_over_long_chat_message_is_not_sent() -> None:
+    """A message longer than the limit is rejected by lichess, so it must not be sent at all."""
+    li = lichess_without_init()
+    posted: list[str] = []
+
+    def record_api_post(path: str, *_args: object, **_kwargs: object) -> None:
+        posted.append(path)
+
+    li.api_post = record_api_post  # type: ignore[method-assign, assignment]
+
+    li.chat("game_id", "player", "x" * (lichess.MAX_CHAT_MESSAGE_LEN + 1))
+
+    assert posted == []
+
+
+def test_failed_chat_message_does_not_raise() -> None:
+    """Chat is cosmetic: a failed chat message must never interrupt the game it was sent from."""
+    li = lichess_without_init()
+
+    def failing_api_post(*_args: object, **_kwargs: object) -> None:
+        raise HTTPError("400 Client Error")
+
+    li.api_post = failing_api_post  # type: ignore[method-assign]
+
+    li.chat("game_id", "player", "Good luck!")
 
 
 def test_lichess() -> None:


### PR DESCRIPTION
## Type of pull request:
- [x] Bug fix
- [ ] Feature
- [ ] Other

## Description:

This PR originally bundled three unrelated production fixes. I have split it: it now contains only the chat fix, and the other two are #1241 (games past `challenge.concurrency` sit unplayed) and #1242 (the event stream goes silent and the bot never notices). The three are independent and can be reviewed, changed or merged in any order. Nothing had been reviewed yet, so nothing is lost by the restructuring — apologies for the churn.

### The failure

We run two bots, sunfish-engine and sunfish-nnue-engine, with a greeting configured that turned out to be longer than 140 characters. Lichess answered 400 to the chat POST on every greeted game.

`chat()` logged that an over-long message "will not be sent" and then sent it anyway. The resulting `HTTPError` propagated out of `say_hello()` into `play_game()`'s stream loop — after the game state that prompted the engine's move had already been consumed from the stream. The move was never made, and the state that would have prompted it was gone. Every greeted game died the same way, aborted by lichess "by lack of activity": <https://lichess.org/h4tDwluR>, <https://lichess.org/ZbT4vfAs>.

The over-long greeting is our own misconfiguration. The bug is that a cosmetic chat message could cancel the move the engine owed.

### What changed

Two changes in `chat()`, nine lines:

* An over-long message is now actually skipped — the existing warning ends with a `return` instead of falling through to the POST.
* Request errors are caught in `chat()` itself. Chat is cosmetic; it must never propagate an exception into the game loop.

The second change is the one that matters, and it holds for any chat failure, not just the over-long case: a flaky connection at the moment the bot says "Good luck!" should not cost it the game.

## Related Issues:

None.

## Checklist:

- [x] I have read and followed the [contribution guidelines](/docs/CONTRIBUTING.md).
- [x] I have added necessary documentation (if applicable).
- [x] The changes pass all existing tests.

## Screenshots/logs (if applicable):

Verification on this branch, rebased on current master:

* `pytest` — 55 passed, 1 skipped (`test_lichess`, which needs `LICHESS_BOT_TEST_TOKEN`). Two of those are new, in `test_bot/test_lichess.py`: an over-long message is not POSTed, and a failing POST does not raise. Both fail before the change and pass after.
* `ruff check --config test_bot/ruff.toml` — clean.
* `mypy --strict .` — clean.
* Running in production on both bots since 2026-08-11.

Happy to restructure this to your preference — for instance if you would rather have the exception caught in `say_hello()`/`Conversation` than in `chat()`, or want the caught exception list narrowed or widened.
