### PR TITLE
Abort games that exceed challenge.concurrency instead of queuing them

### DIFF
--- a/lib/lichess_bot.py
+++ b/lib/lichess_bot.py
@@ -344,6 +344,7 @@ def lichess_bot_main(li: lichess.Lichess,
     max_games = config.challenge.concurrency
     reserved_for_humans = min(config.challenge.games_reserved_for_humans, max_games)
     max_bot_games = max_games - reserved_for_humans
+    games_in_progress.clear()  # A restart abandons the old pool and the games it was playing.
 
     one_game_completed = False
 
@@ -387,6 +388,7 @@ def lichess_bot_main(li: lichess.Lichess,
 
             if event["type"] == "local_game_done":
                 active_games.pop(event["game"]["id"], None)
+                games_in_progress.discard(event["game"]["id"])
                 matchmaker.game_done()
                 log_proc_count("Freed", active_games)
                 one_game_completed = True
@@ -422,7 +424,8 @@ def lichess_bot_main(li: lichess.Lichess,
                                              play_game_args,
                                              active_games,
                                              max_games)
-            accept_challenges(li, challenge_queue, active_games, max_games, max_bot_games)
+            accept_challenges(li, challenge_queue, active_games, max_games, max_bot_games,
+                              int(bool(matchmaker.challenge_id)))
             matchmaker.challenge(active_games, challenge_queue, max_bot_games)
             check_online_status(li, user_profile, last_check_online_time)
 
@@ -487,7 +490,7 @@ def check_in_on_correspondence_games(pool: POOL_TYPE,
         correspondence_games_to_start -= 1
         correspondence_queue.task_done()
         opponent_name = event["game"].get("opponent", {}).get("username", "")
-        start_game_thread(active_games, game_id, opponent_name, play_game_args, pool)
+        start_game_thread(active_games, game_id, opponent_name, play_game_args, pool, max_games)
 
 
 def start_low_time_games(low_time_games: list[GameType], active_games: dict[str, str], max_games: int,
@@ -498,13 +501,19 @@ def start_low_time_games(low_time_games: list[GameType], active_games: dict[str,
         low_time_game = low_time_games.pop(0)
         game_id = low_time_game["id"]
         opponent_name = low_time_game.get("opponent", {}).get("username", "")
-        start_game_thread(active_games, game_id, opponent_name, play_game_args, pool)
+        start_game_thread(active_games, game_id, opponent_name, play_game_args, pool, max_games)
 
 
 def accept_challenges(li: lichess.Lichess, challenge_queue: MULTIPROCESSING_LIST_TYPE, active_games: dict[str, str],
-                      max_games: int, max_bot_games: int) -> None:
-    """Accept a challenge."""
-    while len(active_games) < max_games and challenge_queue:
+                      max_games: int, max_bot_games: int, pending_outgoing_challenges: int = 0) -> None:
+    """
+    Accept a challenge.
+
+    :param pending_outgoing_challenges: The number of not-yet-answered challenges this bot has sent (matchmaking).
+        Each one reserves a game slot: if the opponent accepts it while we also accept an incoming challenge,
+        more games than `challenge.concurrency` start at once.
+    """
+    while len(active_games) + pending_outgoing_challenges < max_games and challenge_queue:
         chlng = challenge_queue[0]
         if chlng.from_self:
             challenge_queue.pop(0)
@@ -562,9 +571,53 @@ def game_is_active(li: lichess.Lichess, game_id: str) -> bool:
     return game_id in (ongoing_game["gameId"] for ongoing_game in active_games)
 
 
+# The games that currently hold a process in the pool. This differs from
+# `active_games`, which also counts accepted challenges whose game has not
+# started yet.
+games_in_progress: set[str] = set()
+
+
+def abort_overflow_game(li: lichess.Lichess, game_id: str, active_games: dict[str, str], max_games: int) -> None:
+    """
+    Abort a game that started while every process in the pool is busy, and free its slot.
+
+    :param li: Provides communication with lichess.org.
+    :param game_id: The id of the game that has no process to play it.
+    :param active_games: A dict mapping active game IDs to opponent names.
+    :param max_games: The maximum number of simultaneous games (`challenge.concurrency`).
+    """
+    logger.warning(f"Aborting game {game_id}: already playing {max_games} game(s), the limit set by "
+                   "challenge.concurrency. An aborted game is unrated and harmless, a game left to sit "
+                   "unplayed until lichess abandons it is not.")
+    try:
+        li.abort(game_id)
+    except (HTTPError, ReadTimeout, RemoteDisconnected, RequestsConnectionError) as e:
+        # Lichess only refuses an abort once a game has moves, so this game has
+        # moves that lichess-bot never made. Do not play it: it would share the
+        # host with the games already running. Do not resign it either: if
+        # another client is playing on this account, resigning throws away that
+        # client's live game. Leave it alone and say so loudly.
+        logger.error(f"Could not abort game {game_id} ({e}). Lichess refuses to abort a game that has moves, "
+                     "so this game has moves lichess-bot never made -- another client is probably playing on "
+                     f"this account. Leaving game {game_id} alone.")
+    active_games.pop(game_id, None)
+    log_proc_count("Freed", active_games)
+
+
 def start_game_thread(active_games: dict[str, str], game_id: str, opponent_name: str,
-                      play_game_args: PlayGameArgsType, pool: POOL_TYPE) -> None:
-    """Start a game thread."""
+                      play_game_args: PlayGameArgsType, pool: POOL_TYPE, max_games: int) -> None:
+    """Start a game thread, or abort the game if no process in the pool is free to play it."""
+    if len(games_in_progress) >= max_games and game_id not in games_in_progress:
+        # Races when games start -- an opponent accepting an outgoing matchmaking
+        # challenge just as an incoming challenge is accepted, or games replayed
+        # after a reconnect -- can start more games than `challenge.concurrency`.
+        # Such a game must not be quietly queued behind the games already holding
+        # the pool's processes: it would sit unplayed until lichess abandons it,
+        # with the bot online but never moving.
+        abort_overflow_game(play_game_args["li"], game_id, active_games, max_games)
+        return
+
+    games_in_progress.add(game_id)
     active_games[game_id] = opponent_name
     log_proc_count("Used", active_games)
     play_game_args["game_id"] = game_id
@@ -615,7 +668,7 @@ def start_game(event: EventType,
         startup_correspondence_games.remove(game_id)
     else:
         opponent_name = event["game"].get("opponent", {}).get("username", "")
-        start_game_thread(active_games, game_id, opponent_name, play_game_args, pool)
+        start_game_thread(active_games, game_id, opponent_name, play_game_args, pool, config.challenge.concurrency)
 
 
 def enough_time_to_queue(event: EventType, config: Configuration) -> bool:

--- a/test_bot/test_start_game.py
+++ b/test_bot/test_start_game.py
@@ -1,0 +1,91 @@
+"""Tests for starting games without exceeding challenge.concurrency."""
+
+from lib import lichess_bot
+from lib.lichess_bot import PlayGameArgsType
+from collections.abc import Iterator
+from requests.exceptions import HTTPError
+from typing import cast
+import pytest
+
+
+class MockLichess:
+    """A stand-in for `lichess.Lichess` that records abort attempts."""
+
+    def __init__(self, abort_error: Exception | None = None) -> None:
+        """Create a mock lichess connection whose abort() raises `abort_error`, if given."""
+        self.aborted: list[str] = []
+        self.abort_error = abort_error
+
+    def abort(self, game_id: str) -> None:
+        """Record the abort attempt, and fail it if the test asked for a failure."""
+        self.aborted.append(game_id)
+        if self.abort_error is not None:
+            raise self.abort_error
+
+
+class MockPool:
+    """A stand-in for the process pool that records the games handed to it."""
+
+    def __init__(self) -> None:
+        """Create a mock pool that has been given no games."""
+        self.games: list[str] = []
+
+    def apply_async(self, func: object, kwds: PlayGameArgsType, error_callback: object) -> None:  # noqa: ARG002
+        """Record the game that would have been played in a pool process."""
+        self.games.append(kwds["game_id"])
+
+
+@pytest.fixture(autouse=True)
+def _empty_games_in_progress() -> Iterator[None]:
+    """Start and leave every test with no game holding a pool process."""
+    lichess_bot.games_in_progress.clear()
+    yield
+    lichess_bot.games_in_progress.clear()
+
+
+def start_game(li: MockLichess, pool: MockPool, active_games: dict[str, str], game_id: str, max_games: int) -> None:
+    """Call `start_game_thread()` with mock lichess and pool objects."""
+    play_game_args = cast(PlayGameArgsType, {"li": li})
+    lichess_bot.start_game_thread(active_games, game_id, "opponent", play_game_args,
+                                  cast(lichess_bot.POOL_TYPE, pool), max_games)
+
+
+def test_game_within_the_concurrency_limit_is_played() -> None:
+    """A game that can get a pool process is played, not aborted."""
+    li, pool = MockLichess(), MockPool()
+    active_games = {"first_game": "opponent"}
+    lichess_bot.games_in_progress.add("first_game")
+
+    start_game(li, pool, active_games, "second_game", 2)
+
+    assert pool.games == ["second_game"]
+    assert li.aborted == []
+    assert active_games["second_game"] == "opponent"
+
+
+def test_game_beyond_the_concurrency_limit_is_aborted() -> None:
+    """A game with no free pool process is aborted instead of waiting for one."""
+    li, pool = MockLichess(), MockPool()
+    active_games = {"first_game": "opponent"}
+    lichess_bot.games_in_progress.add("first_game")
+
+    start_game(li, pool, active_games, "second_game", 1)
+
+    assert li.aborted == ["second_game"]
+    assert pool.games == []
+    assert "second_game" not in active_games
+    assert "second_game" not in lichess_bot.games_in_progress
+
+
+def test_overflow_game_that_cannot_be_aborted_is_left_alone() -> None:
+    """Lichess refuses to abort a game with moves, but such a game must not be played or resigned either."""
+    li, pool = MockLichess(HTTPError("400 Client Error")), MockPool()
+    active_games = {"first_game": "opponent"}
+    lichess_bot.games_in_progress.add("first_game")
+
+    start_game(li, pool, active_games, "second_game", 1)
+
+    assert li.aborted == ["second_game"]
+    assert pool.games == []
+    assert "second_game" not in active_games
+    assert "second_game" not in lichess_bot.games_in_progress


### PR DESCRIPTION
## Type of pull request:
- [x] Bug fix
- [ ] Feature
- [ ] Other

## Description:

Split out of #1240, which bundled three unrelated production fixes into one PR. The three are independent and can be reviewed, changed or merged in any order. See also #1240 (a failed chat message cancels the move the engine owes) and #1242 (the event stream goes silent and the bot never notices).

### The failure

`start_game_thread()` hands every game to the multiprocessing pool, whose size is `challenge.concurrency` (+1). `accept_challenges()` respects that limit, but bare `gameStart` events bypass it: an opponent accepting one of our outgoing matchmaking challenges just as an incoming challenge is accepted, or games replayed on reconnect. The extra game is then queued behind the games already holding the pool's processes and sits there unplayed until lichess abandons it. The bot is online, its clock is running, and it never moves. We hit this repeatedly running two bots on one host.

### What changed

* `games_in_progress` tracks which games actually hold a pool process. This is not the same set as `active_games`, which also counts accepted challenges whose game has not started yet.
* When a game starts and no process is free, it is aborted immediately. An aborted game is unrated and harmless; a game left to sit until lichess abandons it is neither.
* `accept_challenges()` gains a `pending_outgoing_challenges` argument, so an unanswered outgoing matchmaking challenge reserves a game slot. That closes the race at the source in the common case; the abort is the backstop for the rest.

### The abort-refused path, and why it does nothing

This is the part we got wrong twice in production, so it is worth spelling out.

Lichess answers 400 to an abort once the game has moves. The first version of this patch fell back to **playing** the overflow game with the pool's reserve process. In production that slow-served two games on one core — exactly the harm the concurrency limit exists to prevent.

The second version **resigned** it instead. That was worse. It resigned two games that were alive and going fine — <https://lichess.org/x4E0Q6js> and <https://lichess.org/bQQnPWSb> — because a second lichess-bot instance on the same account had made the moves that made them unabortable.

The conclusion that survived contact with production: a refused abort means the game has moves *this process never made*. Under correct single-serving that is impossible, so it is evidence that something else is serving this account, and then neither playing nor resigning is safe. So the code attempts the abort (the polite, ratingless exit), and if the abort is refused it logs an ERROR naming the game and saying precisely that, frees the slot, and leaves the game alone. Whoever is making those moves keeps the game.

The abort is wrapped so that no exception can escape `start_game_thread()`. An exception there would propagate into the caller and cost the *other* game the move it owes, which is the failure mode fixed in #1240.

## Related Issues:

None.

## Checklist:

- [x] I have read and followed the [contribution guidelines](/docs/CONTRIBUTING.md).
- [x] I have added necessary documentation (if applicable).
- [x] The changes pass all existing tests.

## Screenshots/logs (if applicable):

Verification on this branch, rebased on current master:

* `pytest` — 55 passed, 1 skipped (`test_lichess`, which needs `LICHESS_BOT_TEST_TOKEN`). Three of those are new, in `test_bot/test_start_game.py`: a game within the limit is played, a game past the limit is aborted, and an overflow game whose abort is refused is neither played nor resigned.
* `ruff check --config test_bot/ruff.toml` — clean.
* `mypy --strict .` — clean.
* Running in production on two bots since 2026-08-11.

I am happy to restructure this to your preference: rename things, drop the `pending_outgoing_challenges` half if you would rather have only the abort backstop, thread `games_in_progress` through the call chain instead of keeping it at module level next to `correspondence_games_to_start`, or fold the tests in elsewhere.
