### PR TITLE
Restart loudly when the lichess event stream goes silent

### DIFF
--- a/lib/lichess_bot.py
+++ b/lib/lichess_bot.py
@@ -440,12 +440,26 @@ def close_pool(pool: POOL_TYPE, active_games: dict[str, str], config: Configurat
         pool.join()
 
 
+# A healthy lichess event stream sends a keepalive line every few seconds,
+# which arrives here as a "ping" event. If nothing arrives for this long, the
+# event stream (or the process reading it) is dead, even though the connection
+# may look fine, and the bot would otherwise wait forever while appearing
+# online. Restarting re-creates the stream process and its connection.
+EVENT_STREAM_SILENCE_LIMIT = seconds(60)
+
+
 def next_event(control_queue: CONTROL_QUEUE_TYPE) -> EventType:
     """Get the next event from the control queue."""
     try:
-        event = control_queue.get()
+        event = control_queue.get(timeout=to_seconds(EVENT_STREAM_SILENCE_LIMIT))
         if event is None:
             return {}
+    except Empty:
+        logger.error(f"No events or pings from the lichess event stream in the last "
+                     f"{to_seconds(EVENT_STREAM_SILENCE_LIMIT):.0f} seconds even though the stream "
+                     "pings every few seconds. The event stream is assumed dead. Restarting lichess-bot.")
+        stop.restart = True
+        return {}
     except InterruptedError:
         return {}
 

--- a/test_bot/test_next_event.py
+++ b/test_bot/test_next_event.py
@@ -1,0 +1,34 @@
+"""Tests for noticing that the lichess event stream has gone silent."""
+
+from lib import lichess_bot
+from lib.lichess import stop
+from lib.lichess_types import CONTROL_QUEUE_TYPE, EventType
+from lib.timer import msec
+from queue import Queue
+import pytest
+
+
+def empty_control_queue() -> CONTROL_QUEUE_TYPE:
+    """Create a control queue that no event-stream process is writing to."""
+    queue: Queue[EventType] = Queue()
+    return queue
+
+
+def test_silent_event_stream_asks_for_a_restart(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A stream that sends neither events nor pings is dead, and waiting on it forever is not an option."""
+    monkeypatch.setattr(lichess_bot, "EVENT_STREAM_SILENCE_LIMIT", msec(10))
+    monkeypatch.setattr(stop, "restart", False)
+
+    assert lichess_bot.next_event(empty_control_queue()) == {}
+    assert stop.restart is True
+
+
+def test_event_before_the_silence_limit_is_returned(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A stream that is still delivering pings must not be declared dead."""
+    monkeypatch.setattr(lichess_bot, "EVENT_STREAM_SILENCE_LIMIT", msec(10))
+    monkeypatch.setattr(stop, "restart", False)
+    control_queue = empty_control_queue()
+    control_queue.put_nowait({"type": "ping"})
+
+    assert lichess_bot.next_event(control_queue) == {"type": "ping"}
+    assert stop.restart is False


### PR DESCRIPTION
## Type of pull request:
- [x] Bug fix
- [ ] Feature
- [ ] Other

## Description:

Split out of #1240, which bundled three unrelated production fixes into one PR. The three are independent and can be reviewed, changed or merged in any order. See also #1240 (a failed chat message cancels the move the engine owes) and #1241 (games past `challenge.concurrency` sit unplayed).

### The failure

Every bit of liveness in the main loop is event-driven, and every event comes through `control_queue`. If the event-stream reader process dies, or its connection goes dead without an error surfacing in `watch_control_stream()`, `control_queue.get()` blocks forever. The bot stays connected and shows as online, accepts nothing, starts nothing, and logs nothing. We saw this in production more than once; the only cure was noticing by hand and restarting.

### What changed

A healthy event stream sends a keepalive line every few seconds, which arrives here as a `ping` event, so silence is diagnostic rather than ambiguous. `next_event()` now waits at most `EVENT_STREAM_SILENCE_LIMIT` (60 seconds). On timeout it logs an ERROR explaining that the stream is presumed dead and sets `stop.restart`, which tears down and re-creates the stream process and its connection through the existing restart path.

60 seconds is deliberately far above the few-second keepalive interval, so a slow moment cannot trigger it, and far below the time it takes for an unnoticed deaf bot to do real damage to its rating.

## Related Issues:

None.

## Checklist:

- [x] I have read and followed the [contribution guidelines](/docs/CONTRIBUTING.md).
- [x] I have added necessary documentation (if applicable).
- [x] The changes pass all existing tests.

## Screenshots/logs (if applicable):

Verification on this branch, rebased on current master:

* `pytest` — 55 passed, 1 skipped (`test_lichess`, which needs `LICHESS_BOT_TEST_TOKEN`). Two of those are new, in `test_bot/test_next_event.py`: a silent control queue asks for a restart, and a queue that still delivers pings does not.
* `ruff check --config test_bot/ruff.toml` — clean.
* `mypy --strict .` — clean.
* Running in production on two bots since 2026-08-11.

Happy to restructure this to your preference — make the limit configurable, put the watchdog in the main loop instead of `next_event()`, or change the log level or wording.
